### PR TITLE
✨ feat: Add handleClickOutside event listener to close popup on outsi…

### DIFF
--- a/src/frontend/fmtm_openlayer_map/src/views/Home.jsx
+++ b/src/frontend/fmtm_openlayer_map/src/views/Home.jsx
@@ -102,6 +102,17 @@ const Home = () => {
         },
       },
     });
+    /**
+     * Function to setPosition of Popup to Undefined so that the popup closes
+     */
+    function handleClickOutside(event) {
+      if (container && !container.contains(event.target)) {
+        overlay.setPosition(undefined);
+        closer.blur();
+      }
+    }
+    // Bind the event listener for outside click and trigger handleClickOutside
+    document.addEventListener('mousedown', handleClickOutside);
 
     closer.style.textDecoration = "none";
     closer.style.color = defaultTheme.palette.info["main"];
@@ -160,6 +171,13 @@ const Home = () => {
     setMap(initialMap);
     setView(view);
     setFeaturesLayer(initalFeaturesLayer);
+
+    return ()=>{
+       /**
+     * Removed handleClickOutside Eventlistener on unmount
+     */
+      document.removeEventListener('mousedown', handleClickOutside);
+    }
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
…de click, and remove it on unmount in Home.jsx

This commit adds an event listener to the document for `mousedown` that triggers a function called `handleClickOutside`. This function sets the position of an overlay to undefined and removes focus from an element called `closer` if the click event occurs outside of a container. The commit also includes a return function in the `useEffect` hook that removes the `mousedown` event listener on component unmount.

- Resolve #343 
- Resolve #344 