### PR TITLE
Retriving model attribute directly.

### DIFF
--- a/src/backend/app/tasks/tasks_schemas.py
+++ b/src/backend/app/tasks/tasks_schemas.py
@@ -103,7 +103,7 @@ class TaskBase(BaseModel):
     def get_lock_uid(cls, v: int, info: ValidationInfo) -> str:
         """Get lock uid from lock_holder details."""
         if lock_holder := info.data.get("lock_holder"):
-            return lock_holder.get("id")
+            return lock_holder.id
         return None
 
     @field_validator("locked_by_username", mode="before")
@@ -111,7 +111,7 @@ class TaskBase(BaseModel):
     def get_lock_username(cls, v: str, info: ValidationInfo) -> str:
         """Get lock username from lock_holder details."""
         if lock_holder := info.data.get("lock_holder"):
-            return lock_holder.get("username")
+            return lock_holder.username
         return None
 
 


### PR DESCRIPTION
The previous code was using the get method to retrieve the attribute from model_obj, which resulted in an error. To address this issue, I replaced it with the more direct and appropriate attribute access using `model_obj.id.` like this