### PR TITLE
Create auto-deploy docker-compose action for prod

### DIFF
--- a/.github/workflows/prod_deploy.yml
+++ b/.github/workflows/prod_deploy.yml
@@ -1,0 +1,35 @@
+name: Production Deploy
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  # Allow manual trigger (workflow_dispatch)
+  workflow_dispatch:
+
+jobs:
+  deploy-prod:
+    runs-on: ubuntu-latest
+    environment: prod
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Environment to .env
+        env:
+          DOTENV: ${{ secrets.DOTENV }}
+        run: echo "${{ secrets.DOTENV }}" > .env
+
+      - uses: webfactory/ssh-agent@v0.7.0
+        with:
+          ssh-private-key: ${{ secrets.FMTM_HOTOSM_ORG_PRIV_KEY }}
+
+      - name: Disable Host key verification
+        # Hack to prevent "Host key verification failed". Should be replaced with a ssh-keyscan based solution
+        run: echo "StrictHostKeyChecking no" >> ~/.ssh/config
+
+      - name: Deploy
+        run: docker compose --file docker-compose.prod.yml up --build --detach
+        env:
+          DOCKER_HOST: "ssh://svcfmtm@fmtm.hotosm.org"

--- a/.github/workflows/prod_deploy.yml
+++ b/.github/workflows/prod_deploy.yml
@@ -3,8 +3,6 @@ name: Production Deploy
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
   # Allow manual trigger (workflow_dispatch)
   workflow_dispatch:
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -3,6 +3,7 @@ name: pytest
 on:
   push:
     branches: [main]
+  # Run tests on PR, prior to merge
   pull_request:
     branches: [main]
   # Allow manual trigger (workflow_dispatch)

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Allow manual trigger (workflow_dispatch)
+  workflow_dispatch:
 
 env:
   DB_URL: postgresql+psycopg2://fmtm:fmtm@localhost:5432/fmtm

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,8 @@ repos:
             --exit-non-zero-on-fix,
             --target-version,
             py39,
+            --ignore,
+            "N805",
           ]
 
   # Autoformat: YAML, JSON, Markdown, etc.

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -96,8 +96,8 @@ services:
       # The Go regex below requires escaping or changing, is this possible?
       # - "traefik.http.routers.api.rule=HostRegexp(`${API_URL}`, `{regex:[a-z]+\.[a-z].*}`)"
       - "traefik.http.routers.api.rule=Host(`fmtm-api.hotosm.org`)"
-      - "traefik.http.services.api.loadbalancer.server.port=8000"
-      - "traefik.http.routers.api.service=api"
+      - "traefik.http.services.api-svc.loadbalancer.server.port=8000"
+      - "traefik.http.routers.api.service=api-svc"
 
   ui-main:
     image: "quay.io/hotosm/fmtm-mf-main:latest"
@@ -119,8 +119,8 @@ services:
       # The Go regex below requires escaping or changing, is this possible?
       # - "traefik.http.routers.ui-main.rule=HostRegexp(`${FRONTEND_MAIN_URL}`, `{regex:[a-z]+\.[a-z].*}`)"
       - "traefik.http.routers.ui-main.rule=Host(`fmtm.hotosm.org`)"
-      - "traefik.http.services.ui-main.loadbalancer.server.port=8080"
-      - "traefik.http.routers.ui-main.service=ui-main"
+      - "traefik.http.services.ui-main-svc.loadbalancer.server.port=8080"
+      - "traefik.http.routers.ui-main.service=ui-main-svc"
 
   ui-map:
     image: "quay.io/hotosm/fmtm-mf-map:latest"
@@ -142,8 +142,8 @@ services:
       # The Go regex below requires escaping or changing, is this possible?
       # - "traefik.http.routers.ui-map.rule=HostRegexp(`${FRONTEND_MAP_URL}`, `{regex:[a-z]+\.[a-z].*}`)"
       - "traefik.http.routers.ui-map.rule=Host(`map.fmtm.hotosm.org`)"
-      - "traefik.http.services.ui-map.loadbalancer.server.port=8080"
-      - "traefik.http.routers.ui-map.service=ui-map"
+      - "traefik.http.services.ui-map-svc.loadbalancer.server.port=8080"
+      - "traefik.http.routers.ui-map.service=ui-map-svc"
 
   central-db:
     image: postgis/postgis:14-3.3-alpine

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -86,8 +86,6 @@ services:
       - traefik
     env_file:
       - .env
-    environment:
-      - BACKEND_CORS_ORIGINS=${FRONTEND_MAIN_URL},${FRONTEND_MAP_URL}
     networks:
       - fmtm-prod
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,8 +54,6 @@ services:
       - central-proxy
     env_file:
       - .env
-    environment:
-      - BACKEND_CORS_ORIGINS=${FRONTEND_MAIN_URL},${FRONTEND_MAP_URL}
     ports:
       - "8000:8000"
       # - "5678:5678"

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -23,7 +23,7 @@ class Settings(BaseSettings):
 
     @validator("BACKEND_CORS_ORIGINS", pre=True)
     def assemble_cors_origins(
-        self, val: Union[str, list[AnyUrl]], values: dict
+        cls, val: Union[str, list[AnyUrl]], values: dict
     ) -> list[str]:
         """Build and validate CORS origins list."""
         default_origins = [
@@ -50,7 +50,7 @@ class Settings(BaseSettings):
     DB_URL: Optional[PostgresDsn]
 
     @validator("DB_URL", pre=True)
-    def assemble_db_connection(self, v: str, values: dict[str, Any]) -> Any:
+    def assemble_db_connection(cls, v: str, values: dict[str, Any]) -> Any:
         """Build Postgres connection from environment variables."""
         if isinstance(v, str):
             return v

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -16,18 +16,29 @@ class Settings(BaseSettings):
     DEBUG: str = False
     LOG_LEVEL: str = "DEBUG"
 
-    BACKEND_CORS_ORIGINS: Union[str, list[AnyUrl]] = [
-        "http://localhost:8080",
-        "http://localhost:8081",
-    ]
+    FRONTEND_MAIN_URL: Optional[str]
+    FRONTEND_MAP_URL: Optional[str]
+
+    BACKEND_CORS_ORIGINS: Union[str, list[AnyUrl]]
 
     @validator("BACKEND_CORS_ORIGINS", pre=True)
-    def assemble_cors_origins(cls, val: Union[str, list[AnyUrl]]) -> list[str]:
+    def assemble_cors_origins(
+        self, val: Union[str, list[AnyUrl]], values: dict
+    ) -> list[str]:
         """Build and validate CORS origins list."""
+        default_origins = [
+            values.get("FRONTEND_MAIN_URL"),
+            values.get("FRONTEND_MAP_URL"),
+        ]
+
         if isinstance(val, str):
-            return [i.strip() for i in val.split(",")]
+            default_origins += [i.strip() for i in val.split(",")]
+            return default_origins
+
         elif isinstance(val, list):
-            return val
+            default_origins += val
+            return default_origins
+
         raise ValueError(f"Not a valid CORS origin list: {val}")
 
     API_PREFIX: Optional[str] = "/"
@@ -39,7 +50,7 @@ class Settings(BaseSettings):
     DB_URL: Optional[PostgresDsn]
 
     @validator("DB_URL", pre=True)
-    def assemble_db_connection(cls, v: str, values: dict[str, Any]) -> Any:
+    def assemble_db_connection(self, v: str, values: dict[str, Any]) -> Any:
         """Build Postgres connection from environment variables."""
         if isinstance(v, str):
             return v
@@ -78,6 +89,7 @@ class Settings(BaseSettings):
 
 @lru_cache
 def get_settings():
+    """Cache settings, for calling in multiple modules."""
     _settings = Settings()
     logger.info(f"Loaded settings: {_settings.dict()}")
     return _settings


### PR DESCRIPTION
First attempt at docker compose based deploy to fmtm.hotosm.org.

- Checks out repo.
- Creates a .env using repo secrets for the `prod` environment.
- Uses SSH key for service account user.
- Uses a --build deploy, to prevent deployment prior to quay.io build (i.e. builds locally instead).

I also refined the BACKEND_CORS_ORIGIN validator. The variable should no longer be required as default (it will include the frontend origins). The variable may still be included to override default values.