### PR TITLE
Unzip, collate submissions, expand geopoints

### DIFF
--- a/old_scripts/odk_fieldmap_original/utils/dl_submissions.py
+++ b/old_scripts/odk_fieldmap_original/utils/dl_submissions.py
@@ -31,6 +31,10 @@
 import os
 import sys
 
+from io import BytesIO, StringIO
+from zipfile import ZipFile as zf
+import csv
+
 from odk_requests import (forms, submissions, csv_submissions)
 
 def project_forms(url, aut, pid):
@@ -43,12 +47,53 @@ def project_forms(url, aut, pid):
 def project_submissions(url, aut, pid, formsl, outdir):
     """Downloads all of the submissions frm a given ODK Central project"""
     for form in formsl:
-        form_id = (form['xmlFormId'])
+        form_id = form['xmlFormId']
         print(f'Checking submissions from {form_id}.')
         subs_zip = csv_submissions(url, aut, pid, form_id)
+        
         outfilename = os.path.join(outdir, f'{form_id}.csv.zip')
         outfile = open(outfilename, 'wb')
         outfile.write(subs_zip.content)
+
+def project_submissions_unzipped(url, aut, pid, formsl, outdir):
+    """Downloads and unzips all of the submissions from a given ODK project"""
+    collated_project_csv_outfile = 
+    for form in formsl:
+        form_id = form['xmlFormId']
+        print(f'Checking submissions from {form_id}.')
+        subs_zip = csv_submissions(url, aut, pid, form_id)
+        subs_bytes = BytesIO(subs_zip.content)
+        subs_bytes.seek(0)
+        subs_unzipped = zf(subs_bytes)
+        sub_namelist = subs_unzipped.namelist()
+        print(f'Files in submissions from {form_id}:')
+        print(sub_namelist)
+        for sub_name in sub_namelist:
+            subs_bytes = subs_unzipped.read(sub_name)
+            outfilename = os.path.join(outdir, sub_name)
+            
+            # Some attachments need a subdirectory
+            suboutdir = os.path.split(outfilename)[0])
+            if not os.path.exists(suboutdir):
+                os.makedirs(suboutdir)
+
+            # If it is a csv, open it and see if it is more than one line
+            # This might go wrong if something is encoded in other than UTF-8
+            if os.path.splitext(sub_name)[1] == '.csv':
+                subs_stringio = StringIO(subs_bytes.decode())
+                subs_list = list(csv.reader(subs_stringio))
+                # Check if there are CSV lines after the headers
+                subs_num = len(subs_list)
+                print(f'{sub_name} has {subs_num - 1} submissions')
+                if subs_num > 1:
+                    with open(outfilename, 'w') as outfile:
+                        w = csv.writer(outfile)
+                        w.writerows(subs_list)
+                    
+                        
+            else:
+                with open(outfilename, 'wb') as outfile:
+                    outfile.write(subs_bytes)
 
 if __name__ == "__main__":
     """Downloads all of the submissions from a given ODK Central project"""
@@ -58,5 +103,5 @@ if __name__ == "__main__":
     outdir = sys.argv[5]
     
     formsl = project_forms(url, aut, pid)
-    subs = project_submissions(url, aut, pid, formsl, outdir)
+    subs = project_submissions_unzipped(url, aut, pid, formsl, outdir)
     


### PR DESCRIPTION
The dl-submissions module now:
- Unzips submissions from each form, 
- checks for CSV with more than a header row
- checks for an ODK GeoPoint-type column, expands it into 4 additional columns for easy import into QGIS or direct conversion to GIS files like GeoJSON
- Writes the individual CSV files to a specified directory (not in a Zip archive)
- Writes a collated CSV for the entire project
  - WARNING: this will probably do something horrible if there are different types of surveys in a project; it's only sensible at the moment if it's a single survey split amongst multiple geographies (as we're basically doing now with the FMTM)
- If any media attachments, creates the subdirectory specified in the Zip archive for them and writes them (again outside of the archive). 

## TODO:
- The collation and geopoint expansion happen automatically, should be flags to do or not.
- The function to simply download and write the Zip archives exists but is not accessible (again should be a flag, i.e. -z or whatever)
- The geopoint expansion _will_ go wrong with multiple survey types in a single project