### PR TITLE
Update ODK Central API config for development, remove from prod

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,9 +11,6 @@ ODK_CENTRAL_PASSWD=
 API_URL=http://127.0.0.1:8000
 FRONTEND_MAIN_URL=http://localhost:8080
 FRONTEND_MAP_URL=http://localhost:8081
-
-BACKEND_CORS_ORIGINS=http://localhost:8000
-
 # API_PREFIX=/api
 
 ### OSM ###

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -19,6 +19,7 @@ version: "3"
 
 volumes:
   fmtm_db_data:
+  central_db_data:
   traefik-public-certificates:
 
 networks:
@@ -81,6 +82,7 @@ services:
     container_name: fmtm_api
     depends_on:
       - fmtm-db
+      - central-proxy
       - traefik
     env_file:
       - .env
@@ -142,3 +144,72 @@ services:
       - "traefik.http.routers.ui-map.rule=Host(`map.fmtm.hotosm.org`)"
       - "traefik.http.services.ui-map-svc.loadbalancer.server.port=8080"
       - "traefik.http.routers.ui-map.service=ui-map-svc"
+
+  central-db:
+    image: postgis/postgis:14-3.3-alpine
+    container_name: central_db
+    volumes:
+      - central_db_data:/var/lib/postgresql/data/
+    environment:
+      - POSTGRES_USER=${CENTRAL_DB_USER:-odk}
+      - POSTGRES_PASSWORD=${CENTRAL_DB_PASSWORD:-odk}
+      - POSTGRES_DB=${CENTRAL_DB_NAME:-odk}
+    networks:
+      - fmtm-prod
+    restart: unless-stopped
+
+  central:
+    image: "quay.io/hotosm/odkcentral-api:latest"
+    build:
+      context: odkcentral/api
+    container_name: central_api
+    depends_on:
+      - central-db
+      - pyxform
+    environment:
+      - DOMAIN=local
+      - SYSADMIN_EMAIL=${ODK_CENTRAL_USER}
+      - HTTPS_PORT=${HTTPS_PORT:-443}
+      - DB_HOST=${CENTRAL_DB_HOST:-postgres14}
+      - DB_USER=${CENTRAL_DB_USER:-odk}
+      - DB_PASSWORD=${CENTRAL_DB_PASSWORD:-odk}
+      - DB_NAME=${CENTRAL_DB_NAME:-odk}
+      - DB_SSL=${DB_SSL:-null}
+      - EMAIL_FROM=${ODK_CENTRAL_USER}
+      - EMAIL_HOST=${EMAIL_HOST:-mail}
+      - EMAIL_PORT=${EMAIL_PORT:-25}
+      - EMAIL_SECURE=${EMAIL_SECURE:-false}
+      - EMAIL_IGNORE_TLS=${EMAIL_IGNORE_TLS:-true}
+      - EMAIL_USER=${EMAIL_USER:-''}
+      - EMAIL_PASSWORD=${EMAIL_PASSWORD:-''}
+      - SENTRY_ORG_SUBDOMAIN=${SENTRY_ORG_SUBDOMAIN:-o130137}
+      - SENTRY_KEY=${SENTRY_KEY:-3cf75f54983e473da6bd07daddf0d2ee}
+      - SENTRY_PROJECT=${SENTRY_PROJECT:-1298632}
+    networks:
+      - fmtm-prod
+    command:
+      [
+        "./wait-for-it.sh",
+        "${CENTRAL_DB_HOST:-central-db}:5432",
+        "--",
+        "./init-user-and-start.sh",
+      ]
+    restart: unless-stopped
+
+  central-proxy:
+    image: "quay.io/hotosm/odkcentral-proxy:latest"
+    build:
+      context: odkcentral/proxy
+    container_name: central_proxy
+    depends_on:
+      - central
+    networks:
+      - fmtm-prod
+    restart: unless-stopped
+
+  pyxform:
+    image: "ghcr.io/getodk/pyxform-http:v1.10.1.1"
+    container_name: central_pyxform
+    networks:
+      - fmtm-prod
+    restart: always

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -19,7 +19,6 @@ version: "3"
 
 volumes:
   fmtm_db_data:
-  central_db_data:
   traefik-public-certificates:
 
 networks:
@@ -82,7 +81,6 @@ services:
     container_name: fmtm_api
     depends_on:
       - fmtm-db
-      - central-proxy
       - traefik
     env_file:
       - .env
@@ -144,48 +142,3 @@ services:
       - "traefik.http.routers.ui-map.rule=Host(`map.fmtm.hotosm.org`)"
       - "traefik.http.services.ui-map-svc.loadbalancer.server.port=8080"
       - "traefik.http.routers.ui-map.service=ui-map-svc"
-
-  central-db:
-    image: postgis/postgis:14-3.3-alpine
-    container_name: central_db
-    volumes:
-      - central_db_data:/var/lib/postgresql/data/
-    environment:
-      - POSTGRES_USER=${CENTRAL_DB_USER:-odk}
-      - POSTGRES_PASSWORD=${CENTRAL_DB_PASSWORD:-odk}
-      - POSTGRES_DB=${CENTRAL_DB_NAME:-odk}
-    networks:
-      - fmtm-prod
-    restart: unless-stopped
-
-  central:
-    image: "quay.io/hotosm/odkcentral-api:latest"
-    build:
-      context: odkcentral/api
-    container_name: central_api
-    depends_on:
-      - central-db
-      - pyxform
-    env_file:
-      - .env
-    networks:
-      - fmtm-prod
-    restart: unless-stopped
-
-  central-proxy:
-    image: "quay.io/hotosm/odkcentral-proxy:latest"
-    build:
-      context: odkcentral/proxy
-    container_name: central_proxy
-    depends_on:
-      - central
-    networks:
-      - fmtm-prod
-    restart: unless-stopped
-
-  pyxform:
-    image: "ghcr.io/getodk/pyxform-http:v1.10.1.1"
-    container_name: central_pyxform
-    networks:
-      - fmtm-prod
-    restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -136,8 +136,6 @@ services:
     depends_on:
       - central-db
       - pyxform
-    env_file:
-      - .env
     environment:
       - DOMAIN=local
       - SYSADMIN_EMAIL=${ODK_CENTRAL_USER}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,10 +138,36 @@ services:
       - pyxform
     env_file:
       - .env
+    environment:
+      - DOMAIN=local
+      - SYSADMIN_EMAIL=${ODK_CENTRAL_USER}
+      - HTTPS_PORT=${HTTPS_PORT:-443}
+      - DB_HOST=${CENTRAL_DB_HOST:-postgres14}
+      - DB_USER=${CENTRAL_DB_USER:-odk}
+      - DB_PASSWORD=${CENTRAL_DB_PASSWORD:-odk}
+      - DB_NAME=${CENTRAL_DB_NAME:-odk}
+      - DB_SSL=${DB_SSL:-null}
+      - EMAIL_FROM=${ODK_CENTRAL_USER}
+      - EMAIL_HOST=${EMAIL_HOST:-mail}
+      - EMAIL_PORT=${EMAIL_PORT:-25}
+      - EMAIL_SECURE=${EMAIL_SECURE:-false}
+      - EMAIL_IGNORE_TLS=${EMAIL_IGNORE_TLS:-true}
+      - EMAIL_USER=${EMAIL_USER:-''}
+      - EMAIL_PASSWORD=${EMAIL_PASSWORD:-''}
+      - SENTRY_ORG_SUBDOMAIN=${SENTRY_ORG_SUBDOMAIN:-o130137}
+      - SENTRY_KEY=${SENTRY_KEY:-3cf75f54983e473da6bd07daddf0d2ee}
+      - SENTRY_PROJECT=${SENTRY_PROJECT:-1298632}
     ports:
       - "8383:8383"
     networks:
       - fmtm-dev
+    command:
+      [
+        "./wait-for-it.sh",
+        "${CENTRAL_DB_HOST:-central-db}:5432",
+        "--",
+        "./init-user-and-start.sh",
+      ]
     restart: unless-stopped
 
   central-proxy:

--- a/docs/DEV-1.-Getting-Started.md
+++ b/docs/DEV-1.-Getting-Started.md
@@ -117,9 +117,6 @@ Your env should look like this
     API_URL=http://127.0.0.1:8000
     FRONTEND_MAIN_URL=http://localhost:8080
     FRONTEND_MAP_URL=http://localhost:8081
-    
-    BACKEND_CORS_ORIGINS=http://localhost:8000
-
     # API_PREFIX=/api
 
     ### OSM ###
@@ -141,6 +138,8 @@ Your env should look like this
     FMTM_DB_PASSWORD=fmtm
     FMTM_DB_NAME=fmtm'
 
+> Note: If extra cors origins are required for testing, the variable `EXTRA_CORS_ORIGINS` is a set of comma separated strings, e.g. <http://localhost:7050,http://localhost:7051>
+
 ## Verify Setup
 
 ### Check Deployment
@@ -151,12 +150,12 @@ For details on how to run this project locally for development, please look at: 
 
 Once you have deployed, you will need to check that you can properly authenticate.
 
-1.  Navigate to `http://127.0.0.1:8000/docs`
+1. Navigate to `http://127.0.0.1:8000/docs`
 
     Three endpoints are responsible for oauth
     <img width="698" alt="image" src="../images/endpoints_responsible_for_auth_screenshot-2023-03-26-092756.png">
 
-2.  Select the `/auth/osm_login/` endpoint, click `Try it out` and then `Execute`.  
+2. Select the `/auth/osm_login/` endpoint, click `Try it out` and then `Execute`.  
     This would give you the Login URL where you can supply your osm username and password.
 
     Your response should look like this:
@@ -167,7 +166,7 @@ Once you have deployed, you will need to check that you can properly authenticat
 
     After a successful login, you will get your `access_token` for FMTM, Copy it. Now, you can use it for rest of the endpoints that needs authorization.
 
-3.  Check your access token: Select the `/auth/me/` endpoint and click `Try it out`.  
+3. Check your access token: Select the `/auth/me/` endpoint and click `Try it out`.  
     Pass in the `access_token` you copied in the previous step into the `access-token` field and click `Execute`. You should get your osm id, username and profile picture id.
 
 # Start Developing

--- a/docs/DEV-2.-Backend.md
+++ b/docs/DEV-2.-Backend.md
@@ -19,26 +19,18 @@ The easiest way to get up and running is by using the FMTM Docker deployment. Do
 4. Once everything is pulled, from the command line run: `docker compose up -d api`
 5. If everything goes well you should now be able to **navigate to the project in your browser:** `http://127.0.0.1:8000/docs`
 
+> Note: If the images do not exist yet, run `docker compose build`.
+
 > Note: If the link doesn't work, check the logs with `docker logs fmtm_api`.
 
-### 1B: Setup ODK Central User
+> Note: The ODKCentral admin user will be generated automatically, with provided credentials ODK_CENTRAL_USER:ODK_CENTRAL_PASSWD
 
-The FMTM uses ODK Central to store ODK data. By default, the docker setup includes a Central server.
-
-1. Create a user with the email you provided in the **ODK_CENTRAL_USER** field of your `.env` file using the following command:    
-  `docker compose exec central odk-cmd --email YOUREMAIL@ADDRESSHERE.com user-create`
-2. When prompted to put a password, input the password you provided in the **ODK_CENTRAL_PASSWD** field of the `.env` file
-3. Promote the user created to an admin using the following command:  
-  `docker-compose exec central odk-cmd --email YOUREMAIL@ADDRESSHERE.com user-promote`
-
-> Note: Alternatively, you may use an external Central server and user.
-
-### 1C: Import Test Data
+### 1B: Import Test Data
 
 Some test data is available to get started quickly.
 
 1. Navigate to the `import-test-data` endpoint in the API docs page:
-  <http://127.0.0.1:8000/docs#/debug/import_test_data_debug_import_test_data_get>
+   <http://127.0.0.1:8000/docs#/debug/import_test_data_debug_import_test_data_get>
 2. Click `Try it out`, then `execute`.
 
 ## 2. Start the API locally (OUTDATED)

--- a/docs/DEV-6.-Production-Deployment.md
+++ b/docs/DEV-6.-Production-Deployment.md
@@ -58,12 +58,6 @@ Create the env file from the example with `cp .env.example .env`. Edit that file
     OSM_LOGIN_REDIRECT_URI=`<YOUR_API_URL>`/auth/callback/
     OSM_SECRET_KEY=`<CHANGEME>`
 
-    # Database (optional)
-    CENTRAL_DB_HOST=central-db
-    CENTRAL_DB_USER=odk
-    CENTRAL_DB_PASSWORD=`<CHANGEME>`
-    CENTRAL_DB_NAME=odk
-
     FMTM_DB_HOST=fmtm-db
     FMTM_DB_USER=fmtm
     FMTM_DB_PASSWORD=`<CHANGEME>`
@@ -71,9 +65,11 @@ Create the env file from the example with `cp .env.example .env`. Edit that file
 
 > Note: It is also possible to use the API_PREFIX variable if the api is served under, e.g. /api on the domain.
 
+> Note: You must have an existing version of ODKCentral running, to provide the URL and credentials here.
+
 Run the production docker-compose config:
-`docker compose -f docker-compose.prod.yml up --build -d`
+`docker compose -f docker-compose.prod.yml up -d`
+
+> Note: The images should be built already on Quay. If they don't exist, use the `--build` flag during run.
 
 With any luck, this will launch the docker container where the project runs, and you can access the working website from the domain name!
-
-> Note: don't forget to make an admin user for odkcentral [see Deployment page](https://github.com/hotosm/fmtm/wiki/DEV-2.-Backend).

--- a/odkcentral/api/.dockerignore
+++ b/odkcentral/api/.dockerignore
@@ -1,1 +1,2 @@
 **/*
+!init-user-and-start.sh

--- a/odkcentral/api/Dockerfile
+++ b/odkcentral/api/Dockerfile
@@ -15,33 +15,37 @@
 #     along with FMTM.  If not, see <https:#www.gnu.org/licenses/>.
 #
 
+ARG node_version=16.19.1
+
+
+
 FROM docker.io/bitnami/git:2 as repo
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         "jq" \
     && rm -rf /var/lib/apt/lists/*
-ARG ODK_CENTRAL_VERSION=v2023.1.0
+ARG ODK_CENTRAL_VERSION=v2023.2.1
 RUN git clone --depth 1 --branch ${ODK_CENTRAL_VERSION} \
     "https://github.com/getodk/central.git" \
     && cd central && git submodule update --init
 
 
 
-FROM docker.io/node:16.17.0
+FROM docker.io/node:${node_version}
 
 WORKDIR /usr/odk
 
-RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(grep -oP 'VERSION_CODENAME=\K\w+' /etc/os-release)-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list; \
-    curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg; \
-    apt-get update; \
-    apt-get install -y cron gettext postgresql-client-9.6 jq
+RUN echo "deb http://apt.postgresql.org/pub/repos/apt/ $(grep -oP 'VERSION_CODENAME=\K\w+' /etc/os-release)-pgdg main" | tee /etc/apt/sources.list.d/pgdg.list && \
+  curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/apt.postgresql.org.gpg && \
+  apt-get update && \
+  apt-get install -y cron gettext postgresql-client-14
 
 COPY --from=repo central/files/service/crontab /etc/cron.d/odk
 
 COPY --from=repo central/server/package*.json ./
 
 RUN npm clean-install --omit=dev --legacy-peer-deps --no-audit --fund=false --update-notifier=false
-RUN npm install pm2@5.2.0 -g
+RUN npm install pm2@5.2.2 -g
 
 COPY --from=repo central/server/ ./
 COPY --from=repo central/files/service/scripts/ ./
@@ -57,20 +61,8 @@ RUN mkdir /etc/secrets sentry-versions \
     && echo '1' > sentry-versions/central \
     && echo '1' > sentry-versions/client
 
-# Substitute central db vars
-RUN printf '#!/bin/bash\n\
-set -eo pipefail\n\
-tmp=$(mktemp)\n\
-echo "Setting database credentials in /usr/share/odk/config.json.template"\n\
-jq --arg host "${CENTRAL_DB_HOST:-central-db}" --arg user "${CENTRAL_DB_USER:-odk}" \
---arg pass "${CENTRAL_DB_PASSWORD:-odk}" --arg db "${CENTRAL_DB_NAME:-odk}" \
-'"'"'.default.database.host = $host | .default.database.user = $user | .default.database.password = $pass | .default.database.database = $db'"'"' \
-/usr/share/odk/config.json.template > \
-"$tmp" && mv "$tmp" /usr/share/odk/config.json.template\n\
-echo "Credentials set"\n\
-exec ./start-odk.sh' \
->> ./sub-db-vars.sh \
-&& chmod +x ./sub-db-vars.sh
-ENTRYPOINT ["./wait-for-it.sh", "${CENTRAL_DB_HOST:-central-db}:5432", "--", "./sub-db-vars.sh"]
+# Add entrypoint script to init user
+COPY ./init-user-and-start.sh ./
+RUN chmod +x ./init-user-and-start.sh
 
 EXPOSE 8383

--- a/odkcentral/api/init-user-and-start.sh
+++ b/odkcentral/api/init-user-and-start.sh
@@ -1,0 +1,32 @@
+set -eo pipefail
+
+### Init, generate config, migrate db
+echo "Stripping pm2 exec command from start-odk.sh script (last 2 lines)"
+head -n -2 ./start-odk.sh > ./init-odk-db.sh
+chmod +x ./init-odk-db.sh
+
+echo "Running ODKCentral start script to init environment and migrate DB"
+echo "The server will not start on this run"
+./init-odk-db.sh
+
+
+### Create admin user
+echo "Creating test user ${ODK_CENTRAL_USER} with password ${ODK_CENTRAL_PASSWD}"
+echo "${ODK_CENTRAL_PASSWD}" | odk-cmd --email "${ODK_CENTRAL_USER}" user-create || true
+
+echo "Elevating user to admin"
+odk-cmd --email "${ODK_CENTRAL_USER}" user-promote || true
+
+
+### Run server
+MEMTOT=$(vmstat -s | grep 'total memory' | awk '{ print $1 }')
+if [ "$MEMTOT" -gt "1100000" ]
+then
+  export WORKER_COUNT=4
+else
+  export WORKER_COUNT=1
+fi
+echo "using $WORKER_COUNT worker(s) based on available memory ($MEMTOT).."
+
+echo "Starting server"
+exec pm2-runtime ./pm2.config.js

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -53,6 +53,9 @@ class Settings(BaseSettings):
             values.get("FRONTEND_MAP_URL"),
         ]
 
+        if val is None:
+            return default_origins
+
         if isinstance(val, str):
             default_origins += [i.strip() for i in val.split(",")]
             return default_origins

--- a/src/backend/config.py
+++ b/src/backend/config.py
@@ -37,13 +37,17 @@ class Settings(BaseSettings):
     FRONTEND_MAIN_URL: Optional[str]
     FRONTEND_MAP_URL: Optional[str]
 
-    BACKEND_CORS_ORIGINS: Union[str, list[AnyUrl]]
+    EXTRA_CORS_ORIGINS: Optional[Union[str, list[AnyUrl]]]
 
-    @validator("BACKEND_CORS_ORIGINS", pre=True)
+    @validator("EXTRA_CORS_ORIGINS", pre=True)
     def assemble_cors_origins(
         cls, val: Union[str, list[AnyUrl]], values: dict
     ) -> list[str]:
-        """Build and validate CORS origins list."""
+        """Build and validate CORS origins list.
+
+        By default, the provided frontend URLs are included in the origins list.
+        If this variable used, the provided urls are appended to the list.
+        """
         default_origins = [
             values.get("FRONTEND_MAIN_URL"),
             values.get("FRONTEND_MAP_URL"),

--- a/src/backend/main.py
+++ b/src/backend/main.py
@@ -16,6 +16,7 @@
 #     along with FMTM.  If not, see <https:#www.gnu.org/licenses/>.
 #
 
+"""Entrypoint for FastAPI app."""
 
 import logging
 import os
@@ -23,9 +24,10 @@ import sys
 from typing import Union
 
 from fastapi import FastAPI, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.logger import logger as fastapi_logger
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, JSONResponse, RedirectResponse
 from odkconvert.xlsforms import xlsforms_path
 
 from .__version__ import __version__
@@ -38,9 +40,6 @@ from .projects import project_routes
 from .projects.project_crud import read_xlsforms
 from .tasks import tasks_routes
 from .users import user_routes
-from fastapi.exceptions import RequestValidationError
-from fastapi.responses import JSONResponse
-
 
 # Env variables
 os.environ["OAUTHLIB_INSECURE_TRANSPORT"] = settings.OAUTHLIB_INSECURE_TRANSPORT
@@ -67,7 +66,7 @@ logger = logging.getLogger(__name__)
 
 
 def get_application() -> FastAPI:
-
+    """Get the FastAPI app instance, with settings."""
     _app = FastAPI(
         title=settings.APP_NAME,
         description="HOTOSM Field Tasking Manager",
@@ -81,7 +80,7 @@ def get_application() -> FastAPI:
 
     _app.add_middleware(
         CORSMiddleware,
-        allow_origins=settings.BACKEND_CORS_ORIGINS,
+        allow_origins=settings.EXTRA_CORS_ORIGINS,
         allow_credentials=True,
         allow_methods=["*"],
         allow_headers=["*"],
@@ -104,12 +103,16 @@ api = get_application()
 
 @api.exception_handler(RequestValidationError)
 async def validation_exception_handler(request: Request, exc: RequestValidationError):
+    """Exception handler for more descriptive logging."""
     errors = []
     for error in exc.errors():
-        errors.append({"loc": error["loc"],
-                       "msg":error["msg"],
-                       "error":error["msg"] + str([x for x in error["loc"]])
-                        })
+        errors.append(
+            {
+                "loc": error["loc"],
+                "msg": error["msg"],
+                "error": error["msg"] + str([x for x in error["loc"]]),
+            }
+        )
     return JSONResponse(status_code=400, content={"errors": errors})
 
 
@@ -131,17 +134,19 @@ async def shutdown_event():
 
 
 @api.get("/")
-def read_root():
-    logger.info("logging from the root logger")
-    return {"Hello": "Big, big World"}
+def home():
+    """Redirect home to docs."""
+    return RedirectResponse("/docs")
 
 
 @api.get("/items/{item_id}")
 def read_item(item_id: int, q: Union[str, None] = None):
+    """Get item IDs."""
     return {"item_id": item_id, "q": q}
 
 
 @api.get("/images/{image_filename}")
 def get_images(image_filename: str):
+    """Download image files."""
     path = f"./backend/images/{image_filename}"
     return FileResponse(path)


### PR DESCRIPTION
Fixes #163

Changes:
- ODKCentral now supports database credential injection (https://github.com/getodk/central/pull/389), so I removed the `jq` hack in our API dockerfile.
- Added environment variables to the development docker-compose.yml.
- Automatically init the admin user for ODK Central, using provided credentials in the `.env` (created via terminal no longer required).
- Remove ODKCentral containers from docker-compose.prod.yml. We will run a standalone ODKCentral in production (odk.fmtm.hotosm.org, or odk.hotosm.org).

I thought I would also take the opportunity to make some minor tweaks to the backend:
- Fix issues with BACKEND_CORS_ORIGINS variable. It is now optional and has been renamed to EXTRA_CORS_ORIGINS.
- Automatically redirect root path for https://fmtm-api.hotosm.org to the /docs path.

**PR ready to merge. I reverted the removal of ODK Central services from the docker-compose.prod.yml, to avoid breaking deploy workflows for now. We can update with #285.**