### PR TITLE
Fix bottom menu

### DIFF
--- a/src/frontend/src/components/ProjectDetails/ProjectOptions.tsx
+++ b/src/frontend/src/components/ProjectDetails/ProjectOptions.tsx
@@ -3,6 +3,7 @@ import CoreModules from '../../shared/CoreModules';
 import AssetModules from '../../shared/AssetModules';
 import environment from '../../environment';
 import { DownloadDataExtract, DownloadProjectForm } from '../../api/Project';
+import { ProjectActions } from '../../store/slices/ProjectSlice';
 
 const ProjectOptions = ({ setToggleGenerateModal }) => {
   const dispatch = CoreModules.useAppDispatch();
@@ -119,7 +120,10 @@ const ProjectOptions = ({ setToggleGenerateModal }) => {
             </CoreModules.Button>
           </CoreModules.Link>
           <CoreModules.Button
-            onClick={() => setToggleGenerateModal(true)}
+            onClick={() => {
+              setToggleGenerateModal(true);
+              dispatch(ProjectActions.SetMobileFooterSelection('explore'));
+            }}
             variant="contained"
             color="error"
             sx={{ width: '200px', mr: '15px' }}

--- a/src/frontend/src/views/NewProjectDetails.jsx
+++ b/src/frontend/src/views/NewProjectDetails.jsx
@@ -186,6 +186,12 @@ const Home = () => {
     fillOpacity: '0',
   };
 
+  useEffect(() => {
+    if (mobileFooterSelection !== 'explore') {
+      setToggleGenerateModal(false);
+    }
+  }, [mobileFooterSelection]);
+
   return (
     <div>
       {/* Customized Modal For Generate Tiles */}


### PR DESCRIPTION
This PR fixes the issue #936 where bottom sheet(bottom menu) is closed when "Generate mbtiles" button is clicked in mobile view.
![1698648072469_720](https://github.com/hotosm/fmtm/assets/81785002/a755ef91-9eee-495f-bd8c-faa2ebf748cc)
