### PR TITLE
Update production docker-compose config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,3 +29,4 @@ FMTM_DB_NAME=fmtm
 
 # Production only
 API_DOMAIN=
+API_PREFIX=

--- a/.env.example
+++ b/.env.example
@@ -5,21 +5,8 @@ ODK_CENTRAL_URL=http://central:8383
 ODK_CENTRAL_USER=
 ODK_CENTRAL_PASSWD=
 
-CENTRAL_DB_HOST=central-db
-CENTRAL_DB_USER=odk
-CENTRAL_DB_PASSWORD=odk
-CENTRAL_DB_NAME=odk
-
 # FMTM
 API_URL=http://127.0.0.1:8000
-
-FMTM_DB_HOST=fmtm-db
-FMTM_DB_USER=fmtm
-FMTM_DB_PASSWORD=fmtm
-FMTM_DB_NAME=fmtm
-
-METRICS_DOMAIN=
-METRICS_LOGIN=
 
 # OSM
 OSM_CLIENT_ID=
@@ -28,3 +15,17 @@ OSM_URL=https://www.openstreetmap.org
 OSM_SCOPE=read_prefs
 OSM_LOGIN_REDIRECT_URI={API_URL}/auth/callback/
 OSM_SECRET_KEY=
+
+# Database (optional)
+CENTRAL_DB_HOST=central-db
+CENTRAL_DB_USER=odk
+CENTRAL_DB_PASSWORD=odk
+CENTRAL_DB_NAME=odk
+
+FMTM_DB_HOST=fmtm-db
+FMTM_DB_USER=fmtm
+FMTM_DB_PASSWORD=fmtm
+FMTM_DB_NAME=fmtm
+
+# Production only
+API_DOMAIN=

--- a/central.dockerfile
+++ b/central.dockerfile
@@ -61,8 +61,8 @@ RUN printf '#!/bin/bash\n\
 set -eo pipefail\n\
 tmp=$(mktemp)\n\
 echo "Setting database credentials in /usr/share/odk/config.json.template"\n\
-jq --arg host "${CENTRAL_DB_HOST}" --arg user "${CENTRAL_DB_USER}" \
---arg pass "${CENTRAL_DB_PASSWORD}" --arg db "${CENTRAL_DB_NAME}" \
+jq --arg host "${CENTRAL_DB_HOST:-central-db}" --arg user "${CENTRAL_DB_USER:-odk}" \
+--arg pass "${CENTRAL_DB_PASSWORD:-odk}" --arg db "${CENTRAL_DB_NAME:-odk}" \
 '"'"'.default.database.host = $host | .default.database.user = $user | .default.database.password = $pass | .default.database.database = $db'"'"' \
 /usr/share/odk/config.json.template > \
 "$tmp" && mv "$tmp" /usr/share/odk/config.json.template\n\
@@ -70,6 +70,6 @@ echo "Credentials set"\n\
 exec ./start-odk.sh' \
 >> ./sub-db-vars.sh \
 && chmod +x ./sub-db-vars.sh
-ENTRYPOINT ["./wait-for-it.sh", "central-db:5432", "--", "./sub-db-vars.sh"]
+ENTRYPOINT ["./wait-for-it.sh", "${CENTRAL_DB_HOST:-central-db}:5432", "--", "./sub-db-vars.sh"]
 
 EXPOSE 8383

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -15,83 +15,121 @@
 #     along with FMTM.  If not, see <https:#www.gnu.org/licenses/>.
 #
 
-version: "3.4"
+version: "3"
+
+volumes:
+  fmtm_db_data:
+  central_db_data:
+  traefik-public-certificates:
+
+networks:
+  fmtm-prod:
 
 services:
-  db:
-    image: postgis/postgis:14-3.3-alpine
-    volumes:
-      - postgres_data_prod1:/var/lib/postgresql/data/
-    environment:
-      - POSTGRES_USER=${DB_USER}
-      - POSTGRES_PASSWORD=${DB_PASSWORD}
-      - POSTGRES_DB=${DB_NAME}
-    ports:
-      - 5432
-    networks:
-      - fmtm-net
-
-  # pgadmin:
-  #   container_name: pgadmin
-  #   image: dpage/pgadmin4
-  #   environment:
-  #     - PGADMIN_DEFAULT_EMAIL=pgadmin4@hotosm.org
-  #     - PGADMIN_DEFAULT_PASSWORD=admin
-  #   ports:
-  #     - "5050:80"
-  #   depends_on:
-  #     - db
-
-  api:
-    build:
-      context: .
-      dockerfile: Dockerfile.prod
-    command: bash -c 'while !</dev/tcp/db/5432; do sleep 1; done; uvicorn main:api --host 0.0.0.0 --reload'
-    volumes:
-      - .:/api
-    ports:
-      - 8000
-    networks:
-      - fmtm-net
-    depends_on:
-      - db
-    environment:
-      - API_DOMAIN=${API_DOMAIN}
-      - DATABASE_URL=postgresql://${DB_USER}:${DB_PASSWORD}@db:5432/${DB_NAME}
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.services.api.loadbalancer.server.port=8000"
-      - "traefik.http.routers.api.tls=true"
-      - "traefik.http.routers.api.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.api.rule=Host(`${API_DOMAIN}`)"
-      - "traefik.http.routers.api.service=api"
-
   traefik:
     build:
-      context: ./traefik
+      context: traefik
       dockerfile: Dockerfile.traefik
     restart: always
     ports:
       - 80:80
       - 443:443
     networks:
-      - fmtm-net
+      - fmtm-prod
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
       - "./traefik-public-certificates:/certificates"
     labels:
       - "traefik.enable=true"
-      - "traefik.docker.network=fmtm-net"
-      - "traefik.http.routers.dashboard.rule=Host(`${METRICS_DOMAIN}`)"
-      - "traefik.http.routers.dashboard.tls=true"
-      - "traefik.http.routers.dashboard.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.dashboard.service=api@internal"
-      - "traefik.http.routers.dashboard.middlewares=auth"
-      - "traefik.http.middlewares.auth.basicauth.users=${METRICS_LOGIN}"
+      - "traefik.docker.network=fmtm-prod"
+      - "traefik.api.dashboard=false"
 
-volumes:
-  traefik-public-certificates:
-  postgres_data_prod1:
+  fmtm-db:
+    image: postgis/postgis:14-3.3-alpine
+    container_name: fmtm_db
+    volumes:
+      - fmtm_db_data:/var/lib/postgresql/data/
+    environment:
+      - POSTGRES_USER=${FMTM_DB_USER:-fmtm}
+      - POSTGRES_PASSWORD=${FMTM_DB_PASSWORD:-fmtm}
+      - POSTGRES_DB=${FMTM_DB_NAME:-fmtm}
+    ports:
+      - "5432:5432"
+    networks:
+      - fmtm-prod
+    restart: unless-stopped
 
-networks:
-  fmtm-net:
+  api:
+    build:
+      context: src/backend
+      target: prod
+    container_name: fmtm_api
+    depends_on:
+      - fmtm-db
+      - central
+    env_file:
+      - .env
+    environment:
+      - DB_URL=postgresql+psycopg2://${FMTM_DB_USER:-fmtm}:${FMTM_DB_PASSWORD:-fmtm}@${FMTM_DB_HOST:-fmtm-db}:5432/${FMTM_DB_NAME:-fmtm}
+    networks:
+      - fmtm-prod
+    restart: unless-stopped
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.services.api.loadbalancer.server.port=8000"
+      - "traefik.http.routers.api.tls=true"
+      - "traefik.http.routers.api.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.api.rule=Host(`${API_DOMAIN}`) && PathPrefix(`/api{regex:$$|/.*}`)"
+      - "traefik.http.routers.api.service=api"
+
+  ui:
+    build:
+      context: src/frontend
+      target: prod
+    container_name: fmtm_ui
+    networks:
+      - fmtm-prod
+    restart: unless-stopped
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.services.ui.loadbalancer.server.port=8080"
+      - "traefik.http.routers.ui.tls=true"
+      - "traefik.http.routers.ui.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.ui.rule=Host(`${API_DOMAIN}`)"
+      - "traefik.http.routers.ui.service=ui"
+
+  central-db:
+    image: postgis/postgis:14-3.3-alpine
+    container_name: central_db
+    volumes:
+      - central_db_data:/var/lib/postgresql/data/
+    environment:
+      - POSTGRES_USER=${CENTRAL_DB_USER:-odk}
+      - POSTGRES_PASSWORD=${CENTRAL_DB_PASSWORD:-odk}
+      - POSTGRES_DB=${CENTRAL_DB_NAME:-odk}
+    networks:
+      - fmtm-prod
+    restart: unless-stopped
+
+  central:
+    image: "ghcr.io/hotosm/fmtm-central:0.1.0"
+    build:
+      context: .
+      dockerfile: central.dockerfile
+    container_name: central_api
+    depends_on:
+      - central-db
+      - pyxform
+    env_file:
+      - .env
+    ports:
+      - "8383:8383"
+    networks:
+      - fmtm-prod
+    restart: unless-stopped
+
+  pyxform:
+    image: "ghcr.io/getodk/pyxform-http:v1.10.1.1"
+    networks:
+      - fmtm-prod
+    restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
     restart: unless-stopped
 
   api:
+    image: "ghcr.io/hotosm/fmtm-backend:0.1.0"
     build:
       context: src/backend
       # target: debug
@@ -63,6 +64,7 @@ services:
     restart: unless-stopped
 
   ui:
+    image: "ghcr.io/hotosm/fmtm-frontend:1.0.0"
     build:
       context: src/frontend
       target: debug
@@ -85,11 +87,14 @@ services:
       - POSTGRES_USER=${CENTRAL_DB_USER:-odk}
       - POSTGRES_PASSWORD=${CENTRAL_DB_PASSWORD:-odk}
       - POSTGRES_DB=${CENTRAL_DB_NAME:-odk}
+    ports:
+      - "5433:5432"
     networks:
       - fmtm-dev
     restart: unless-stopped
 
   central:
+    image: "ghcr.io/hotosm/fmtm-central:0.1.0"
     build:
       context: .
       dockerfile: central.dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,9 +31,9 @@ services:
     volumes:
       - fmtm_db_data:/var/lib/postgresql/data/
     environment:
-      - POSTGRES_USER=${FMTM_DB_USER}
-      - POSTGRES_PASSWORD=${FMTM_DB_PASSWORD}
-      - POSTGRES_DB=${FMTM_DB_NAME}
+      - POSTGRES_USER=${FMTM_DB_USER:-fmtm}
+      - POSTGRES_PASSWORD=${FMTM_DB_PASSWORD:-fmtm}
+      - POSTGRES_DB=${FMTM_DB_NAME:-fmtm}
     ports:
       - "5432:5432"
     networks:
@@ -54,9 +54,10 @@ services:
     env_file:
       - .env
     environment:
-      - DB_URL=postgresql+psycopg2://${FMTM_DB_USER}:${FMTM_DB_PASSWORD}@${FMTM_DB_HOST}:5432/${FMTM_DB_NAME}
+      - DB_URL=postgresql+psycopg2://${FMTM_DB_USER:-fmtm}:${FMTM_DB_PASSWORD:-fmtm}@${FMTM_DB_HOST:-fmtm-db}:5432/${FMTM_DB_NAME:-fmtm}
     ports:
       - "8000:8000"
+      # - "5678:5678"
     networks:
       - fmtm-dev
     restart: unless-stopped
@@ -81,9 +82,9 @@ services:
     volumes:
       - central_db_data:/var/lib/postgresql/data/
     environment:
-      - POSTGRES_USER=${CENTRAL_DB_USER}
-      - POSTGRES_PASSWORD=${CENTRAL_DB_PASSWORD}
-      - POSTGRES_DB=${CENTRAL_DB_NAME}
+      - POSTGRES_USER=${CENTRAL_DB_USER:-odk}
+      - POSTGRES_PASSWORD=${CENTRAL_DB_PASSWORD:-odk}
+      - POSTGRES_DB=${CENTRAL_DB_NAME:-odk}
     networks:
       - fmtm-dev
     restart: unless-stopped

--- a/docs/DEV-1.-Getting-Started.md
+++ b/docs/DEV-1.-Getting-Started.md
@@ -40,15 +40,7 @@ Your env should look like this
     ODK_CENTRAL_URL=`<external_url_or_local_instance_url>`
     ODK_CENTRAL_USER=`<any_valid_email_address>`
     ODK_CENTRAL_PASSWD=`<password_of_central_user>`
-    CENTRAL_DB_HOST=central-db
-    CENTRAL_DB_USER=odk
-    CENTRAL_DB_PASSWORD=odk
-    CENTRAL_DB_NAME=odk
     API_URL=http://127.0.0.1:8000
-    FMTM_DB_HOST=fmtm-db
-    FMTM_DB_USER=fmtm
-    FMTM_DB_PASSWORD=fmtm
-    FMTM_DB_NAME=fmtm
     OSM_CLIENT_ID=`<OSM_CLIENT_ID_FROM_ABOVE>`
     OSM_CLIENT_SECRET=`<OSM_CLIENT_SECRET_FROM_ABOVE>`
     OSM_URL=https://www.openstreetmap.org
@@ -102,3 +94,40 @@ Don't forget to review [Contribution](https://github.com/hotosm/fmtm/wiki/Contri
 ### Implement authorization on an endpoints
 
 To add authentication to an endpoint, import `login_required` from `auth` module , you can use it as decorator or use fastapi `Depends(login_required)` on endpoints.
+
+## Backend Debugging
+
+1. Uncomment in docker-compose.yml:
+```
+target: debug
+ports:
+  - "5678:5678"
+```
+2. Re-build the docker image `docker compose build api`
+3. Start the docker container `docker compose up -d api` (the api startup will be halted until you connect a debugger)
+4. Set a debugger config in your IDE (e.g. VSCode) and start the debugger
+5. The API server will start up & any set breakpoints will trigger
+
+Example launch.json config for vscode:
+```
+{
+  "configurations": [
+    {
+      "name": "Remote - Server Debug",
+      "type": "python",
+      "request": "attach",
+      "host": "localhost",
+      "port": 5678,
+      "pathMappings": [
+        {
+          "localRoot": "${workspaceFolder}/src/backend",
+          "remoteRoot": "/app/backend"
+        }
+      ],
+      "justMyCode": false
+    }
+  ]
+}
+```
+
+Note: either port 5678 needs to be bound to your localhost, or the `host` parameter can be set to the container IP address.

--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -90,7 +90,7 @@ COPY . /app/backend
 ARG FMTM_DB_HOST
 RUN printf '#!/bin/bash\n\
     set -eo pipefail\n\
-    while !</dev/tcp/${FMTM_DB_HOST}/5432; do sleep 1; done;\n\
+    while !</dev/tcp/${FMTM_DB_HOST:-fmtm-db}/5432; do sleep 1; done;\n\
     exec "$@"'\
     >> /docker-entrypoint.sh \
     && chmod +x /docker-entrypoint.sh

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -61,7 +61,9 @@ else:
 
 Base.metadata.create_all(bind=engine)
 
-api = FastAPI()
+api = FastAPI(
+    root_path=os.getenv("API_PREFIX", default="/")
+)
 
 api.include_router(user_routes.router)
 api.include_router(project_routes.router)


### PR DESCRIPTION
Updated to match dev docker-compose, except:
- Includes traefik for routing / the web server:
  - The frontend will be accessible on fmtm.hotosm.org
  - The API will be accessible on fmtm.hotosm.org/api
- I kept ports 5432 (db) and 8383 (central) bound to localhost, for ssh debugging.
  - The ports should be blocked publicly by the Azure firewall settings.
- I also added in an additional optional production env variable API_PREFIX, linked to the root_path in FastAPI. This allows serving behind a proxy subpath, such as /api.