### PR TITLE
Add JOSM API to docker compose dev stack

### DIFF
--- a/docker-compose.josm.yml
+++ b/docker-compose.josm.yml
@@ -1,0 +1,54 @@
+# Copyright (c) 2022, 2023 Humanitarian OpenStreetMap Team
+# This file is part of FMTM.
+#
+#     FMTM is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     FMTM is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with FMTM.  If not, see <https:#www.gnu.org/licenses/>.
+#
+
+version: "3"
+
+networks:
+  x11:
+
+services:
+  josm:
+    image: "ghcr.io/hotosm/fmtm/josm:latest"
+    build:
+      context: josm
+    container_name: josm
+    environment:
+      - DISPLAY=josm-novnc:0.0
+    depends_on:
+      - josm-novnc
+    networks:
+      - fmtm-dev
+      - x11
+    ports:
+      - 8111:80
+    restart: unless-stopped
+
+  josm-novnc:
+    image: "ghcr.io/hotosm/fmtm/josm-novnc:latest"
+    build:
+      context: josm/novnc
+    container_name: josm_novnc
+    environment:
+      - DISPLAY_WIDTH=1280
+      - DISPLAY_HEIGHT=600
+      - RUN_XTERM=no
+      - RUN_FLUXBOX=no
+    ports:
+      - "8112:8080"
+    networks:
+      - x11
+    restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,6 @@ volumes:
 
 networks:
   fmtm-dev:
-  x11:
 
 services:
   fmtm-db:
@@ -185,38 +184,6 @@ services:
       - central
     networks:
       - fmtm-dev
-    restart: unless-stopped
-
-  josm:
-    image: "ghcr.io/hotosm/fmtm/josm:latest"
-    build:
-      context: josm
-    container_name: josm
-    environment:
-      - DISPLAY=josm-novnc:0.0
-    depends_on:
-      - josm-novnc
-    networks:
-      - fmtm-dev
-      - x11
-    ports:
-      - 8111:80
-    restart: unless-stopped
-
-  josm-novnc:
-    image: "ghcr.io/hotosm/fmtm/josm-novnc:latest"
-    build:
-      context: josm/novnc
-    container_name: josm_novnc
-    environment:
-      - DISPLAY_WIDTH=1280
-      - DISPLAY_HEIGHT=600
-      - RUN_XTERM=no
-      - RUN_FLUXBOX=no
-    ports:
-      - "8112:8080"
-    networks:
-      - x11
     restart: unless-stopped
 
   pyxform:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ volumes:
 
 networks:
   fmtm-dev:
+  x11:
 
 services:
   fmtm-db:
@@ -184,6 +185,38 @@ services:
       - central
     networks:
       - fmtm-dev
+    restart: unless-stopped
+
+  josm:
+    image: "ghcr.io/hotosm/fmtm/josm:latest"
+    build:
+      context: josm
+    container_name: josm
+    environment:
+      - DISPLAY=josm-novnc:0.0
+    depends_on:
+      - josm-novnc
+    networks:
+      - fmtm-dev
+      - x11
+    ports:
+      - 8111:80
+    restart: unless-stopped
+
+  josm-novnc:
+    image: "ghcr.io/hotosm/fmtm/josm-novnc:latest"
+    build:
+      context: josm/novnc
+    container_name: josm_novnc
+    environment:
+      - DISPLAY_WIDTH=1280
+      - DISPLAY_HEIGHT=600
+      - RUN_XTERM=no
+      - RUN_FLUXBOX=no
+    ports:
+      - "8112:8080"
+    networks:
+      - x11
     restart: unless-stopped
 
   pyxform:

--- a/docs/DEV-2.-Backend.md
+++ b/docs/DEV-2.-Backend.md
@@ -155,6 +155,23 @@ Creating a new release during development may not always be feasible.
 
 > Note: this is useful for debugging features during active development.
 
+## Running JOSM in the dev stack
+
+- Run JOSM with FMTM:
+
+```bash
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.josm.yml \
+  up -d
+```
+
+This adds JOSM to the docker compose stack for local development.
+Access the JOSM Remote API: <http://localhost:8111>
+Access the JOSM GUI in browser: <http://localhost:8112>
+
+You can now call the JOSM API from FMTM and changes will be reflected in the GUI.
+
 ## Conclusion
 
 Running the FMTM project is easy with Docker. You can also run the

--- a/josm/Dockerfile
+++ b/josm/Dockerfile
@@ -1,0 +1,78 @@
+# Copyright (c) 2022, 2023 Humanitarian OpenStreetMap Team
+# This file is part of FMTM.
+#
+#     FMTM is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     FMTM is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with FMTM.  If not, see <https:#www.gnu.org/licenses/>.
+#
+
+FROM docker.io/debian:bookworm as base
+ARG MAINTAINER=admin@hotosm.org
+LABEL org.hotosm.fmtm.maintainer="${MAINTAINER}" \
+      org.hotosm.fmtm.josm-port="8111" \
+      org.hotosm.fmtm.nginx-port="80"
+RUN set -ex \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install \
+    -y --no-install-recommends "locales" "ca-certificates" \
+    && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \
+    && rm -rf /var/lib/apt/lists/* \
+    && update-ca-certificates
+# Set locale
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+
+
+FROM base as gpg-key
+RUN set -ex \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install \
+    -y --no-install-recommends \
+        "curl" \
+        "gnupg2" \
+    && rm -rf /var/lib/apt/lists/*
+RUN curl -sS https://josm.openstreetmap.de/josm-apt.key \
+    | gpg --dearmor | tee /opt/josm.gpg
+
+
+
+FROM base as runtime
+COPY --from=gpg-key \
+    /opt/josm.gpg /etc/apt/trusted.gpg.d/josm.gpg
+RUN echo \
+    "deb [arch=$(dpkg --print-architecture) \
+    signed-by=/etc/apt/trusted.gpg.d/josm.gpg] \
+    https://josm.openstreetmap.de/apt alldist universe" \ 
+    | tee /etc/apt/sources.list.d/josm.list > /dev/null
+RUN set -ex \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install \
+    -y --no-install-recommends \
+        "gosu" \
+        "josm" \
+        "nginx" \
+    && rm -rf /var/lib/apt/lists/*
+COPY container-entrypoint.sh /container-entrypoint.sh
+# Add non-root user
+RUN useradd --system -r -u 101 -m -c "nginx user" \
+    -d /home/nginx -s /bin/false nginx \
+    && chmod +x /container-entrypoint.sh
+COPY --chown=nginx \
+    preferences.xml /home/nginx/.config/JOSM/preferences.xml
+# Replace default nginx config
+COPY --chown=nginx \
+    nginx-josm.conf /etc/nginx/sites-enabled/default
+# Run as root, change to nginx user in entrypoint
+ENTRYPOINT ["/container-entrypoint.sh"]

--- a/josm/container-entrypoint.sh
+++ b/josm/container-entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Start JOSM as nginx (unpriv) user
+gosu nginx josm &
+
+exec nginx -g "daemon off;"

--- a/josm/nginx-josm.conf
+++ b/josm/nginx-josm.conf
@@ -1,0 +1,13 @@
+server {
+    listen 80 default_server;
+    server_name _;
+
+    location / {
+        proxy_pass http://127.0.0.1:8111;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }    
+}

--- a/josm/novnc/Dockerfile
+++ b/josm/novnc/Dockerfile
@@ -1,0 +1,6 @@
+FROM docker.io/theasp/novnc:latest
+COPY index.html /usr/share/novnc/
+RUN useradd -r -u 900 -m -c "novnc account" -d /home/appuser -s /bin/false appuser \
+    && chown -R appuser:appuser /app
+WORKDIR /app
+USER appuser

--- a/josm/novnc/index.html
+++ b/josm/novnc/index.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0; URL=vnc.html?resize=scale" />
+  </head>
+  <body>
+    <p>If you see this <a href="vnc.html?resize=scale">click here</a>.</p>
+  </body>
+</html>

--- a/josm/preferences.xml
+++ b/josm/preferences.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<preferences xmlns='http://josm.openstreetmap.de/preferences-1.0' version='18789'>
+  <tag key='josm.version' value='18789'/>
+  <tag key='draw.splashscreen' value='false'/>
+  <tag key='expert' value='true'/>
+  <tag key='gui.start.animation' value='false'/>
+  <tag key='cache.capabilities1637351842' value='1691490836'/>
+  <tag key='cache.motd.html' value='1691490835'/>
+  <tag key='cache.motd.html.java' value='11.0.18'/>
+  <tag key='cache.motd.html.lang' value='En:'/>
+  <tag key='cache.motd.html.version' value='18789'/>
+  <tag key='draw.rawgps.colormode' value='0'/>
+  <tag key='draw.rawgps.lines' value='2'/>
+  <tag key='mappaint.renderer-class-name' value='org.openstreetmap.josm.data.osm.visitor.paint.StyledMapRenderer'/>
+  <tag key='oauth.use-for-all-requests' value='false'/>
+  <tag key='org.openstreetmap.josm.gui.preferences.PreferenceDialog.geometry' value='x=1610,y=585,width=800,height=774'/>
+  <tag key='preferences.reset.draw.rawgps.lines' value='true'/>
+  <list key='projection.sub.core:mercator'>
+  </list>
+  <tag key='propertiesdialog.preview-on-hover' value='false'/>
+  <tag key='proxy.policy' value='no-proxy'/>
+  <tag key='remotecontrol.enabled' value='true'/>
+  <list key='validator.skip'>
+  </list>
+  <list key='validator.skipBeforeUpload'>
+  </list>
+</preferences>


### PR DESCRIPTION
Part misunderstanding, part fun little project.

I originally containerised JOSM in the hope to make the API accessible.

**Two Issues**

- JOSM is useless without the GUI component.

- JOSM has very strict and non-configurable remote access settings. It's accessible on 127.0.0.1:8111, which doesn't work with Docker (uses localhost).

**Solution**

- I made the JOSM GUI accessible via noVNC. This way we don't need to install Java or JOSM on our local machine for development. It runs entirely in a container, the GUI accessible on `localhost:8112`.

- I added nginx to the JOSM container, which is against the one-service-per-container ethos, but necessary in this case. Nginx reverse-proxies 127.0.0.1:8111 to localhost:80, making the JOSM API accessible by port mapping the container 8111:8111. Now we have remote JOSM available on `localhost:8111` for development.

**Next Steps**

- Tasking manager connects remotely to the JOSM API and configures the user session.
- It doesn't use anything fancy: just http calls using URL params.
- We can do the same from the FMTM frontend (making calls from the backend if needed too using `josm:80`).
- E.g. we can call a URL like: `http://127.0.0.1:8111/load_and_zoom?left=8.19&right=8.20&top=48.605&bottom=48.590&select=node413602999` to configure JOSM remotely.

**Note:** I added docs on how to run this in DEV-2: Backend.