### PR TITLE
Add support for file I/O from database

### DIFF
--- a/src/backend/central/central_crud.py
+++ b/src/backend/central/central_crud.py
@@ -45,19 +45,20 @@ from ..tasks import tasks_schemas
 from ..central import central_schemas
 from ..odkconvert.OdkCentral import OdkProject, OdkAppUser, OdkForm
 
-project = OdkProject()
-xform = OdkForm()
-
 url = config_env["ODK_CENTRAL_URL"]
 user = config_env["ODK_CENTRAL_USER"]
 pw = config_env["ODK_CENTRAL_PASSWD"]
-project.authenticate(url, user, pw)
+
+project = OdkProject(url, user, pw)
+xform = OdkForm(url, user, pw)
+appuser = OdkAppUser(url, user, pw)
+# project.authenticate()
 project.listProjects()
 
 def create_odk_project(name):
     """Create a project on a remote ODK Server"""
     result = project.createProject(name)
-    project.id = result
+    project.id = result['id']
     logger.info(f"Project {name} has been created on the ODK Central server.")
     return result
 
@@ -73,7 +74,6 @@ def create_appuser(project_id: int, name: str):
     # user = project.findAppUser(name=name)
     # user = False
     # if not user:
-    appuser = OdkAppUser()
     result = appuser.create(project_id, name)
     return result
 

--- a/src/backend/debug/debug_routes.py
+++ b/src/backend/debug/debug_routes.py
@@ -21,7 +21,7 @@ from sqlalchemy.orm import Session
 import logging.config
 from fastapi.logger import logger as logger
 import os
-from ..odkconvert.make_data_extract import PostgresClient, OverpassClient
+# from ..odkconvert.make_data_extract import PostgresClient, OverpassClient
 
 from ..db import database
 from ..models.enums import TaskStatus

--- a/src/backend/models/enums.py
+++ b/src/backend/models/enums.py
@@ -16,23 +16,7 @@
 #     along with FMTM.  If not, see <https:#www.gnu.org/licenses/>.
 #
 
-from enum import Enum, IntEnum, StrEnum
-
-
-class category(StrEnum, Enum):
-    """The category of data to look for"""
-    "buildings"
-    "waterpoints"
-    "waste"
-    "healthcare"
-    "education"
-    "cemeteries"
-    "landuse"
-    "toilets"
-    "transportation"
-    "religious"
-    "place"
-    "natural"
+from enum import Enum, IntEnum
 
 class TeamVisibility(IntEnum, Enum):
     """ Describes the visibility associated with an Team """

--- a/src/backend/odkconvert/OdkCentral.py
+++ b/src/backend/odkconvert/OdkCentral.py
@@ -127,12 +127,12 @@ class OdkCentral(object):
             result = self.session.post(url, auth=self.auth, json={'name': name}, verify=self.verify)
             # update the internal list of projects
             self.listProjects()
-        return self.findProject(name)
+        return result.json()
 
     def deleteProject(self, project_id: int):
         """Delete a project on an ODK Central server"""
         url = f'{self.base}projects/{project_id}'
-        result = self.session.delete(url, auth=self.auth)
+        result = self.session.delete(url, auth=self.auth, verify=self.verify)
         # update the internal list of projects
         self.listProjects()
         return self.findProject(project_id)
@@ -405,7 +405,7 @@ class OdkForm(OdkCentral):
         else:
             url = f'{self.base}projects/{projectId}/forms/{xmlFormId}'
         print(url)
-        result = self.session.delete(url, auth=self.auth)
+        result = self.session.delete(url, auth=self.auth, verify=self.verify)
         return result
 
     def publishForm(self, projectId=None, xmlFormId=None):

--- a/src/backend/odkconvert/OdkCentral.py
+++ b/src/backend/odkconvert/OdkCentral.py
@@ -47,6 +47,7 @@ class OdkCentral(object):
         self.url = url
         self.user = user
         self.passwd = passwd
+        self.verify=False
         # These are settings used by ODK Collect
         self.general = {
             "form_update_mode": "match_exactly",
@@ -101,14 +102,14 @@ class OdkCentral(object):
         self.session.headers.update({'accept': 'odkcentral'})
 
         # Connect to the server
-        return self.session.get(self.url, auth=self.auth)
+        return self.session.get(self.url, auth=self.auth, verify=self.verify)
 
     def listProjects(self):
         """Fetch a list of projects from an ODK Central server, and
         store it as an indexed list."""
         logging.info("Getting a list of projects from %s" % self.url)
         url = f'{self.base}projects'
-        result = self.session.get(url, auth=self.auth)
+        result = self.session.get(url, auth=self.auth, verify=self.verify)
         projects = result.json()
         for project in projects:
             self.projects[project['id']] = project
@@ -123,7 +124,7 @@ class OdkCentral(object):
             return exists
         else:
             url = f'{self.base}projects'
-            result = self.session.post(url, auth=self.auth, json={'name': name})
+            result = self.session.post(url, auth=self.auth, json={'name': name}, verify=self.verify)
             # update the internal list of projects
             self.listProjects()
         return self.findProject(name)
@@ -166,7 +167,7 @@ class OdkCentral(object):
         """Fetch a list of users on the ODK Central server"""
         logging.info("Getting a list of users from %s" % self.url)
         url = self.base + "users"
-        result = self.session.get(url, auth=self.auth)
+        result = self.session.get(url, auth=self.auth, verify=self.verify)
         self.users = result.json()
         return self.users
         
@@ -190,8 +191,8 @@ class OdkCentral(object):
 
 class OdkProject(OdkCentral):
     """Class to manipulate a project on an ODK Central server"""
-    def __init__(self, session=None):
-        super().__init__()
+    def __init__(self, url=None, user=None, passwd=None):
+        super().__init__(url, user, passwd)
         self.forms = None
         self.submissions = None
         self.data = None
@@ -204,27 +205,27 @@ class OdkProject(OdkCentral):
     def listForms(self, id=None):
         """Fetch a list of forms in a project on an ODK Central server."""
         url = f'{self.base}projects/{id}/forms'
-        result = self.session.get(url, auth=self.auth)
+        result = self.session.get(url, auth=self.auth, verify=self.verify)
         self.forms = result.json()
         return self.forms
 
     def listAppUsers(self, projectId=None):
         """Fetch a list of app users for a project from an ODK Central server."""
         url = f'{self.base}projects/{projectId}/app-users'
-        result = self.session.get(url, auth=self.auth)
+        result = self.session.get(url, auth=self.auth, verify=self.verify)
         self.appusers = result.json()
         return self.appusers
 
     def listAssignments(self, projectId=None):
         """List the Role & Actor assignments for users on a project"""
         url = f'{self.base}projects/{projectId}/assignments'
-        result = self.session.get(url, auth=self.auth)
+        result = self.session.get(url, auth=self.auth, verify=self.verify)
         return result.json()
 
     def getDetails(self, projectId=None):
         """Get all the details for a project on an ODK Central server"""
         url = f'{self.base}projects/{projectId}'
-        result = self.session.get(url, auth=self.auth)
+        result = self.session.get(url, auth=self.auth, verify=self.verify)
         self.data = result.json()
         return self.data
 
@@ -246,8 +247,8 @@ class OdkProject(OdkCentral):
 
 class OdkForm(OdkCentral):
     """Class to manipulate a from on an ODK Central server"""
-    def __init__(self, session=None):
-        super().__init__()
+    def __init__(self, url=None, user=None, passwd=None):
+        super().__init__(url, user, passwd)
         self.name = None
         # Draft is for a form that isn't published yet
         self.draft = True
@@ -279,28 +280,28 @@ class OdkForm(OdkCentral):
     def getDetails(self, projectId=None, xmlFormId=None):
         """Get all the details for a form on an ODK Central server"""
         url = f'{self.base}projects/{projectId}/forms/{xmlFormId}'
-        result = self.session.get(url, auth=self.auth)
+        result = self.session.get(url, auth=self.auth, verify=self.verify)
         self.data = result.json()
         return result
 
     def listSubmissions(self, projectId, formId):
         """Fetch a list of submission instances for a given form."""
         url = f'{self.base}projects/{projectId}/forms/{formId}/submissions'
-        result = self.session.get(url, auth=self.auth)
+        result = self.session.get(url, auth=self.auth, verify=self.verify)
         self.submissions = result.json()
         return self.submissions
 
     def listAssignments(self, projectId=None, xmlFormId=None):
         """List the Role & Actor assignments for users on a project"""
         url = f'{self.base}projects/{projectId}/forms/{xmlFormId}/assignments'
-        result = self.session.get(url, auth=self.auth)
+        result = self.session.get(url, auth=self.auth, verify=self.verify)
         return result.json()
 
     def getSubmission(self, projectId=None, formId=None, disk=False):
         """Fetch a CSV file of the submissions without media to a survey form."""
         instanceId = "uuid:47bda2ec-c282-4cb7-9f37-03dc3bbdf96b: 2022-09-02T17:09:19.648Z"
         url = self.base + f'projects/{projectId}/forms/{formId}/submissions'
-        result = self.session.get(url, auth=self.auth)
+        result = self.session.get(url, auth=self.auth, verify=self.verify)
         if result.status_code == 200:
             if disk:
                 now = datetime.now()
@@ -323,7 +324,7 @@ class OdkForm(OdkCentral):
     def getSubmissionMedia(self, projectId, formId):
         """Fetch a ZIP file of the submissions with media to a survey form."""
         url = self.base + f'projects/{projectId}/forms/{formId}/submissions.csv.zip'
-        result = self.session.get(url, auth=self.auth)
+        result = self.session.get(url, auth=self.auth, verify=self.verify)
         return result
 
     def addMedia(self, media=None, filespec=None):
@@ -341,7 +342,7 @@ class OdkForm(OdkCentral):
             url = f'{self.base}projects/{projectId}/forms/{xmlFormId}/draft/attachments'
         else:
             url = f'{self.base}projects/{projectId}/forms/{xmlFormId}/attachments'
-        result = self.session.get(url, auth=self.auth)
+        result = self.session.get(url, auth=self.auth, verify=self.verify)
         self.media = result.json()
         return self.media
 
@@ -357,7 +358,7 @@ class OdkForm(OdkCentral):
         file = open(filespec, "rb")
         media = file.read()
         file.close()
-        result = self.session.post(url, auth=self.auth, data=media, headers=headers)
+        result = self.session.post(url, auth=self.auth, data=media, headers=headers, verify=self.verify)
         return result
         
     def getMedia(self, projectId=None, xmlFormId=None, filename=None):
@@ -366,7 +367,7 @@ class OdkForm(OdkCentral):
             url = f'{self.base}projects/{projectId}/forms/{xmlFormId}/draft/attachments/{filename}'
         else:
             url = f'{self.base}projects/{projectId}/forms/{xmlFormId}/attachments/{filename}'
-        result = self.session.get(url, auth=self.auth)
+        result = self.session.get(url, auth=self.auth, verify=self.verify)
         self.media = result.content
         return self.media
 
@@ -390,7 +391,7 @@ class OdkForm(OdkCentral):
         file.close()
         logging.info("Read %d bytes from %s" % (len(xml), filespec))
 
-        result = self.session.post(url, auth=self.auth,  data=xml, headers=headers)
+        result = self.session.post(url, auth=self.auth,  data=xml, headers=headers, verify=self.verify)
         # epdb.st()
         # FIXME: should update self.forms with the new form
         return result
@@ -416,7 +417,7 @@ class OdkForm(OdkCentral):
         else:
             url = f'{self.base}projects/{projectId}/forms/{xmlFormId}/publish?version={version}'
             # url = f'{self.base}projects/{projectId}/forms/{xmlFormId}/publish'
-        result = self.session.get(url, auth=self.auth)
+        result = self.session.get(url, auth=self.auth, verify=self.verify)
         return result
 
     def dump(self):
@@ -430,9 +431,9 @@ class OdkForm(OdkCentral):
 
 
 class OdkAppUser(OdkCentral):
-    def __init__(self):
+    def __init__(self, url=None, user=None, passwd=None):
         """A Class for app user data"""
-        super().__init__()
+        super().__init__(url, user, passwd)
         self.user = None
         self.qrcode = None
         self.id = None
@@ -440,7 +441,7 @@ class OdkAppUser(OdkCentral):
     def create(self, projectId=None, name=None):
         """Create a new app-user for a form"""
         url = f'{self.base}projects/{projectId}/app-users'
-        result = self.session.post(url, auth=self.auth, json={'displayName': name})
+        result = self.session.post(url, auth=self.auth, json={'displayName': name}, verify=self.verify)
         self.user = name
         return result
 
@@ -454,14 +455,14 @@ class OdkAppUser(OdkCentral):
         """Update the role of an app user for a form"""
         logging.info("Update access to XForm %s for %s" % (xmlFormId, actorId))
         url = f'{self.base}projects/{projectId}/forms/{xmlFormId}/assignments/{roleId}/{actorId}'
-        result = self.session.post(url, auth=self.auth)
+        result = self.session.post(url, auth=self.auth, verify=self.verify)
         return result
 
     def grantAccess(self, projectId=None, roleId=2, userId=None, xmlFormId=None, actorId=None):
         """Grant access to an app user for a form"""
         kwargs = { "formId": xmlFormId, "actorId": userId, }
         url = f'{self.base}projects/{projectId}/forms/{formId}/assignments/{roleId}/{actorId}'
-        result = self.session.post(url, auth=self.auth)
+        result = self.session.post(url, auth=self.auth, verify=self.verify)
         return result
 
     def createQRCode(self, project_id=None, token=None, name=None):

--- a/src/backend/odkconvert/make_data_extract.py
+++ b/src/backend/odkconvert/make_data_extract.py
@@ -25,7 +25,6 @@ import sys
 import re
 import epdb
 from sys import argv
-from osgeo import ogr, gdal
 import json
 from geojson import Point, Polygon, Feature, FeatureCollection, dump
 import geojson
@@ -46,9 +45,9 @@ class PostgresClient(object):
         # OutputFile.__init__( self, output)
         logging.info("Opening database connection to: %s" % dbhost)
         connect = "PG: dbname=" + dbname
-        if dbhost:
-            connect += " host=" + dbhost
-        self.pg = ogr.Open(connect)
+        # if dbhost:
+        #     connect += " host=" + dbhost
+        # self.pg = ogr.Open(connect)
         self.boundary = None
         if dbhost is None or dbhost == 'localhost':
             connect = f"dbname={dbname}"
@@ -103,7 +102,7 @@ class PostgresClient(object):
         if type(boundary) != dict:
             clip = open(boundary, 'r')
             geom = geojson.load(clip)
-            feature = data['features'][0]
+            feature = geom['features'][0]
             geom = feature['geometry']
         else:
             geom = boundary

--- a/src/backend/odkconvert/odk_client.py
+++ b/src/backend/odkconvert/odk_client.py
@@ -60,7 +60,7 @@ parser.add_argument("-v", "--verbose", action="store_true", help="verbose output
 parser.add_argument("-s", "--server", choices=['projects', 'users'],
                     help="project operations")
 # This is for project specific requests
-parser.add_argument("-p", "--project", choices=['forms', 'app-users', 'assignments'],
+parser.add_argument("-p", "--project", choices=['forms', 'app-users', 'assignments', 'delete'],
                     help="project operations")
 parser.add_argument('-i', '--id', type=int, help = 'Project ID nunmber')
 parser.add_argument("-f", "--form", help="XForm name")
@@ -147,6 +147,9 @@ elif args.project:
         ordered = sorted(users, key=lambda item: item.get('id'))
         for user in ordered:
             print("\t%r: %s (%s)" % (user['id'], user['displayName'], user['token']))
+    if args.project == "delete":
+        project.deleteProject(args.id)
+        # logging.info("There are %d app users on this ODK Central server" %)
     if args.project == "assignments":
         assign = project.listAssignments(args.id)
         logging.info("There are %d assignments  on this ODK Central server" % len(assign))

--- a/src/backend/odkconvert/requirements.txt
+++ b/src/backend/odkconvert/requirements.txt
@@ -4,7 +4,6 @@ GDAL==3.4.3
 geodex==0.1.2
 geojson==2.5.0
 numpy==1.22.0
-osgeo==0.0.1
 OSMPythonTools==0.3.5
 pandas==1.3.4
 progress==1.6

--- a/src/backend/projects/project_crud.py
+++ b/src/backend/projects/project_crud.py
@@ -47,8 +47,7 @@ from ..db import db_models
 from ..tasks import tasks_crud, tasks_schemas
 from ..users import user_crud
 from ..central import central_crud
-from ..models.enums import DataCategory
-from ..odkconvert.make_data_extract import PostgresClient, OverpassClient
+# from ..odkconvert.make_data_extract import PostgresClient, OverpassClient
 from ..env_utils import is_docker, config_env
 
 from . import project_schemas
@@ -516,10 +515,10 @@ def generate_appuser_files(
             xlsform = f'{config_env["XLSFORMS_LIBRARY"]}/{one.xform_title}.xls'
             xform = f'/tmp/{prefix}_{one.xform_title}_{poly.id}.xml'
             result = central_crud.generate_updated_xform(db, poly.id, xlsform, xform)
-            outfile = f"/tmp/{prefix}_{one.xform_title}_{poly.id}.geojson"
-            pg = PostgresClient('localhost', dbname, outfile)
-            outline = eval(poly.outline)
-            pg.getFeature(outline, outfile, one.xform_title)
+            # outfile = f"/tmp/{prefix}_{one.xform_title}_{poly.id}.geojson"
+            # pg = PostgresClient('localhost', dbname, outfile)
+            # outline = eval(poly.outline)
+            # pg.getFeature(outline, outfile, one.xform_title)
 
 def create_qrcode(
         db: Session,

--- a/src/backend/projects/project_crud.py
+++ b/src/backend/projects/project_crud.py
@@ -206,6 +206,20 @@ def create_project_with_project_info(
     return convert_to_app_project(db_project)
 
 
+def upload_xlsform(
+        db: Session,
+        project_id: int,
+        xlsform: str,
+        name: str,
+):
+    forms = table('xlsforms', column('title'), column('xls'), column('xml'), column('id'))
+    ins = insert(forms).values(title=name, xls=xlsform)
+    sql = ins.on_conflict_do_update(constraint='xlsforms_title_key', set_=dict(title=name, xls=xlsform))
+    result = db.execute(sql)
+    db.commit()
+
+    return True
+
 def update_project_boundary(
         db: Session,
         project_id: int,

--- a/src/backend/projects/project_routes.py
+++ b/src/backend/projects/project_routes.py
@@ -19,7 +19,7 @@
 from typing import List
 from fastapi import APIRouter, Depends, File, Form, HTTPException, UploadFile
 from fastapi.logger import logger as logger
-from fastapi.logger import logger as logging
+from fastapi.responses import StreamingResponse
 from sqlalchemy.orm import Session
 from pathlib import Path
 import json
@@ -146,6 +146,26 @@ async def upload_project_boundary(
 
     # FIXME: fix return value
     return {f"Message": f"{project_id}"}
+
+@router.post("/{project_id}/download")
+async def download_project_boundary(
+    project_id: int,
+    db: Session = Depends(database.get_db),
+):
+    """Download the boundary polygon for this project"""
+    out = project_crud.download_geometry(db, project_id, False)
+    # FIXME: fix return value
+    return {f"Message": out}
+
+@router.post("/{project_id}/download_tasks")
+async def download_task_boundaries(
+    project_id: int,
+    db: Session = Depends(database.get_db),
+):
+    """Download the task boundary polygons for this project"""
+    out = project_crud.download_geometry(db, project_id, True)
+    # FIXME: fix return value
+    return {f"Message": out}
 
 @router.post("/{project_id}/generate")
 async def generate_files(

--- a/src/backend/projects/project_routes.py
+++ b/src/backend/projects/project_routes.py
@@ -25,7 +25,6 @@ from pathlib import Path
 import json
 import epdb
 import os
-from ..models.enums import DataCategory
 
 from ..env_utils import is_docker, config_env
 from ..db import database

--- a/src/backend/projects/project_routes.py
+++ b/src/backend/projects/project_routes.py
@@ -122,6 +122,20 @@ async def upload_project_boundary_with_zip(
     )
     return f"{project}"
 
+@router.post("/{project_id}/upload_xlsform")
+async def upload_custom_xls(
+    project_id: int,
+    upload: UploadFile = File(...),
+    db: Session = Depends(database.get_db),
+):
+    # read entire file
+    content = await upload.read()
+    category = upload.filename.split(".")[0]
+    result = project_crud.upload_xlsform(db, project_id, content, category)
+
+    # FIXME: fix return value
+    return {f"Message": f"{project_id}"}
+
 @router.post("/{project_id}/upload")
 async def upload_project_boundary(
     project_id: int,

--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -32,6 +32,7 @@ sqlmodel==0.0.8
 geojson==2.5.0
 shapely==1.8.4
 python-dotenv==0.21.0
+OSMPythonTools==0.3.5
 
 # ----OSM LOGIN -----
 osm-login-python==0.0.2
@@ -39,6 +40,8 @@ osm-login-python==0.0.2
 # ---- ODK ----
 # pyodk==0.1.0
 qrcode==7.3.1
+pyxform==1.12.0
+xmltodict==0.13.0
 
 # ----- FILE UPLOAD ----
 python-multipart==0.0.5

--- a/traefik/traefik.dev.toml
+++ b/traefik/traefik.dev.toml
@@ -16,12 +16,12 @@
 # 
 
 # listen on port 80
-[entryPoints]
-  [entryPoints.web]
-    address = ":80"
-    address = ":8008"
-  [entryPoints.backend]
-    address = ":5000"
+#[entryPoints]
+#  [entryPoints.web]
+#    address = ":80"
+#    address = ":8008"
+#  [entryPoints.backend]
+#    address = ":5000"
 
 # Traefik dashboard over http
 [api]


### PR DESCRIPTION
This patch allows for the download of both the project boundary polygon, as well as all the task boundaries as GeoJson. This can be used for display, or with frontend support, downloaded to disk. This patch also support upload a custom XLSForm to the database, adding it to the XLSForm library. If the name matches an existing XLSForm, then it gets updated instead.