### PR TITLE
Fix pytest during PRs

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -26,12 +26,12 @@ jobs:
     container:
       image: ghcr.io/hotosm/fmtm/backend:ci-${{ github.base_ref || github.ref_name }}
       env:
-        ODK_CENTRAL_URL: ${{ env.ODK_CENTRAL_URL }}
-        ODK_CENTRAL_USER: ${{ env.ODK_CENTRAL_USER }}
-        ODK_CENTRAL_PASSWD: ${{ env.ODK_CENTRAL_PASSWD }}
-        OSM_CLIENT_ID: ${{ env.OSM_CLIENT_ID }}
-        OSM_CLIENT_SECRET: ${{ env.OSM_CLIENT_SECRET }}
-        OSM_SECRET_KEY: ${{ env.OSM_SECRET_KEY }}
+        ODK_CENTRAL_URL: ${{ vars.ODK_CENTRAL_URL }}
+        ODK_CENTRAL_USER: ${{ vars.ODK_CENTRAL_USER }}
+        ODK_CENTRAL_PASSWD: ${{ vars.ODK_CENTRAL_PASSWD }}
+        OSM_CLIENT_ID: ${{ vars.OSM_CLIENT_ID }}
+        OSM_CLIENT_SECRET: ${{ vars.OSM_CLIENT_SECRET }}
+        OSM_SECRET_KEY: ${{ vars.OSM_SECRET_KEY }}
       options: --user root
 
     services:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -26,18 +26,12 @@ jobs:
     container:
       image: ghcr.io/hotosm/fmtm/backend:ci-${{ github.base_ref || github.ref_name }}
       env:
-        ODK_CENTRAL_URL: https://central-proxy
-        ODK_CENTRAL_USER: test@hotosm.org
-        ODK_CENTRAL_PASSWD: odk
-        OSM_CLIENT_ID: test
-        OSM_CLIENT_SECRET: test
-        OSM_SECRET_KEY: test
-        # Fix why env. vars not working below
-        # OSM_CLIENT_ID: ${{ env.OSM_TEST_CLIENT_ID }}
-        # OSM_CLIENT_SECRET: ${{ env.OSM_TEST_CLIENT_SECRET }}
-        # OSM_SECRET_KEY: ${{ env.OSM_TEST_SECRET_KEY }}
-        # FRONTEND_MAIN_URL: "ui-main:8080"
-        # FRONTEND_MAP_URL: "ui-map:8081"
+        ODK_CENTRAL_URL: ${{ env.ODK_CENTRAL_URL }}
+        ODK_CENTRAL_USER: ${{ env.ODK_CENTRAL_USER }}
+        ODK_CENTRAL_PASSWD: ${{ env.ODK_CENTRAL_PASSWD }}
+        OSM_CLIENT_ID: ${{ env.OSM_CLIENT_ID }}
+        OSM_CLIENT_SECRET: ${{ env.OSM_CLIENT_SECRET }}
+        OSM_SECRET_KEY: ${{ env.OSM_SECRET_KEY }}
       options: --user root
 
     services:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -21,10 +21,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     environment:
-      name: ${{ github.base_ref || github.ref_name }}
+      name: ${{ github.event_name == 'push' && github.ref_name || github.base_ref }}
 
     container:
-      image: ghcr.io/hotosm/fmtm/backend:ci-${{ github.base_ref || github.ref_name }}
+      image: ghcr.io/hotosm/fmtm/backend:ci-${{ github.event_name == 'push' && github.ref_name || github.base_ref }}
       env:
         ODK_CENTRAL_URL: https://central-proxy
         ODK_CENTRAL_USER: test@hotosm.org

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -21,7 +21,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     environment:
-      name: ${{ github.event_name == 'push' && github.ref_name || github.base_ref }}
+      name: development
 
     container:
       image: ghcr.io/hotosm/fmtm/backend:ci-${{ github.event_name == 'push' && github.ref_name || github.base_ref }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -21,10 +21,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     environment:
-      name: ${{ github.ref_name }}
+      name: ${{ github.head_ref || github.ref_name }}
 
     container:
-      image: ghcr.io/hotosm/fmtm/backend:ci-${{ github.ref_name }}
+      image: ghcr.io/hotosm/fmtm/backend:ci-${{ github.head_ref || github.ref_name }}
       env:
         ODK_CENTRAL_URL: https://central-proxy
         ODK_CENTRAL_USER: test@hotosm.org

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -21,10 +21,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     environment:
-      name: development
+      name: test
 
     container:
-      image: ghcr.io/hotosm/fmtm/backend:ci-${{ github.event_name == 'push' && github.ref_name || github.base_ref }}
+      image: ghcr.io/hotosm/fmtm/backend:ci-${{ github.base_ref || github.ref_name }}
       env:
         ODK_CENTRAL_URL: https://central-proxy
         ODK_CENTRAL_USER: test@hotosm.org

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -21,10 +21,10 @@ jobs:
   test:
     runs-on: ubuntu-latest
     environment:
-      name: ${{ github.head_ref || github.ref_name }}
+      name: ${{ github.base_ref || github.ref_name }}
 
     container:
-      image: ghcr.io/hotosm/fmtm/backend:ci-${{ github.head_ref || github.ref_name }}
+      image: ghcr.io/hotosm/fmtm/backend:ci-${{ github.base_ref || github.ref_name }}
       env:
         ODK_CENTRAL_URL: https://central-proxy
         ODK_CENTRAL_USER: test@hotosm.org


### PR DESCRIPTION
Closes #797

I had to set github.head_ref instead of github.ref_name, as during PRs ref_name is set to the PR branch name (when we want the target branch).

The syntax `${{ github.head_ref || github.ref_name }}` works, as head_ref is only available if a PR.