### PR TITLE
Fix migration schema init (trim whitespace)

### DIFF
--- a/src/backend/migrate-entrypoint.sh
+++ b/src/backend/migrate-entrypoint.sh
@@ -60,8 +60,9 @@ create_db_schema_if_missing() {
     table_exists=$(psql -t "$db_url" -c "
         SELECT EXISTS (SELECT 1 FROM information_schema.tables
         WHERE table_schema = 'public' AND table_name = 'projects');
-    ")
-    
+    " | tr -d '[:space:]')  # Remove all whitespace and formatting characters
+    echo "Debug: return from table_exists query: $table_exists"
+
     if [ "$table_exists" = "t" ]; then
         echo "Data exists in the database. Skipping schema creation."
         return 0


### PR DESCRIPTION
- I merged the migration script PR without testing thoroughly enough.
- psql sometimes returns additional whitespace from it's queries, so the check if tables/schema existed, prior to applying the schema didn't work correctly.
- This PR adds a trim to the database check for the `projects` table, correctly identifying that data already exists.