### PR TITLE
fix (createNewProject): splitTasks - validation for submit button dis…

### DIFF
--- a/src/frontend/src/api/CreateProjectService.ts
+++ b/src/frontend/src/api/CreateProjectService.ts
@@ -280,6 +280,8 @@ const GetDividedTaskFromGeojson: Function = (url: string, payload: any) => {
         dividedTaskFormData.append('dimension', payload.dimension);
         const getGetDividedTaskFromGeojsonResponse = await axios.post(url, dividedTaskFormData);
         const resp: OrganisationListModel = getGetDividedTaskFromGeojsonResponse.data;
+        dispatch(CreateProjectActions.SetIsTasksGenerated({ key: 'divide_on_square', value: true }));
+        dispatch(CreateProjectActions.SetIsTasksGenerated({ key: 'task_splitting_algorithm', value: false }));
         dispatch(CreateProjectActions.SetDividedTaskGeojson(resp));
         dispatch(CreateProjectActions.SetDividedTaskFromGeojsonLoading(false));
       } catch (error) {
@@ -346,6 +348,8 @@ const TaskSplittingPreviewService: Function = (
           // TODO display error to user, perhaps there is not osm data here?
           return;
         }
+        dispatch(CreateProjectActions.SetIsTasksGenerated({ key: 'divide_on_square', value: false }));
+        dispatch(CreateProjectActions.SetIsTasksGenerated({ key: 'task_splitting_algorithm', value: true }));
         dispatch(CreateProjectActions.GetTaskSplittingPreview(resp));
       } catch (error) {
         dispatch(CreateProjectActions.GetTaskSplittingPreviewLoading(false));

--- a/src/frontend/src/components/createnewproject/SplitTasks.tsx
+++ b/src/frontend/src/components/createnewproject/SplitTasks.tsx
@@ -39,6 +39,7 @@ const SplitTasks = ({ flag, geojsonFile, setGeojsonFile, customLineUpload, custo
   const navigate = useNavigate();
 
   const [toggleStatus, setToggleStatus] = useState(false);
+  const [taskGenerationStatus, setTaskGenerationStatus] = useState(false);
 
   const divRef = useRef(null);
   const splitTasksSelection = CoreModules.useAppSelector((state) => state.createproject.splitTasksSelection);
@@ -60,11 +61,29 @@ const SplitTasks = ({ flag, geojsonFile, setGeojsonFile, customLineUpload, custo
   const taskSplittingGeojsonLoading = CoreModules.useAppSelector(
     (state) => state.createproject.taskSplittingGeojsonLoading,
   );
+  const isTasksGenerated = CoreModules.useAppSelector((state) => state.createproject.isTasksGenerated);
 
   const toggleStep = (step, url) => {
     dispatch(CommonActions.SetCurrentStepFormStep({ flag: flag, step: step }));
     navigate(url);
   };
+
+  const checkTasksGeneration = () => {
+    if (!isTasksGenerated.divide_on_square && splitTasksSelection === task_split_type['divide_on_square']) {
+      setTaskGenerationStatus(false);
+    } else if (
+      !isTasksGenerated.task_splitting_algorithm &&
+      splitTasksSelection === task_split_type['task_splitting_algorithm']
+    ) {
+      setTaskGenerationStatus(false);
+    } else {
+      setTaskGenerationStatus(true);
+    }
+  };
+
+  useEffect(() => {
+    checkTasksGeneration();
+  }, [splitTasksSelection, isTasksGenerated]);
 
   const submission = () => {
     dispatch(CreateProjectActions.SetIsUnsavedChanges(false));
@@ -300,6 +319,12 @@ const SplitTasks = ({ flag, geojsonFile, setGeojsonFile, customLineUpload, custo
                     onChangeData={(value) => {
                       handleCustomChange('task_split_type', parseInt(value));
                       dispatch(CreateProjectActions.SetSplitTasksSelection(parseInt(value)));
+                      if (task_split_type['choose_area_as_task'] === parseInt(value)) {
+                        dispatch(CreateProjectActions.SetIsTasksGenerated({ key: 'divide_on_square', value: false }));
+                        dispatch(
+                          CreateProjectActions.SetIsTasksGenerated({ key: 'task_splitting_algorithm', value: false }),
+                        );
+                      }
                     }}
                     errorMsg={errors.task_split_type}
                   />
@@ -382,6 +407,7 @@ const SplitTasks = ({ flag, geojsonFile, setGeojsonFile, customLineUpload, custo
                     btnType="primary"
                     type="submit"
                     className="fmtm-font-bold"
+                    disabled={taskGenerationStatus ? false : true}
                   />
                 </div>
               </div>

--- a/src/frontend/src/store/slices/CreateProjectSlice.ts
+++ b/src/frontend/src/store/slices/CreateProjectSlice.ts
@@ -48,6 +48,7 @@ export const initialState: CreateProjectStateTypes = {
   createProjectValidations: {},
   isUnsavedChanges: false,
   canSwitchCreateProjectSteps: false,
+  isTasksGenerated: { divide_on_square: false, task_splitting_algorithm: false },
 };
 
 const CreateProject = createSlice({
@@ -212,6 +213,12 @@ const CreateProject = createSlice({
     },
     SetCanSwitchCreateProjectSteps(state, action) {
       state.canSwitchCreateProjectSteps = action.payload;
+    },
+    SetIsTasksGenerated(state, action) {
+      state.isTasksGenerated = {
+        ...state.isTasksGenerated,
+        [action.payload.key]: action.payload.value,
+      };
     },
   },
 });

--- a/src/frontend/src/store/types/ICreateProject.ts
+++ b/src/frontend/src/store/types/ICreateProject.ts
@@ -34,6 +34,7 @@ export type CreateProjectStateTypes = {
   createProjectValidations: {};
   isUnsavedChanges: boolean;
   canSwitchCreateProjectSteps: boolean;
+  isTasksGenerated: {};
 };
 export type ValidateCustomFormResponse = {
   detail: { message: string; possible_reason: string };


### PR DESCRIPTION
- Fix #1014 
This PR adds validation on split tasks, where the submit button is disabled if `Click to generate task` is not clicked if splitTasksSubmission is `divide_on_square` or `task_splitting_algorithm`.

![image_720](https://github.com/hotosm/fmtm/assets/81785002/51fb3836-c74f-4220-b2e6-0bd27961f94b)
![image_720](https://github.com/hotosm/fmtm/assets/81785002/8c45df9b-f018-4530-92db-30af162708fd)
