### PR TITLE
Fix signinout issue

### DIFF
--- a/src/frontend/src/utilities/CustomDrawer.jsx
+++ b/src/frontend/src/utilities/CustomDrawer.jsx
@@ -154,14 +154,11 @@ export default function CustomDrawer({ open, placement, size, type, onClose, onS
                   <NavLink
                     key={index}
                     to={menuDetails.ref}
-                    style={{
-                      textDecoration: 'inherit',
-                      color: 'inherit',
-                      fontFamily: 'inherit',
-                      fontSize: '1.01587rem',
-                      background: '#000000',
-                      opacity: 0.8,
-                    }}
+                    className={`fmtm-no-underline fmtm-text-inherit fmtm-opacity-80 ${
+                      menuDetails.name === 'Explore Projects' || menuDetails.name === 'Manage Organizations'
+                        ? 'lg:fmtm-hidden'
+                        : ''
+                    }`}
                   >
                     <CoreModules.ListItem
                       id={index.toString()}
@@ -174,17 +171,17 @@ export default function CustomDrawer({ open, placement, size, type, onClose, onS
                   </NavLink>
                 ),
               )}
-              <div className="fmtm-mt-2">
+              <div className="fmtm-ml-4 fmtm-mt-2 lg:fmtm-hidden">
                 {token != null ? (
                   <div
-                    className="fmtm-ml-4 fmtm-text-[#d73e3e] hover:fmtm-text-[#d73e3e] fmtm-cursor-pointer"
+                    className="fmtm-text-[#d73e3e] hover:fmtm-text-[#d73e3e] fmtm-cursor-pointer fmtm-opacity-80"
                     onClick={handleOnSignOut}
                   >
                     Sign Out
                   </div>
                 ) : (
                   <div
-                    className="fmtm-ml-4 fmtm-text-[#44546a] hover:fmtm-text-[#d73e3e] fmtm-cursor-pointer"
+                    className="fmtm-text-[#44546a] hover:fmtm-text-[#d73e3e] fmtm-cursor-pointer fmtm-opacity-80"
                     onClick={() => createLoginWindow('/')}
                   >
                     Sign In

--- a/src/frontend/src/utilities/CustomDrawer.jsx
+++ b/src/frontend/src/utilities/CustomDrawer.jsx
@@ -3,9 +3,13 @@ import SwipeableDrawer from '@mui/material/SwipeableDrawer';
 import CoreModules from '../shared/CoreModules';
 import AssetModules from '../shared/AssetModules';
 import { NavLink } from 'react-router-dom';
+import { createLoginWindow } from '../utilfunctions/login';
+import { LoginActions } from '../store/slices/LoginSlice';
+import { ProjectActions } from '../store/slices/ProjectSlice';
 
-export default function CustomDrawer({ open, placement, size, type, onClose, onSignOut }) {
+export default function CustomDrawer({ open, placement, size, type, onClose, onSignOut, setOpen }) {
   const defaultTheme = CoreModules.useAppSelector((state) => state.theme.hotTheme);
+  const dispatch = CoreModules.useAppDispatch();
 
   const onMouseEnter = (event) => {
     const element = document.getElementById(`text${event.target.id}`);
@@ -80,6 +84,12 @@ export default function CustomDrawer({ open, placement, size, type, onClose, onS
       isActive: true,
     },
   ];
+
+  const handleOnSignOut = () => {
+    setOpen(false);
+    dispatch(LoginActions.signOut(null));
+    dispatch(ProjectActions.clearProjects([]));
+  };
 
   return (
     <div>
@@ -164,6 +174,23 @@ export default function CustomDrawer({ open, placement, size, type, onClose, onS
                   </NavLink>
                 ),
               )}
+              <div className="fmtm-mt-2">
+                {token != null ? (
+                  <div
+                    className="fmtm-ml-4 fmtm-text-[#d73e3e] hover:fmtm-text-[#d73e3e] fmtm-cursor-pointer"
+                    onClick={handleOnSignOut}
+                  >
+                    Sign Out
+                  </div>
+                ) : (
+                  <div
+                    className="fmtm-ml-4 fmtm-text-[#44546a] hover:fmtm-text-[#d73e3e] fmtm-cursor-pointer"
+                    onClick={() => createLoginWindow('/')}
+                  >
+                    Sign In
+                  </div>
+                )}
+              </div>
             </CoreModules.List>
           </CoreModules.Stack>
         </SwipeableDrawer>

--- a/src/frontend/src/utilities/PrimaryAppBar.tsx
+++ b/src/frontend/src/utilities/PrimaryAppBar.tsx
@@ -66,6 +66,7 @@ export default function PrimaryAppBar() {
         size={windowSize}
         type={type}
         onSignOut={handleOnSignOut}
+        setOpen={setOpen}
       />
       <CoreModules.AppBar
         position="static"


### PR DESCRIPTION
This PR fixes issue #929 where now SignIn/SignOut is added to the Sidebar when breakpoint is activated. Additionally, 'Explore Project' & 'Manage Organizations' have been removed from the sidebar for large screens.

1. Removed  'Explore Project' & 'Manage Organizations' from large screen sidebar
![image](https://github.com/hotosm/fmtm/assets/81785002/4a578784-090a-4f94-8942-446b2b531097)

2. Added SignIn/SignOut in sidebar for small screen
![image](https://github.com/hotosm/fmtm/assets/81785002/b216503c-324a-4523-8c53-f015f9ec35dc)


