### PR TITLE
Returned task status as string

### DIFF
--- a/src/backend/app/tasks/tasks_schemas.py
+++ b/src/backend/app/tasks/tasks_schemas.py
@@ -76,7 +76,9 @@ class TaskBase(BaseModel):
             try:
                 return TaskStatus(value).name
             except ValueError as e:
-                raise ValueError(f"Invalid integer value for task_status: {value}") from e
+                raise ValueError(
+                    f"Invalid integer value for task_status: {value}"
+                ) from e
         return value
 
     @field_validator("outline_geojson", mode="before")

--- a/src/backend/app/tasks/tasks_schemas.py
+++ b/src/backend/app/tasks/tasks_schemas.py
@@ -24,7 +24,7 @@ from typing import Any, List, Optional
 
 from geojson_pydantic import Feature
 from loguru import logger as log
-from pydantic import BaseModel, ConfigDict, Field, ValidationInfo
+from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, validator
 from pydantic.functional_validators import field_validator
 
 from app.db.postgis_utils import geometry_to_geojson, get_centroid
@@ -69,6 +69,15 @@ class TaskBase(BaseModel):
     locked_by_uid: Optional[int] = None
     locked_by_username: Optional[str] = None
     task_history: Optional[List[TaskHistoryBase]] = None
+
+    @validator("task_status", pre=False, always=True)
+    def get_enum_name(cls, value, values):
+        if isinstance(value, int):
+            try:
+                return TaskStatus(value).name
+            except ValueError as e:
+                raise ValueError(f"Invalid integer value for task_status: {value}") from e
+        return value
 
     @field_validator("outline_geojson", mode="before")
     @classmethod


### PR DESCRIPTION
Previously, int value was retruned in the response which created conflicts in the old projects. With these changes , it accepts integer value of enum and saves it in db. But while returning it passes "name" of the corresponding "value" resolving probable conflicts.