### PR TITLE
fix (createNewProject): state - uploadAreaSelection & dividedTaskGeoj…

### DIFF
--- a/src/frontend/src/store/slices/CreateProjectSlice.ts
+++ b/src/frontend/src/store/slices/CreateProjectSlice.ts
@@ -87,6 +87,9 @@ const CreateProject = createSlice({
       state.generateProjectLog = null;
       state.generateProjectLogLoading = false;
       state.isUnsavedChanges = false;
+      state.uploadAreaSelection = null;
+      state.dividedTaskGeojson = null;
+      state.dividedTaskLoading = false;
     },
     UploadAreaLoading(state, action) {
       state.projectAreaLoading = action.payload;


### PR DESCRIPTION
- Fix #971 

This PR fixes: 
1. Clear `uploadAreaSelection` state on project submission.
2. Clear `dividedTaskGeojson` state on project submission.