### PR TITLE
Add Github workflow to deploy /docs --> wiki

### DIFF
--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -1,0 +1,41 @@
+name: Publish Docs to Wiki
+
+on:
+  push:
+    paths:
+      - docs/**
+    branches: [main]
+
+env:
+  USER_TOKEN: ${{ secrets.SVC_ACCESS_TOKEN }}
+  USER_NAME: svcfmtm
+  USER_EMAIL: fmtm@hotosm.org
+  ORG: ${{ github.event.repository.owner.name }}
+  REPO_NAME: ${{ github.event.repository.name }}
+
+jobs:
+  publish_docs_to_wiki:
+    # rclone syncs /docs dir to fmtm.wiki repo
+    name: Publish Docs to Wiki
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Pull content from wiki
+        run: |
+          mkdir tmp_wiki
+          cd tmp_wiki
+          git init
+          git config user.name $USER_NAME
+          git config user.email $USER_EMAIL
+          git pull https://$USER_TOKEN@github.com/$ORG/$REPO_NAME.wiki.git
+
+      - name: Push content to wiki
+        run: |
+          apt update && apt install -y rsync
+          rsync -av --delete docs/ tmp_wiki/ --exclude .git
+          cd tmp_wiki
+          git add .
+          git commit -m "docs: automated wiki update on push"
+          git push -f --set-upstream https://$USER_TOKEN@github.com/$ORG/$REPO_NAME.wiki.git master

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 env:
-  USER_TOKEN: ${{ secrets.SVC_ACCESS_TOKEN }}
+  USER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   USER_NAME: svcfmtm
   USER_EMAIL: fmtm@hotosm.org
   ORG: ${{ github.event.repository.owner.name }}


### PR DESCRIPTION
- Triggers when there is a push to main (i.e. merged PR) and the `/docs` dir is changed.
- Syncs content of /docs with wiki, then pushes to wiki using service user access token.

**Note**: for this to work, we need to create a service user for the repo.
I propose a user `svcfmtm` with an email `fmtm@hotosm.org` (does this email exist?).
Then we need to create an access token for that user, and place it in repository secret variable `SVC_ACCESS_TOKEN`.