### PR TITLE
Project specific logging to additional separate file

### DIFF
--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -134,11 +134,15 @@ def get_logger():
             # format=log_json_format, # JSON format func
         )
 
-        log.add("/opt/logs/create_project.json", 
-                enqueue=True,
-                serialize=True,
-                filter=lambda record: "task" in record["extra"] and record["extra"]["task"] == "create_project"
-                )
+        log.add(
+            "/opt/logs/create_project.json",
+            level=settings.LOG_LEVEL,
+            enqueue=True,
+            serialize=True,
+            rotation="00:00",
+            retention="10 days",
+            filter=lambda record: record["extra"]["task"] == "create_project",
+        )
 
 api = get_application()
 

--- a/src/backend/app/projects/project_crud.py
+++ b/src/backend/app/projects/project_crud.py
@@ -1162,8 +1162,9 @@ def generate_task_files(
     xlsform: str,
     form_type: str,
     odk_credentials: project_schemas.ODKCentral,
-    project_log: any
 ):
+    project_log = log.bind(task="create_project", project_id=project_id)
+
     project_log.info(f"Generating files for task {task_id}")
     project = get_project(db, project_id)
     odk_id = project.odkid
@@ -1438,7 +1439,7 @@ def generate_appuser_files(
             for task in tasks_list:
                 try:
                     generate_task_files(
-                        db, project_id, task, xlsform, form_type, odk_credentials, project_log
+                        db, project_id, task, xlsform, form_type, odk_credentials,
                     )
                 except Exception as e:
                     log.warning(str(e))

--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -691,8 +691,9 @@ async def generate_log(
             logs = [json.loads(line) for line in log_file]
             
             filtered_logs = [log.get("record",{}).get("message",None) for log in logs if log.get("record", {}).get("extra", {}).get("project_id") == project_id]
+            last_50_logs = filtered_logs[-50:]
 
-            logs = "\n".join(filtered_logs)
+            logs = "\n".join(last_50_logs)
             return {
                 "status": task_status.name,
                 "message": task_message,


### PR DESCRIPTION
Follow on from #785

Minor tweak to:
- Set log file rotation.
- Instantiate the log with `project_id=project_id and task="create_project"`
(we don't need to pass the logger between functions, as it uses a bind to differentiate it from the standard logs)

This will generate logs to terminal, `fmtm.log` (all logs), and then create_project specific logs to `create_project.json`.