### PR TITLE
Fix generate building task

### DIFF
--- a/src/frontend/src/components/common/Button.tsx
+++ b/src/frontend/src/components/common/Button.tsx
@@ -24,7 +24,7 @@ const btnStyle = (btnType, className) => {
     case 'other':
       return `fmtm-py-1 fmtm-px-5 fmtm-bg-red-500 fmtm-text-white fmtm-rounded-lg hover:fmtm-bg-red-600`;
     case 'disabled':
-      return `fmtm-py-1 fmtm-px-5 fmtm-text-white fmtm-rounded-lg fmtm-bg-gray-400 fmtm-cursor-not-allowed`;
+      return `fmtm-py-1 fmtm-px-4 fmtm-text-white fmtm-rounded-lg fmtm-bg-gray-400 fmtm-cursor-not-allowed`;
 
     default:
       return 'fmtm-primary';

--- a/src/frontend/src/components/createnewproject/SplitTasks.tsx
+++ b/src/frontend/src/components/createnewproject/SplitTasks.tsx
@@ -374,6 +374,7 @@ const SplitTasks = ({ flag, geojsonFile, setGeojsonFile, customLineUpload, custo
                           onClick={generateTaskBasedOnSelection}
                           className=""
                           icon={<AssetModules.SettingsIcon className="fmtm-text-white" />}
+                          disabled={formValues?.average_buildings_per_task ? false : true}
                         />
                         {/* <Button
                         btnText="Stop generating"


### PR DESCRIPTION
- Fix #1027 
This PR disables generate buildings per task button until number of buildings is entered
![image](https://github.com/hotosm/fmtm/assets/81785002/d85cdac0-1307-47ad-a13c-28fd4f34dd7a)
![image](https://github.com/hotosm/fmtm/assets/81785002/aaf9ceae-d030-4a9c-b283-bb08d9241f89)
