### PR TITLE
Add fmtm images to docker volume, osm-fieldwork to pyproject

### DIFF
--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -82,6 +82,8 @@ services:
       args:
         APP_VERSION: ${API_VERSION}
     container_name: fmtm_api
+    volumes:
+      - fmtm_images:/app/images
     depends_on:
       - fmtm-db
       - traefik

--- a/docker-compose.noodk.yml
+++ b/docker-compose.noodk.yml
@@ -48,6 +48,7 @@ services:
         APP_VERSION: debug
     container_name: fmtm_api
     volumes:
+      - fmtm_images:/app/images
       - ./src/backend/app:/opt/app
     depends_on:
       - fmtm-db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ version: "3"
 
 volumes:
   fmtm_db_data:
+  fmtm_images:
   central_db_data:
 
 networks:
@@ -49,6 +50,7 @@ services:
         APP_VERSION: debug
     container_name: fmtm_api
     volumes:
+      - fmtm_images:/app/images
       - ./src/backend/app:/opt/app
     depends_on:
       - fmtm-db

--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -121,9 +121,6 @@ COPY --from=extract-deps \
     /opt/python/requirements-dev.txt /opt/python/
 RUN pip install --no-warn-script-location \
     --no-cache-dir -r /opt/python/requirements-dev.txt 
-
-RUN pip install osm-fieldwork==0.3.1
-
 USER appuser
 CMD ["python", "-m", "debugpy", "--listen", "0.0.0.0:5678", \
     "-m", "uvicorn", "app.main:api", \
@@ -139,6 +136,7 @@ COPY --from=ghcr.io/hotosm/fmtm/odkcentral-proxy:latest \
     /etc/nginx/ca.crt /etc/nginx/central.crt /usr/local/share/ca-certificates/
 RUN update-ca-certificates
 USER appuser
+
 
 
 FROM runtime as prod

--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -113,6 +113,8 @@ ENTRYPOINT ["/docker-entrypoint.sh"]
 # Add non-root user, permissions
 RUN useradd -r -u 900 -m -c "hotosm account" -d /home/appuser -s /bin/false appuser \
     && chown -R appuser:appuser /opt /home/appuser
+# Add volume for persistent images
+VOLUME /app/images
 
 
 

--- a/src/backend/pdm.lock
+++ b/src/backend/pdm.lock
@@ -428,7 +428,7 @@ dependencies = [
 
 [[package]]
 name = "osm-fieldwork"
-version = "0.3.1rc1"
+version = "0.3.1"
 requires_python = ">=3.9"
 summary = "Convert CSV files from ODK Central to OSM format."
 dependencies = [
@@ -895,7 +895,7 @@ summary = "Backport of pathlib-compatible object wrapper for zip files"
 
 [metadata]
 lock_version = "4.0"
-content_hash = "sha256:e45a19ed4492154796db853553d0c8964d5e5c77671d8e7eb178c9ed09e0ba4c"
+content_hash = "sha256:00c23107fecfccbc9a7c87850263f72566daa57802d08160992af8b058b3e29b"
 
 [metadata.files]
 "alembic 1.8.1" = [
@@ -1583,9 +1583,9 @@ content_hash = "sha256:e45a19ed4492154796db853553d0c8964d5e5c77671d8e7eb178c9ed0
     {url = "https://files.pythonhosted.org/packages/1c/a6/8ce4d2ef2c29be3235c08bb00e0b81e29d38ebc47d82b17af681bf662b74/openpyxl-3.0.9-py2.py3-none-any.whl", hash = "sha256:8f3b11bd896a95468a4ab162fc4fcd260d46157155d1f8bfaabb99d88cfcf79f"},
     {url = "https://files.pythonhosted.org/packages/9e/19/c45fb7a40cd46e03e36d60d1db26a50a795fa0b6b8a2a8094f4ac0c71ae5/openpyxl-3.0.9.tar.gz", hash = "sha256:40f568b9829bf9e446acfffce30250ac1fa39035124d55fc024025c41481c90f"},
 ]
-"osm-fieldwork 0.3.1rc1" = [
-    {url = "https://files.pythonhosted.org/packages/16/02/a236c6710487653c143ae32569d058782d2e7cf0046af52be7a7e4c98a14/osm_fieldwork-0.3.1rc1-py3-none-any.whl", hash = "sha256:3cbf108abeb4c5aa4be79af9e6c5139ac48c814f50718a089592682b3c5d1098"},
-    {url = "https://files.pythonhosted.org/packages/32/d9/4706a3fcf0f1d9c15c6502416eb94e9a748ec75f5220ac431981fdf18103/osm-fieldwork-0.3.1rc1.tar.gz", hash = "sha256:f4950a8fae38bfa271d9b66021d6979e18156283b8b760fe7db6326be233940e"},
+"osm-fieldwork 0.3.1" = [
+    {url = "https://files.pythonhosted.org/packages/40/78/46db30ba065aba52a2d797e903bf0e6f741980bd54aa90ff7fe9fea7ba51/osm_fieldwork-0.3.1-py3-none-any.whl", hash = "sha256:61eb72661c84e6cc53a112968845ffd88972decc5c3714aa0c004b7434cc9008"},
+    {url = "https://files.pythonhosted.org/packages/d3/2a/d0645692a84e17ae9c80af8b875b5ab7781fd715c0039a21356b4ce0430c/osm-fieldwork-0.3.1.tar.gz", hash = "sha256:1a5cd638e78ed461ea1121ec4b53d5d5d286206a69cc1fa8fef47d7881ec0eb8"},
 ]
 "osm-login-python 0.0.4" = [
     {url = "https://files.pythonhosted.org/packages/d1/81/9c36618b20b570ddcf6fd7770a528a5d93f5b1f853d7ef81e536fdd39f76/osm-login-python-0.0.4.tar.gz", hash = "sha256:f10c9bc91978aebb38c5083502d42d78463b617d4a9a05d9a8bdc44550de32b8"},

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "SQLAlchemy-Utils==0.40.0",
     "bcrypt==4.0.1",
     "segno==1.5.2",
+    "osm-fieldwork==0.3.1",
 ]
 requires-python = ">=3.10"
 readme = "../../README.md"


### PR DESCRIPTION
PR to move osm-fieldwork back to pyproject.toml and to create a docker volume for /app/images path in the API container.
This allows for persistent images across restarts, without file permission errors.