### PR TITLE
Select nodes or polygons for data extract

### DIFF
--- a/src/backend/projects/project_crud.py
+++ b/src/backend/projects/project_crud.py
@@ -678,6 +678,7 @@ def get_odk_id_for_project(
 def generate_appuser_files(
     db: Session,
     project_id: int,
+    extractPolygon: bool,
     upload: UploadFile,
     background_task_id: uuid.UUID,
 ):
@@ -698,9 +699,7 @@ def generate_appuser_files(
 
         # add handler to logger
         logger.addHandler(handler)
-        logger.info('my_function was called')
-
-
+        logger.info(f"Starting generate_appuser_files for project {project_id}")
 
         # Get the project table contents.
         project = table(
@@ -791,7 +790,7 @@ def generate_appuser_files(
                 # Generating an osm extract from the underpass database.
                 pg = PostgresClient('https://raw-data-api0.hotosm.org/v1', "underpass")
                 outline = eval(poly.outline)
-                outline_geojson = pg.getFeatures(outline, outfile)
+                outline_geojson = pg.getFeatures(boundary = outline, filespec = outfile, polygon = extractPolygon)
 
                 # If the osm extracts contents does not have title, provide an empty text for that.
                 for feature in outline_geojson["features"]:

--- a/src/backend/projects/project_routes.py
+++ b/src/backend/projects/project_routes.py
@@ -21,7 +21,7 @@ import uuid
 
 from typing import List, Optional
 
-from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, Request, BackgroundTasks
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile, Form, BackgroundTasks
 from fastapi.logger import logger as logger
 from sqlalchemy.orm import Session
 
@@ -306,7 +306,7 @@ async def download_task_boundaries(
 async def generate_files(
     background_tasks: BackgroundTasks,
     project_id: int,
-    extractPolygon: bool = False,
+    extractPolygon: bool = Form(False),
     upload: Optional[UploadFile] = File(None),
     db: Session = Depends(database.get_db),
 ):

--- a/src/backend/projects/project_routes.py
+++ b/src/backend/projects/project_routes.py
@@ -306,6 +306,7 @@ async def download_task_boundaries(
 async def generate_files(
     background_tasks: BackgroundTasks,
     project_id: int,
+    extractPolygon: bool = False,
     upload: Optional[UploadFile] = File(None),
     db: Session = Depends(database.get_db),
 ):
@@ -322,6 +323,7 @@ async def generate_files(
     Parameters:
 
     project_id (int): The ID of the project for which files are being generated. This is a required field.
+    polygon (bool): A boolean flag indicating whether the polygon is extracted or not.
 
     upload (UploadFile): An uploaded file that is used as input for generating the files. 
         This is not a required field. A file should be provided if user wants to upload a custom xls form.
@@ -337,7 +339,7 @@ async def generate_files(
     # insert task and task ID into database
     await project_crud.insert_background_task_into_database(db, task_id = background_task_id)
 
-    background_tasks.add_task(project_crud.generate_appuser_files, db, project_id, upload, background_task_id)
+    background_tasks.add_task(project_crud.generate_appuser_files, db, project_id, extractPolygon, upload, background_task_id)
 
     # FIXME: fix return value
     return {

--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -42,8 +42,8 @@ pyxform==1.12.0
 qrcode==7.4.2
 pyxform==1.12.0
 xmltodict==0.13.0
-osm-fieldwork==0.3.0
-
+# osm-fieldwork==0.3.0
+git+https://github.com/hotosm/osm-fieldwork.git
 # ----- FILE UPLOAD ----
 python-multipart==0.0.5
 


### PR DESCRIPTION

This pull request addresses the issue of default data extract generation in the geojson format containing only nodes or building centroids. With this update, users can select either nodes or polygons as the output geometry for data extraction. The fmtm backend now supports both options, allowing users to extract the data in the format that best suits their needs.

To make use of this feature, users can now select the output geometry option when specifying the category for the data extract on the create project page. This update provides users with greater flexibility and control over the data extraction process.

- Closes #374 