### PR TITLE
Remove /images/ endpoint, replaced by s3 logos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@
 
 # Distribution / packaging
 .Python
-src/backend/app/images
 env/
 build/
 develop-eggs/

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -83,7 +83,6 @@ services:
     container_name: fmtm-api-${GIT_BRANCH}
     volumes:
       - fmtm_logs:/opt/logs
-      - fmtm_images:/opt/app/images
       - fmtm_tiles:/opt/tiles
     depends_on:
       fmtm-db:

--- a/docker-compose.main.yml
+++ b/docker-compose.main.yml
@@ -68,7 +68,6 @@ services:
     container_name: fmtm-api-main
     volumes:
       - fmtm_logs:/opt/logs
-      - fmtm_images:/opt/app/images
       - fmtm_tiles:/opt/tiles
     depends_on:
       fmtm-db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,6 @@ services:
     # tty: true
     volumes:
       - fmtm_logs:/opt/logs
-      - fmtm_images:/opt/app/images
       - fmtm_tiles:/opt/tiles
       - ./src/backend/pyproject.toml:/opt/pyproject.toml
       - ./src/backend/app:/opt/app

--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -124,7 +124,6 @@ RUN useradd -u 1001 -m -c "hotosm account" -d /home/appuser -s /bin/false appuse
 # Add volumes for persistence
 VOLUME /opt/logs
 VOLUME /opt/tiles
-VOLUME /opt/app/images
 # Change to non-root user
 USER appuser
 # Add Healthcheck

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -20,7 +20,6 @@
 import logging
 import sys
 from contextlib import asynccontextmanager
-from typing import Optional
 
 import sentry_sdk
 from fastapi import FastAPI, Request
@@ -52,7 +51,7 @@ if not settings.DEBUG:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    """Startup events."""
+    """FastAPI startup/shutdown event."""
     log.debug("Starting up FastAPI server.")
     log.debug("Reading XLSForms from DB.")
     await read_xlsforms(next(get_db()), xlsforms_path)
@@ -208,16 +207,3 @@ async def validation_exception_handler(request: Request, exc: RequestValidationE
 async def home():
     """Redirect home to docs."""
     return RedirectResponse("/docs")
-
-
-@api.get("/items/{item_id}")
-async def read_item(item_id: int, q: Optional[str] = None):
-    """Get item IDs."""
-    return {"item_id": item_id, "q": q}
-
-
-@api.get("/images/{image_filename}")
-async def get_images(image_filename: str):
-    """Download image files."""
-    path = f"./app/images/{image_filename}"
-    return FileResponse(path)

--- a/src/frontend/src/components/home/ExploreProjectCard.tsx
+++ b/src/frontend/src/components/home/ExploreProjectCard.tsx
@@ -73,11 +73,7 @@ export default function ExploreProjectCard({ data }) {
           <div>
             <div className="fmtm-flex fmtm-justify-between">
               {data.organisation_logo ? (
-                <CoreModules.CardMedia
-                  component="img"
-                  src={`${import.meta.env.VITE_API_URL}/images/${data.organisation_logo}`}
-                  sx={{ width: 50, height: 50 }}
-                />
+                <CoreModules.CardMedia component="img" src={data.organisation_logo} sx={{ width: 50, height: 50 }} />
               ) : (
                 <CustomizedImage status={'card'} style={{ width: 50, height: 50 }} />
               )}

--- a/src/frontend/src/views/Organization.tsx
+++ b/src/frontend/src/views/Organization.tsx
@@ -114,11 +114,7 @@ const Organization = () => {
           <CoreModules.Card key={index} sx={cardStyle}>
             <CoreModules.CardMedia
               component="img"
-              src={
-                data.logo
-                  ? `${import.meta.env.VITE_API_URL}/images/${data.logo}`
-                  : 'http://localhost:7051/d907cf67fe587072a592.png'
-              }
+              src={data.logo ? data.logo : 'http://localhost:7051/d907cf67fe587072a592.png'}
               sx={{ width: '150px' }}
             />
             <CoreModules.Box sx={{ display: 'flex', flexDirection: 'column', gap: 1 }}>


### PR DESCRIPTION
The /images/ endpoint is no longer required.
The org logos are stored in S3 thanks to @nrjadkry.
I removed the endpoint & updated the frontend to load the returned org urls from S3.

Note: currently the dev/staging server logos don't display. This PR will fix it.