### PR TITLE
Include task_status_str in status update response

### DIFF
--- a/src/backend/tasks/tasks_schemas.py
+++ b/src/backend/tasks/tasks_schemas.py
@@ -75,6 +75,7 @@ class Task(TaskBase):
 
 
 class TaskOut(TaskBase):
+    task_status_str: TaskStatusOption
     pass
 
 


### PR DESCRIPTION
Fixes #126

Added `task_status_str` to the response for `/tasks/{task_id}/new_status/`

In the long run the schemas need to be refactored, possibly renamed for clarity, and updated for other endpoints.