### PR TITLE
Fix osm-fieldwork package override, use correct central cert

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,8 +35,8 @@ services:
       - POSTGRES_USER=${FMTM_DB_USER:-fmtm}
       - POSTGRES_PASSWORD=${FMTM_DB_PASSWORD:-fmtm}
       - POSTGRES_DB=${FMTM_DB_NAME:-fmtm}
-    # ports:
-    #   - "5432:5432"
+    ports:
+      - "5432:5432"
     networks:
       - fmtm-dev
     restart: unless-stopped
@@ -52,14 +52,13 @@ services:
     volumes:
       - fmtm_images:/opt/app/images
       - ./src/backend/app:/opt/app
-      - ../osm-fieldwork/osm_fieldwork:/home/appuser/.local/lib/python3.10/site-packages/osm_fieldwork
     depends_on:
       - fmtm-db
       - central-proxy
     env_file:
       - .env
     ports:
-      - "7050:8000"
+      - "8000:8000"
       - "5678:5678"
     networks:
       - fmtm-dev
@@ -86,7 +85,7 @@ services:
       - FRONTEND_MAIN_URL=${URL_SCHEME}://${FRONTEND_MAIN_URL}
       - FRONTEND_MAP_URL=${URL_SCHEME}://${FRONTEND_MAP_URL}
     ports:
-      - "8081:8081"
+      - "8080:8080"
     networks:
       - fmtm-dev
     restart: unless-stopped
@@ -112,7 +111,7 @@ services:
       - FRONTEND_MAIN_URL=${URL_SCHEME}://${FRONTEND_MAIN_URL}
       - FRONTEND_MAP_URL=${URL_SCHEME}://${FRONTEND_MAP_URL}
     ports:
-      - "8082:8082"
+      - "8081:8081"
     networks:
       - fmtm-dev
     restart: unless-stopped
@@ -126,8 +125,8 @@ services:
       - POSTGRES_USER=${CENTRAL_DB_USER:-odk}
       - POSTGRES_PASSWORD=${CENTRAL_DB_PASSWORD:-odk}
       - POSTGRES_DB=${CENTRAL_DB_NAME:-odk}
-    # ports:
-    #   - "5433:5432"
+    ports:
+      - "5433:5432"
     networks:
       - fmtm-dev
     restart: unless-stopped

--- a/odkcentral/proxy/Dockerfile
+++ b/odkcentral/proxy/Dockerfile
@@ -22,4 +22,4 @@ WORKDIR /usr/share/nginx/html
 RUN rm -rf ./* /etc/nginx/conf.d/default.conf /etc/nginx/nginx.conf
 COPY . /etc/nginx
 RUN cat /etc/nginx/central.crt /etc/nginx/ca.crt \
-    >> /etc/nginx/central-fullchain.crt \
+    >> /etc/nginx/central-fullchain.crt

--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -45,7 +45,7 @@ COPY pyproject.toml pdm.lock /opt/python/
 RUN pip install --no-cache-dir --upgrade pip \
     && pip install --no-cache-dir pdm==2.6.1
 RUN pdm export --prod > requirements.txt \
-    && pdm export --dev --no-default > requirements-dev.txt 
+    && pdm export --dev --no-default > requirements-dev.txt
 
 
 
@@ -67,7 +67,7 @@ RUN set -ex \
 COPY --from=extract-deps \
     /opt/python/requirements.txt /opt/python/
 RUN pip install --user --no-warn-script-location \
-    --no-cache-dir -r /opt/python/requirements.txt  
+    --no-cache-dir -r /opt/python/requirements.txt
 
 
 
@@ -95,7 +95,7 @@ RUN set -ex \
         "libproj19" \
         "libgeos-c1v5" \
         # "libgdal32" \
-    && rm -rf /var/lib/apt/lists/* 
+    && rm -rf /var/lib/apt/lists/*
 COPY --from=build \
     /root/.local \
     /home/appuser/.local
@@ -122,7 +122,7 @@ FROM runtime as debug-no-odk
 COPY --from=extract-deps \
     /opt/python/requirements-dev.txt /opt/python/
 RUN pip install --no-warn-script-location \
-    --no-cache-dir -r /opt/python/requirements-dev.txt 
+    --no-cache-dir -r /opt/python/requirements-dev.txt
 USER appuser
 CMD ["python", "-m", "debugpy", "--listen", "0.0.0.0:5678", \
     "-m", "uvicorn", "app.main:api", \
@@ -135,16 +135,17 @@ FROM debug-no-odk as debug-with-odk
 # Add the SSL cert for debug odkcentral
 USER root
 COPY --from=ghcr.io/hotosm/fmtm/odkcentral-proxy:latest \
-    /etc/nginx/ca.crt /etc/nginx/central.crt /usr/local/share/ca-certificates/
+    /etc/nginx/central-fullchain.crt /usr/local/share/ca-certificates/
 RUN update-ca-certificates
 USER appuser
 
 
 
 FROM runtime as prod
+# Pre-compile packages to .pyc (init speed gains)
+RUN python -c "import compileall; compileall.compile_path(maxlevels=10, quiet=1)"
+# Change to non-root user after pre-compile
 USER appuser
 # Note: 4 uvicorn workers as running with docker, change to 1 worker for Kubernetes
 CMD ["uvicorn", "app.main:api", "--host", "0.0.0.0", "--port", "8000", \
     "--workers", "4", "--log-level", "error", "--no-access-log"]
-# Pre-compile packages to .pyc (init speed gains)
-RUN python -c "import compileall; compileall.compile_path(maxlevels=10, quiet=1)"


### PR DESCRIPTION
Reverts accidental additions to docker-compose.yml breaking osm-fieldwork.

I also added two bugfixes:
- After updating the odkcentral cert chain in the proxy, I hadn't updated it in the api dockerfile. Connections to central now work again if using it locally.
- The pre-compile for python modules needs to be done by the root user, prior to changing to appuser. Fixed.