### PR TITLE
Update deploy token secret for wiki workflow

### DIFF
--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 env:
-  USER_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  USER_TOKEN: ${{ secrets.WIKI_DEPLOY_TOKEN }}
   USER_NAME: svcfmtm
   USER_EMAIL: fmtm@hotosm.org
   ORG: ${{ github.event.repository.owner.name }}


### PR DESCRIPTION
Fixes #101

I added a token called WIKI_DEPLOY_TOKEN, but the token is owned by me for now:
![image](https://user-images.githubusercontent.com/78538841/221554154-918710c5-3bcf-4f41-8919-de2c938df4da.png)

The token expires at the end of the year, so we have until then to update the token to a service account user.