### PR TITLE
Remove BACKEND_CORS_ORIGINS, set automatically

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,6 @@ API_URL=http://127.0.0.1:8000
 FRONTEND_MAIN_URL=http://localhost:8080
 FRONTEND_MAP_URL=http://localhost:8081
 # API_PREFIX=/api
-# BACKEND_CORS_ORIGINS=http://localhost:8080,http://localhost:8081
 
 ### OSM ###
 OSM_CLIENT_ID=

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -84,6 +84,8 @@ services:
       - traefik
     env_file:
       - .env
+    environment:
+      - BACKEND_CORS_ORIGINS=${FRONTEND_MAIN_URL},${FRONTEND_MAP_URL}
     networks:
       - fmtm-prod
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
     environment:
       - BACKEND_CORS_ORIGINS=${FRONTEND_MAIN_URL},${FRONTEND_MAP_URL}
     ports:
-      - "7050:8000"
+      - "8000:8000"
       # - "5678:5678"
     networks:
       - fmtm-dev

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,8 +54,10 @@ services:
       - central-proxy
     env_file:
       - .env
+    environment:
+      - BACKEND_CORS_ORIGINS=${FRONTEND_MAIN_URL},${FRONTEND_MAP_URL}
     ports:
-      - "8000:8000"
+      - "7050:8000"
       # - "5678:5678"
     networks:
       - fmtm-dev

--- a/docs/DEV-5:-Production-Deployment.md
+++ b/docs/DEV-5:-Production-Deployment.md
@@ -49,7 +49,6 @@ Create the env file from the example with `cp .env.example .env`. Edit that file
     FRONTEND_MAIN_URL=https://fmtm.hotosm.org
     FRONTEND_MAP_URL=https://map.fmtm.hotosm.org
     # API_PREFIX=/api
-    BACKEND_CORS_ORIGINS=https://fmtm.hotosm.org,https://map.fmtm.hotosm.org
 
     # OSM
     OSM_CLIENT_ID=`<CHANGEME>`


### PR DESCRIPTION
As we now have variables `FRONTEND_MAIN_URL` and `FRONTEND_MAP_URL`, we can set the BACKEND_CORS_ORIGINS in the docker-compose file, instead of having the user set it manually.