### PR TITLE
Fixing typos in backend deployment documentation

### DIFF
--- a/docs/DEV-2.-Backend.md
+++ b/docs/DEV-2.-Backend.md
@@ -8,12 +8,12 @@ Now let's get started!
 
 ## 1. Start FMTM with Docker
 
-The easiest way to get up and running is by using the FMTM Docker deployment. Docker creates a virtual environment, isolated from your computer's environment, installs all necessary dependencies, and creates a container for each the database, api, and frontend. These containers talk to each other via the URLs defined in the docker-compose file and your env file.
+The easiest way to get up and running is by using the FMTM Docker deployment. Docker creates a virtual environment, isolated from your computer's environment, installs all necessary dependencies, and creates a container for each the database, the api, and the frontend. These containers talk to each other via the URLs defined in the docker-compose file and your env file.
 
 ### 1A: Starting the Containers
 
-1. You will need to [Install Docker](https://docs.docker.com/engine/install/) and insure that it is running on your local machine.
-2. From the command line: navigate into the top level directory of the FMTM project.
+1. You will need to [Install Docker](https://docs.docker.com/engine/install/) and ensure that it is running on your local machine.
+2. From the command line: navigate to the top level directory of the FMTM project.
 3. From the command line run: `docker compose build`
 4. Once everything is built, from the command line run: `docker compose up -d`
 
@@ -44,7 +44,7 @@ To run FMTM locally, you will need to start the database, the api, and the front
 
 Running the database in Docker means postgres/postgis does not need to be installed and ran on your local machine, and you can use the same database no matter your method of deployment.
 
-1. You will need to [Install Docker](https://docs.docker.com/engine/install/) and insure that it is running on your local machine.
+1. You will need to [Install Docker](https://docs.docker.com/engine/install/) and ensure that it is running on your local machine.
 2. From the command line, navigate into the top level directory of the FMTM project.
 3. From command line, start up database with `docker-compose -f docker-compose.local.yml up --build`
 
@@ -58,8 +58,8 @@ For advanced users, it is also possible to run a postgresql/postgis database loc
 
 After starting the database, from the command line:
 
-1. Navigate into the top level directory of the FMTM project.
-2. Create a virtual environment with: `python3 -m venv fmtm-env`. This ensures that your computer python environment is kept clean.
+1. Navigate to the top level directory of the FMTM project.
+2. Create a virtual environment with: `python3 -m venv fmtm-env`. This ensures that your computer's python environment is kept clean.
 3. Start the FMTM virtual environment with: `source fmtm-env/bin/activate`
 4. Install backend dependencies with: `pip install -r src/backend/requirements.txt`
 5. Run the Fast API backend with: `uvicorn src.backend.main:api --reload`
@@ -70,7 +70,7 @@ The API should now be accessible at: <http://127.0.0.1:8000/docs>
 
 To run the react frontend, from the command line:
 
-1. Navigate into the react frontend directory: `cd src/frontend/main`
+1. Navigate to the react frontend directory: `cd src/frontend/main`
 2. Install dependencies: `npm install`
 3. Run the project: `npm run start:live`
 


### PR DESCRIPTION
This PR fixes some of the minor typos on the [DEV-2.-Backend Deployment](https://github.com/hotosm/fmtm/blob/main/docs/DEV-2.-Backend.md) page.