### PR TITLE
Feat cluster spread

### DIFF
--- a/src/frontend/src/components/MapComponent/OpenLayersComponent/Layers/ClusterLayer.js
+++ b/src/frontend/src/components/MapComponent/OpenLayersComponent/Layers/ClusterLayer.js
@@ -9,6 +9,10 @@ import { Cluster, OSM as OSMSource } from 'ol/source';
 import { Text, Circle, Icon } from 'ol/style';
 import VectorSource from 'ol/source/Vector';
 import { hexToRgba } from '../../../MapComponent/OpenLayersComponent/helpers/styleUtils';
+import SelectCluster from 'ol-ext/interaction/SelectCluster';
+import { asArray as asColorArray } from 'ol/color';
+import CircleStyle from 'ol/style/Circle';
+import MarkerIcon from '../../../../assets/images/red_marker.png';
 
 function setAsyncStyle(style, feature, getIndividualStyle) {
   const styleCache = {};
@@ -161,6 +165,56 @@ const ClusterLayer = ({
   }, [map, vectorLayer, visibleOnMap]);
 
   useEffect(() => () => map && map.removeLayer(vectorLayer), [map, vectorLayer]);
+
+  useEffect(() => {
+    if (!map) return;
+    // Select interaction to spread cluster out and select features
+    const selectCluster = new SelectCluster({
+      selectCluster: false, // disable cluster selection
+      circleMaxObjects: 20,
+      pointRadius: 40,
+      spiral: true,
+      animate: true,
+      autoClose: true,
+      // Feature style when springs apart
+      featureStyle: clusterSingleFeatureStyle,
+    });
+    map.addInteraction(selectCluster);
+
+    function clusterSingleFeatureStyle(clusterMember) {
+      // Call for expandedFeatures pass a resolution instead
+      const isExpandedFeature = clusterMember.get('selectclusterfeature');
+
+      if (isExpandedFeature) {
+        const feature = clusterMember.getProperties().features[0];
+        const featureProperty = feature?.getProperties();
+        console.log(featureProperty, 'featureProperty');
+        console.log(feature, 'isExpandedFeature');
+        const style = new Style({
+          image: new Icon({
+            src: MarkerIcon,
+            scale: 0.06,
+          }),
+          text: new Text({
+            text: featureProperty?.project_id,
+            fill: new Fill({
+              color: 'black',
+            }),
+            offsetY: 25,
+            font: '15px Times New Roman',
+          }),
+        });
+        return style;
+        fillColor = '#96bfff';
+      } else {
+        return;
+      }
+    }
+
+    return () => {
+      map.removeInteraction(selectCluster);
+    };
+  }, [map]);
 
   return null;
 };

--- a/src/frontend/src/components/MapComponent/OpenLayersComponent/Layers/ClusterLayer.js
+++ b/src/frontend/src/components/MapComponent/OpenLayersComponent/Layers/ClusterLayer.js
@@ -10,8 +10,6 @@ import { Text, Circle, Icon } from 'ol/style';
 import VectorSource from 'ol/source/Vector';
 import { hexToRgba } from '../../../MapComponent/OpenLayersComponent/helpers/styleUtils';
 import SelectCluster from 'ol-ext/interaction/SelectCluster';
-import { asArray as asColorArray } from 'ol/color';
-import CircleStyle from 'ol/style/Circle';
 import MarkerIcon from '../../../../assets/images/red_marker.png';
 
 function setAsyncStyle(style, feature, getIndividualStyle) {


### PR DESCRIPTION
- Fix #945 
This PR adds a feature where, when a cluster is clicked it expands to multiple points when the cluster point is clicked on the cluster point at maximum zoom level. Also when 'project id' is clicked user is redirected to the specific project's project_detail page.
![image](https://github.com/hotosm/fmtm/assets/81785002/40a43904-1c26-41c5-be08-22cee171fe2d)
![image](https://github.com/hotosm/fmtm/assets/81785002/952526a3-e0f6-41c5-89f0-420f3be2d653)
