### PR TITLE
Remove database backups from development setup

### DIFF
--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -162,11 +162,12 @@ services:
       MINIO_ROOT_PASSWORD: ${S3_SECRET_KEY}
       MINIO_VOLUMES: "/mnt/data"
       MINIO_BROWSER: "off"
+      # MINIO_CONSOLE_ADDRESS: ":9090"
     volumes:
       - fmtm_data:/mnt/data
     networks:
       - fmtm-net
-    command: minio server # --console-address ":9090"
+    command: minio server
     restart: "unless-stopped"
     healthcheck:
       test: curl --fail http://localhost:9000/minio/health/live || exit 1

--- a/docker-compose.development.yml
+++ b/docker-compose.development.yml
@@ -232,29 +232,6 @@ services:
     entrypoint: ["/migrate-entrypoint.sh"]
     restart: "on-failure:3"
 
-  backups:
-    image: "ghcr.io/hotosm/fmtm/backend:${GIT_BRANCH}"
-    container_name: fmtm-backups-${GIT_BRANCH}
-    depends_on:
-      fmtm-db:
-        condition: service_healthy
-      central-db:
-        condition: service_healthy
-      s3:
-        condition: service_healthy
-    env_file:
-      - .env
-    networks:
-      - fmtm-net
-    entrypoint: ["/backup-entrypoint.sh"]
-    restart: "on-failure:3"
-    healthcheck:
-      test: pg_isready -U ${FMTM_DB_USER} -d ${FMTM_DB_NAME}
-      start_period: 5s
-      interval: 10s
-      timeout: 5s
-      retries: 3
-
   certbot:
     image: "ghcr.io/hotosm/fmtm/proxy:certs-init-development"
     container_name: fmtm-cert-renew-${GIT_BRANCH}

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -82,9 +82,27 @@ services:
       file: docker-compose.development.yml
       service: migrations
   backups:
-    extends:
-      file: docker-compose.development.yml
-      service: backups
+    image: "ghcr.io/hotosm/fmtm/backend:${GIT_BRANCH}"
+    container_name: fmtm-backups-${GIT_BRANCH}
+    depends_on:
+      fmtm-db:
+        condition: service_healthy
+      central-db:
+        condition: service_healthy
+      s3:
+        condition: service_healthy
+    env_file:
+      - .env
+    networks:
+      - fmtm-net
+    entrypoint: ["/backup-entrypoint.sh"]
+    restart: "on-failure:3"
+    healthcheck:
+      test: pg_isready -U ${FMTM_DB_USER} -d ${FMTM_DB_NAME}
+      start_period: 5s
+      interval: 10s
+      timeout: 5s
+      retries: 3
   certbot:
     extends:
       file: docker-compose.development.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -184,13 +184,15 @@ services:
       MINIO_ROOT_PASSWORD: ${S3_SECRET_KEY:-somelongpassword}
       MINIO_VOLUMES: "/mnt/data"
       MINIO_BROWSER: "off"
+      # MINIO_CONSOLE_ADDRESS: ":9090"
     volumes:
       - fmtm_data:/mnt/data
     # ports:
     #   - 9000:9000
+    #   - 9090:9090
     networks:
       - fmtm-net
-    command: minio server # --console-address ":9090"
+    command: minio server
     restart: "unless-stopped"
     healthcheck:
       test: curl --fail http://localhost:9000/minio/health/live || exit 1


### PR DESCRIPTION
Fixes #1038

- During development release cadence is fast & database backups are not required on each redeploy.
- Moved the backup container to only run in the staging config.