### PR TITLE
Update docker config for microfrontend subdomains

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,9 +9,8 @@ ODK_CENTRAL_PASSWD=
 # DEBUG=True
 # LOG_LEVEL=DEBUG
 API_URL=http://127.0.0.1:8000
-FRONTEND_SCHEME=http
-FRONTEND_DOMAIN=localhost
-API_DOMAIN=localhost
+FRONTEND_MAIN_URL=http://localhost:8080
+FRONTEND_MAP_URL=http://localhost:8081
 # API_PREFIX=/api
 # BACKEND_CORS_ORIGINS=http://localhost:8080,http://localhost:8081
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -81,6 +81,7 @@ services:
     depends_on:
       - fmtm-db
       - central-proxy
+      - traefik
     env_file:
       - .env
     networks:
@@ -91,7 +92,7 @@ services:
       - "traefik.http.services.api.loadbalancer.server.port=8000"
       - "traefik.http.routers.api.tls=true"
       - "traefik.http.routers.api.tls.certresolver=letsencrypt"
-      - "traefik.http.routers.api.rule=Host(`${API_DOMAIN}`)"
+      - "traefik.http.routers.api.rule=Host(`${API_URL#https://}`)"
       - "traefik.http.routers.api.service=api"
 
   ui-main:
@@ -101,50 +102,56 @@ services:
       target: prod
       args:
         API_URL: ${API_URL}
-        FRONTEND_SCHEME: ${FRONTEND_SCHEME}
-        FRONTEND_DOMAIN: ${FRONTEND_DOMAIN}
+        FRONTEND_MAIN_URL: ${FRONTEND_MAIN_URL}
+        FRONTEND_MAP_URL: ${FRONTEND_MAP_URL}
         APP_NAME: main
     container_name: fmtm_main
+    depends_on:
+      - api
+      - traefik
     networks:
       - fmtm-prod
     environment:
       - API_URL=${API_URL}
-    ports:
-      - "8080:8080"
+      - FRONTEND_MAIN_URL=${FRONTEND_MAIN_URL}
+      - FRONTEND_MAP_URL=${FRONTEND_MAP_URL}
     restart: unless-stopped
-    # labels:
-    #   - "traefik.enable=true"
-    #   - "traefik.http.services.ui.loadbalancer.server.port=8080"
-    #   - "traefik.http.routers.ui.tls=true"
-    #   - "traefik.http.routers.ui.tls.certresolver=letsencrypt"
-    #   - "traefik.http.routers.ui.rule=Host(`${FRONTEND_DOMAIN}`)"
-    #   - "traefik.http.routers.ui.service=ui"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.services.ui.loadbalancer.server.port=8080"
+      - "traefik.http.routers.ui.tls=true"
+      - "traefik.http.routers.ui.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.ui.rule=Host(`${FRONTEND_MAIN_URL#https://}`)"
+      - "traefik.http.routers.ui.service=ui"
 
-  ui-openlayers:
+  ui-map:
     image: "quay.io/hotosm/fmtm-fmtm_openlayer_map:latest"
     build:
       context: src/frontend
       target: prod
       args:
         API_URL: ${API_URL}
-        FRONTEND_SCHEME: ${FRONTEND_SCHEME}
-        FRONTEND_DOMAIN: ${FRONTEND_DOMAIN}
+        FRONTEND_MAIN_URL: ${FRONTEND_MAIN_URL}
+        FRONTEND_MAP_URL: ${FRONTEND_MAP_URL}
         APP_NAME: fmtm_openlayer_map
-    container_name: fmtm_fmtm_openlayer_map
+    container_name: fmtm_map
+    depends_on:
+      - api
+      - traefik
     networks:
       - fmtm-prod
     environment:
       - API_URL=${API_URL}
-    ports:
-      - "8081:8081"
+      - FRONTEND_MAIN_URL=${FRONTEND_MAIN_URL}
+      - FRONTEND_MAP_URL=${FRONTEND_MAP_URL}
     restart: unless-stopped
-    # labels:
-    #   - "traefik.enable=true"
-    #   - "traefik.http.services.ui.loadbalancer.server.port=8081"
-    #   - "traefik.http.routers.ui.tls=true"
-    #   - "traefik.http.routers.ui.tls.certresolver=letsencrypt"
-    #   - "traefik.http.routers.ui.rule=Host(`${FRONTEND_DOMAIN}` && PathPrefix(`/maps{regex:$$|/.*}`)"
-    #   - "traefik.http.routers.ui.service=ui"
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.services.ui.loadbalancer.server.port=8081"
+      - "traefik.http.routers.ui.tls=true"
+      - "traefik.http.routers.ui.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.ui.rule=Host(`${FRONTEND_MAP_URL#https://}`)"
+      - "traefik.http.routers.ui.service=ui"
 
   central-db:
     image: postgis/postgis:14-3.3-alpine

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,36 +67,46 @@ services:
       context: src/frontend
       target: debug
       args:
-        FRONTEND_SCHEME: ${FRONTEND_SCHEME}
-        FRONTEND_DOMAIN: ${FRONTEND_DOMAIN}
+        API_URL: ${API_URL}
+        FRONTEND_MAIN_URL: ${FRONTEND_MAIN_URL}
+        FRONTEND_MAP_URL: ${FRONTEND_MAP_URL}
         APP_NAME: main
     container_name: fmtm_main
+    depends_on:
+      - api
     volumes:
       - ./src/frontend/main:/app
       - /app/node_modules/
     environment:
       - API_URL=${API_URL}
+      - FRONTEND_MAIN_URL=${FRONTEND_MAIN_URL}
+      - FRONTEND_MAP_URL=${FRONTEND_MAP_URL}
     ports:
       - "8080:8080"
     networks:
       - fmtm-dev
     restart: unless-stopped
 
-  ui-openlayers:
+  ui-map:
     image: "quay.io/hotosm/fmtm-fmtm_openlayer_map:latest"
     build:
       context: src/frontend
       target: debug
       args:
-        FRONTEND_SCHEME: ${FRONTEND_SCHEME}
-        FRONTEND_DOMAIN: ${FRONTEND_DOMAIN}
+        API_URL: ${API_URL}
+        FRONTEND_MAIN_URL: ${FRONTEND_MAIN_URL}
+        FRONTEND_MAP_URL: ${FRONTEND_MAP_URL}
         APP_NAME: fmtm_openlayer_map
-    container_name: fmtm_fmtm_openlayer_map
+    container_name: fmtm_map
+    depends_on:
+      - api
     volumes:
       - ./src/frontend/fmtm_openlayer_map:/app
       - /app/node_modules/
     environment:
       - API_URL=${API_URL}
+      - FRONTEND_MAIN_URL=${FRONTEND_MAIN_URL}
+      - FRONTEND_MAP_URL=${FRONTEND_MAP_URL}
     ports:
       - "8081:8081"
     networks:

--- a/docs/DEV-1.-Getting-Started.md
+++ b/docs/DEV-1.-Getting-Started.md
@@ -41,8 +41,8 @@ Your env should look like this
     ODK_CENTRAL_USER=`<any_valid_email_address>`
     ODK_CENTRAL_PASSWD=`<password_of_central_user>`
     API_URL=http://127.0.0.1:8000
-    FRONTEND_SCHEME=http
-    FRONTEND_DOMAIN=localhost
+    FRONTEND_MAIN_URL=http://localhost:8080
+    FRONTEND_MAP_URL=http://localhost:8081
     OSM_CLIENT_ID=`<OSM_CLIENT_ID_FROM_ABOVE>`
     OSM_CLIENT_SECRET=`<OSM_CLIENT_SECRET_FROM_ABOVE>`
     OSM_URL=https://www.openstreetmap.org

--- a/docs/DEV-5:-Production-Deployment.md
+++ b/docs/DEV-5:-Production-Deployment.md
@@ -45,18 +45,18 @@ Create the env file from the example with `cp .env.example .env`. Edit that file
     ODK_CENTRAL_PASSWD=`<CHANGEME>`
 
     # FMTM
-    API_URL=http://127.0.0.1:8000
-    FRONTEND_SCHEME=http
-    FRONTEND_DOMAIN=localhost
-    API_DOMAIN=localhost
+    API_URL=https://fmtm-api.hotosm.org
+    FRONTEND_MAIN_URL=https://fmtm.hotosm.org
+    FRONTEND_MAP_URL=https://map.fmtm.hotosm.org
     # API_PREFIX=/api
+    BACKEND_CORS_ORIGINS=https://fmtm.hotosm.org,https://map.fmtm.hotosm.org
 
     # OSM
     OSM_CLIENT_ID=`<CHANGEME>`
     OSM_CLIENT_SECRET=`<CHANGEME>`
     OSM_URL=https://www.openstreetmap.org
     OSM_SCOPE=read_prefs
-    OSM_LOGIN_REDIRECT_URI=`<YOUR_API_DOMAIN>`/auth/callback/
+    OSM_LOGIN_REDIRECT_URI=`<YOUR_API_URL>`/auth/callback/
     OSM_SECRET_KEY=`<CHANGEME>`
 
     # Database (optional)

--- a/src/frontend/Dockerfile
+++ b/src/frontend/Dockerfile
@@ -4,17 +4,15 @@ ARG APP_NAME
 ARG MAINTAINER=admin@hotosm.org
 ARG API_URL
 ENV API_URL=${API_URL}
-ARG FRONTEND_SCHEME
-ENV FRONTEND_SCHEME=${FRONTEND_SCHEME}
-ARG FRONTEND_DOMAIN
-ENV FRONTEND_DOMAIN=${FRONTEND_DOMAIN}
-ENV MAIN_PORT=8080
-ENV FMTM_OPENLAYER_MAP_PORT=8081
+ARG FRONTEND_MAIN_URL
+ENV FRONTEND_MAIN_URL=${FRONTEND_MAIN_URL}
+ARG FRONTEND_MAP_URL
+ENV FRONTEND_MAP_URL=${FRONTEND_MAP_URL}
 LABEL fmtm.hotosm.org.app-name="${APP_NAME}" \
     fmtm.hotosm.org.app-version="${APP_VERSION}" \
     fmtm.hotosm.org.maintainer="${MAINTAINER}" \
-    fmtm.hotosm.org.main-port="${MAIN_PORT}" \
-    fmtm.hotosm.org.fmtm_openlayer_map-port="${FMTM_OPENLAYER_MAP_PORT}"
+    fmtm.hotosm.org.main-url="${FRONTEND_MAIN_URL}" \
+    fmtm.hotosm.org.fmtm_openlayer_map-url="${FRONTEND_MAP_URL}"
 WORKDIR /app
 COPY ./${APP_NAME}/package*.json ./
 RUN npm install

--- a/src/frontend/fmtm_openlayer_map/webpack.config.js
+++ b/src/frontend/fmtm_openlayer_map/webpack.config.js
@@ -5,7 +5,7 @@ const ModuleFederationPlugin = require("webpack/lib/container/ModuleFederationPl
 const deps = require("./package.json").dependencies;
 module.exports = {
   output: {
-    publicPath: `${process.env.FRONTEND_SCHEME}://${process.env.FRONTEND_DOMAIN}:${process.env.FMTM_OPENLAYER_MAP_PORT}/`,
+    publicPath: `${process.env.FRONTEND_MAP_URL}/`,
   },
 
   resolve: {
@@ -13,7 +13,7 @@ module.exports = {
   },
 
   devServer: {
-    port: process.env.FMTM_OPENLAYER_MAP_PORT,
+    port: `${new URL(process.env.FRONTEND_MAP_URL).port}`,
     historyApiFallback: true,
   },
 
@@ -52,7 +52,7 @@ module.exports = {
       name: "fmtm_openlayer_map",
       filename: "remoteEntry.js",
       remotes: {
-        fmtm: `fmtm@${process.env.FRONTEND_SCHEME}://${process.env.FRONTEND_DOMAIN}:${process.env.MAIN_PORT}/remoteEntry.js`,
+        fmtm: `fmtm@${process.env.FRONTEND_MAIN_URL}/remoteEntry.js`,
       },
       exposes: {
         "./Map": "./src/App.jsx",
@@ -75,11 +75,6 @@ module.exports = {
     new HtmlWebPackPlugin({
       template: "./src/index.html",
     }),
-    new EnvironmentPlugin([
-      "FRONTEND_SCHEME",
-      "FRONTEND_DOMAIN",
-      "MAIN_PORT",
-      "FMTM_OPENLAYER_MAP_PORT",
-    ]),
+    new EnvironmentPlugin(["FRONTEND_MAIN_URL", "FRONTEND_MAP_URL"]),
   ],
 };

--- a/src/frontend/main/webpack.config.js
+++ b/src/frontend/main/webpack.config.js
@@ -5,7 +5,7 @@ const ModuleFederationPlugin = require("webpack/lib/container/ModuleFederationPl
 const deps = require("./package.json").dependencies;
 module.exports = {
   output: {
-    publicPath: `${process.env.FRONTEND_SCHEME}://${process.env.FRONTEND_DOMAIN}:${process.env.MAIN_PORT}/`,
+    publicPath: `${process.env.FRONTEND_MAIN_URL}/`,
   },
 
   resolve: {
@@ -13,7 +13,7 @@ module.exports = {
   },
 
   devServer: {
-    port: process.env.MAIN_PORT,
+    port: `${new URL(process.env.FRONTEND_MAIN_URL).port}`,
     historyApiFallback: true,
   },
   devtool: "source-map",
@@ -52,7 +52,7 @@ module.exports = {
       name: "fmtm",
       filename: "remoteEntry.js",
       remotes: {
-        map: `fmtm_openlayer_map@${process.env.FRONTEND_SCHEME}://${process.env.FRONTEND_DOMAIN}:${process.env.FMTM_OPENLAYER_MAP_PORT}/remoteEntry.js`,
+        map: `fmtm_openlayer_map@${process.env.FRONTEND_MAP_URL}/remoteEntry.js`,
       },
       exposes: {
         "./ThemeSlice": "./src/store/slices/ThemeSlice.ts",
@@ -80,12 +80,6 @@ module.exports = {
     new HtmlWebPackPlugin({
       template: "./src/index.html",
     }),
-    new EnvironmentPlugin([
-      "API_URL",
-      "FRONTEND_SCHEME",
-      "FRONTEND_DOMAIN",
-      "MAIN_PORT",
-      "FMTM_OPENLAYER_MAP_PORT",
-    ]),
+    new EnvironmentPlugin(["API_URL", "FRONTEND_MAIN_URL", "FRONTEND_MAP_URL"]),
   ],
 };


### PR DESCRIPTION
Fixes #103

There have been some changes to the .env variables.

Replacing:
```dotenv
FRONTEND_SCHEME
FRONTEND_DOMAIN
API_DOMAIN
```

With:
```dotenv
FRONTEND_MAIN_URL
FRONTEND_MAP_URL
```