### PR TITLE
fix (createNewProject): splitTasks - PROCEED btn removed from the pop…

### DIFF
--- a/src/frontend/src/components/createnewproject/SplitTasks.tsx
+++ b/src/frontend/src/components/createnewproject/SplitTasks.tsx
@@ -252,17 +252,9 @@ const SplitTasks = ({ flag, geojsonFile, setGeojsonFile, customLineUpload, custo
               <ProgressBar totalSteps={totalSteps} currentStep={generateProjectLog?.progress} />
             </div>
             <p className="fmtm-text-base">
-              You may click Proceed button whilst the process runs in the background. Click Cancel to terminate the
-              process.
+              Please stay on this page until the process is complete. Your changes might be lost if you cancel the
+              pop-up.
             </p>
-            <div className="fmtm-flex fmtm-justify-center fmtm-gap-6 fmtm-pt-5  ">
-              {/* <Button btnText="CANCEL" btnType="secondary"></Button> */}
-              <Button
-                btnText="PROCEED"
-                onClick={() => navigate(`/project_details/${environment.encode(projectDetailsResponse?.id)}`)}
-                btnType="primary"
-              ></Button>
-            </div>
           </div>
         }
         open={toggleStatus}


### PR DESCRIPTION
This PR contains work on popup modal shown after project creation where following tasks were done: 
1. Removed PROCEED button that navigates user to 'project details' page.
2. Replacement of text below progress bar.
![image_720](https://github.com/hotosm/fmtm/assets/81785002/0c89ecd6-a84c-4632-8633-aa1a35fe8b59)
