### PR TITLE
build: set PYTHONPATH to /opt, for ci img

### DIFF
--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -79,6 +79,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PYTHONFAULTHANDLER=1 \
     PATH="/home/appuser/.local/bin:$PATH" \
+    PYTHONPATH="/opt" \
     PYTHON_LIB="/home/appuser/.local/lib/python$PYTHON_IMG_TAG/site-packages" \
     SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
     REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \


### PR DESCRIPTION
Useful to have PYTHONPATH pre set to /opt, allowing import of app.xxx from code outside of the directory.