### PR TITLE
Update pytest CI action, tweak

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -24,38 +24,62 @@ jobs:
     container:
       image: ghcr.io/hotosm/fmtm/backend:ci
       env:
-        FMTM_DB_URL: postgresql+psycopg2://fmtm:fmtm@fmtm-db:5432/fmtm
-        ODK_CENTRAL_URL: http://localhost:8383
-        ODK_CENTRAL_USER: odk
+        ODK_CENTRAL_URL: https://central-proxy
+        ODK_CENTRAL_USER: test@hotosm.org
         ODK_CENTRAL_PASSWD: odk
-        OSM_CLIENT_ID: test
-        OSM_CLIENT_SECRET: test
-        OSM_URL: https://www.openstreetmap.org
-        OSM_SCOPE: read_prefs
-        OSM_LOGIN_REDIRECT_URI: http://127.0.0.1:8080/osmauth/
-        OSM_SECRET_KEY: test
-        URL_SCHEME: "http"
-        FRONTEND_MAIN_URL: "localhost:8080"
-        FRONTEND_MAP_URL: "localhost:8081"
+        OSM_CLIENT_ID: ${{ env.OSM_TEST_CLIENT_ID }}
+        OSM_CLIENT_SECRET: ${{ env.OSM_TEST_CLIENT_SECRET }}
+        OSM_SECRET_KEY: ${{ env.OSM_TEST_SECRET_KEY }}
+        # FRONTEND_MAIN_URL: "ui-main:8080"
+        # FRONTEND_MAP_URL: "ui-map:8081"
       options: --user root
 
-    # pytest needs a database
     services:
-      # Label used to access the postgres service container
+      # Start backend database
       fmtm-db:
-        # Uses dockerhub postgis image
         image: postgis/postgis:14-3.3-alpine
-        # Provide the password, initilized database for pytest user
         env:
           POSTGRES_PASSWORD: fmtm
           POSTGRES_DB: fmtm
           POSTGRES_USER: fmtm
-        # Set health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+
+      # Start ODK Central database
+      central-db:
+        image: "postgis/postgis:14-3.3-alpine"
+        env:
+          POSTGRES_PASSWORD: odk
+          POSTGRES_DB: odk
+          POSTGRES_USER: odk
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+      # Start ODK Central
+      central:
+        image: "ghcr.io/hotosm/fmtm/odkcentral:v2023.2.1"
+        env:
+          DOMAIN: local
+          SYSADMIN_EMAIL: test@hotosm.org
+          SYSADMIN_PASSWD: odk
+          HTTPS_PORT: 443
+          DB_HOST: central-db
+          DB_USER: odk
+          DB_PASSWORD: odk
+          DB_NAME: odk
+          SENTRY_ORG_SUBDOMAIN: o130137
+          SENTRY_KEY: 3cf75f54983e473da6bd07daddf0d2ee
+          SENTRY_PROJECT: 1298632
+
+      # Start proxy to access ODK Central
+      central-proxy:
+        image: "ghcr.io/hotosm/fmtm/odkcentral-proxy:latest"
 
     steps:
       - uses: actions/checkout@v3

--- a/build_ci_imgs.sh
+++ b/build_ci_imgs.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -eo pipefail
+
+docker build --push \
+    -t ghcr.io/hotosm/fmtm/backend:ci \
+    --target ci \
+    --build-arg APP_VERSION=ci \
+    ./src/backend

--- a/odkcentral/api/Dockerfile
+++ b/odkcentral/api/Dockerfile
@@ -64,5 +64,7 @@ RUN mkdir /etc/secrets sentry-versions \
 # Add entrypoint script to init user
 COPY ./init-user-and-start.sh ./
 RUN chmod +x ./init-user-and-start.sh
+CMD ["./wait-for-it.sh", "central-db:5432", \
+    "--", "./init-user-and-start.sh"]
 
 EXPOSE 8383

--- a/src/backend/.dockerignore
+++ b/src/backend/.dockerignore
@@ -4,5 +4,7 @@
 # Allow files and directories
 !**/*.py
 !app
+!tests
+!container-entrypoint.sh
 !pyproject.toml
 !pdm.lock

--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -102,19 +102,13 @@ COPY --from=build \
     /root/.local \
     /home/appuser/.local
 WORKDIR /opt
-COPY . /opt/
-# ENTRYPOINT bash script to check db is ready
-ARG FMTM_DB_HOST
-RUN printf '#!/bin/bash\n\
-    set -eo pipefail\n\
-    while !</dev/tcp/${FMTM_DB_HOST:-fmtm-db}/5432; do sleep 1; done;\n\
-    exec "$@"'\
-    >> /docker-entrypoint.sh \
-    && chmod +x /docker-entrypoint.sh
-ENTRYPOINT ["/docker-entrypoint.sh"]
+COPY app/ /opt/app/
+COPY container-entrypoint.sh /
+ENTRYPOINT ["/container-entrypoint.sh"]
 # Add non-root user, permissions
 RUN useradd -r -u 900 -m -c "hotosm account" -d /home/appuser -s /bin/false appuser \
-    && chown -R appuser:appuser /opt /home/appuser
+    && chown -R appuser:appuser /opt /home/appuser \
+    && chmod +x /container-entrypoint.sh
 # Add volume for persistent images
 VOLUME /opt/app/images
 # Change to non-root user
@@ -158,6 +152,7 @@ USER appuser
 
 
 FROM debug-no-odk as ci
+COPY tests/ /opt/tests/
 # Pre-compile packages to .pyc (init speed gains)
 RUN python -c "import compileall; compileall.compile_path(maxlevels=10, quiet=1)"
 # Override entrypoint, as not possible in Github action

--- a/src/backend/app/config.py
+++ b/src/backend/app/config.py
@@ -34,7 +34,7 @@ class Settings(BaseSettings):
     DEBUG: bool = False
     LOG_LEVEL: str = "DEBUG"
 
-    URL_SCHEME: Optional[str]
+    URL_SCHEME: Optional[str] = "http"
     FRONTEND_MAIN_URL: Optional[str]
     FRONTEND_MAP_URL: Optional[str]
 
@@ -108,10 +108,10 @@ class Settings(BaseSettings):
 
     OSM_CLIENT_ID: str
     OSM_CLIENT_SECRET: str
-    OSM_URL: AnyUrl
-    OSM_SCOPE: str
-    OSM_LOGIN_REDIRECT_URI: AnyUrl
     OSM_SECRET_KEY: str
+    OSM_URL: AnyUrl = "https://www.openstreetmap.org"
+    OSM_SCOPE: str = "read_prefs"
+    OSM_LOGIN_REDIRECT_URI: AnyUrl = "http://127.0.0.1:8080/osmauth/"
 
     SENTRY_DSN: Optional[str]
 

--- a/src/backend/container-entrypoint.sh
+++ b/src/backend/container-entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -eo pipefail
+
+while !</dev/tcp/${FMTM_DB_HOST:-fmtm-db}/5432;
+do
+    sleep 1;
+done;
+
+exec "$@"

--- a/src/backend/tests/test_users.py
+++ b/src/backend/tests/test_users.py
@@ -16,6 +16,14 @@
 # #     along with FMTM.  If not, see <https:#www.gnu.org/licenses/>.
 # #
 
+"""Tests for user / auth endpoints."""
+
+
+def dummy_test():
+    """Dummy test to stop exit code 5."""
+    assert True
+
+
 # import pytest
 # from fastapi import status
 


### PR DESCRIPTION
- PyTest fails currently due to commented out tests - I added a dummy test to prevent this.
- Add helper script for building backend CI img, including test code.
- Add services to the pytest action (fmtm db, central db, central, central-proxy), so we can test all endpoints with proper responses.
- Moved all entrypoint script into files, instead of hacky dockerfile setup.