### PR TITLE
Remove pydantic Url in favour of str

### DIFF
--- a/src/backend/app/config.py
+++ b/src/backend/app/config.py
@@ -20,7 +20,7 @@
 from functools import lru_cache
 from typing import Any, Optional, Union
 
-from pydantic import AnyUrl, Extra, FieldValidationInfo, PostgresDsn, field_validator
+from pydantic import Extra, FieldValidationInfo, PostgresDsn, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -41,7 +41,7 @@ class Settings(BaseSettings):
     @classmethod
     def assemble_cors_origins(
         cls,
-        val: Union[str, list[AnyUrl]],
+        val: Union[str, list[str]],
         info: FieldValidationInfo,
     ) -> Union[list[str], str]:
         """Build and validate CORS origins list.
@@ -99,16 +99,16 @@ class Settings(BaseSettings):
         # Convert Url type to string
         return str(pg_url)
 
-    ODK_CENTRAL_URL: Optional[AnyUrl] = None
+    ODK_CENTRAL_URL: Optional[str] = ""
     ODK_CENTRAL_USER: Optional[str] = ""
     ODK_CENTRAL_PASSWD: Optional[str] = ""
 
     OSM_CLIENT_ID: str
     OSM_CLIENT_SECRET: str
     OSM_SECRET_KEY: str
-    OSM_URL: AnyUrl = "https://www.openstreetmap.org"
+    OSM_URL: str = "https://www.openstreetmap.org"
     OSM_SCOPE: str = "read_prefs"
-    OSM_LOGIN_REDIRECT_URI: AnyUrl = "http://127.0.0.1:8080/osmauth/"
+    OSM_LOGIN_REDIRECT_URI: str = "http://127.0.0.1:8080/osmauth/"
 
     SENTRY_DSN: Optional[str] = None
 


### PR DESCRIPTION
The Pydantic Url type is a pain to work with. It doesn't work in place of where a str should be.

Removed all instances of AnyUrl to prevent issues parsing as str type.

In the future when Pydantic docs are improved & usage of AnyUrl is clearer, we should change back (as it does helpful config validation checking that URLs are valid.