### PR TITLE
Simplify project features response & prep for flatgeobuf osm extracts

### DIFF
--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -673,16 +673,16 @@ def get_project_features(
     task_id: int = None,
     db: Session = Depends(database.get_db),
 ):
-    """Get api for fetching all the features of a project.
+    """Fetch all the features for a project.
 
-    This endpoint allows you to get all the features of a project.
+    The features are generated from raw-data-api
 
-    ## Request Body
-    - `project_id` (int): the project's id. Required.
+    Args:
+        project_id (int): The project id.
+        task_id (int): The task id.
 
-    ## Response
-    - Returns a JSON object containing a list of features.
-
+    Returns:
+        feature(json): JSON object containing a list of features
     """
     features = project_crud.get_project_features(db, project_id, task_id)
     return features


### PR DESCRIPTION
# Issue

1. The response from `get_project_features_geojson` has many redundant keys, increasing the data transfer size when displaying the data extract.
2. We currently request for a data extract from raw-data-api, then download the resulting zipped geojson to /tmp, extract, and return the data. In the long run there is no need for this step. We can request a flatgeobuf file from raw-data-api, then either access directly from the S3 url (store the link in db), or upload the flatgeobuf to our own S3 for access.

# Solution

1. Simplify the returned JSON response when getting data extracts, removing keys:
```
task_id
project_id
geometry.properties.label
geometry.properties.title
geometry.properties.version
geometry.properties.changeset
geometry.properties.timestamp
```
from each JSON object in the array.

2. Update to allow passing what format we require to raw-data-api & add comment TODOs about future changes.