### PR TITLE
Add mamoto tracking to frontend

### DIFF
--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -2,16 +2,22 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="favicon.ico" />
     <link rel="manifest" href="/manifest.json" />
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
+    <!-- Matomo Tracking -->
+    <script type="application/javascript">
+      var site_id = '28';
+    </script>
+    <script type="application/javascript" src="https://cdn.hotosm.org/tracking-v3.js"></script>
     <title>Field Mapping Tasking Manager</title>
   </head>
 
   <body>
     <div id="app"></div>
     <script type="module" src="/src/App.jsx"></script>
+    // Matomo Tracking
+    <div id="optout-form"></div>
   </body>
 </html>

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -7,9 +7,6 @@
     <link rel="manifest" href="/manifest.json" />
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
     <!-- Matomo Tracking -->
-    <script type="application/javascript">
-      var site_id = '28';
-    </script>
     <script type="application/javascript" src="https://cdn.hotosm.org/tracking-v3.js"></script>
     <title>Field Mapping Tasking Manager</title>
   </head>

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -6,13 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" href="favicon.ico" />
     <link rel="manifest" href="/manifest.json" />
-    <link
-      rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/openlayers/7.4.0/ol.min.css"
-      integrity="sha512-InhY7dfdkf2+ZyIsz9AX9M1xDC3GjEy0zVnAIudX1fTUOEhBu13KooX9txjBoWkDAMI3fQ07VE/D0gMUvweerw=="
-      crossorigin="anonymous"
-      referrerpolicy="no-referrer"
-    />
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
     <title>Field Mapping Tasking Manager</title>
   </head>

--- a/src/frontend/index.html
+++ b/src/frontend/index.html
@@ -6,15 +6,11 @@
     <link rel="icon" href="favicon.ico" />
     <link rel="manifest" href="/manifest.json" />
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
-    <!-- Matomo Tracking -->
-    <script type="application/javascript" src="https://cdn.hotosm.org/tracking-v3.js"></script>
     <title>Field Mapping Tasking Manager</title>
   </head>
 
   <body>
     <div id="app"></div>
     <script type="module" src="/src/App.jsx"></script>
-    // Matomo Tracking
-    <div id="optout-form"></div>
   </body>
 </html>

--- a/src/frontend/src/App.jsx
+++ b/src/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import { Provider } from 'react-redux';
 import routes from './routes';
 import { PersistGate } from 'redux-persist/integration/react';
 import './index.css';
+import 'ol/ol.css';
 import 'react-loading-skeleton/dist/skeleton.css';
 import * as Sentry from '@sentry/react';
 import environment from './environment';

--- a/src/frontend/src/App.jsx
+++ b/src/frontend/src/App.jsx
@@ -64,7 +64,7 @@ const SentryInit = () => {
 // Matomo Tracking Component
 const MatomoTrackingInit = () => {
   useEffect(() => {
-    if (import.meta.env.MODE !== 'development' && import.meta.env.BASE_URL === 'fmtm.hotosm.org') {
+    if (import.meta.env.MODE === 'development' || import.meta.env.BASE_URL !== 'fmtm.hotosm.org') {
       return;
     }
     // Set matomo tracking id

--- a/src/frontend/src/environment.ts
+++ b/src/frontend/src/environment.ts
@@ -8,6 +8,7 @@ export default {
     const desimaal = (dec >>> 0).toString(2);
     return window.btoa(desimaal);
   },
+  mamotoTrackingId: 28,
   tasksStatus: [
     {
       label: 'READY',

--- a/src/frontend/src/views/NewProjectDetails.jsx
+++ b/src/frontend/src/views/NewProjectDetails.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useState } from 'react';
-import '../../node_modules/ol/ol.css';
 import '../styles/home.scss';
 import WindowDimension from '../hooks/WindowDimension';
 import MapDescriptionComponents from '../components/MapDescriptionComponents';

--- a/src/frontend/src/views/ProjectDetails.jsx
+++ b/src/frontend/src/views/ProjectDetails.jsx
@@ -1,5 +1,4 @@
 import React, { useEffect, useRef, useState } from 'react';
-import '../../node_modules/ol/ol.css';
 import '../styles/home.scss';
 import WindowDimension from '../hooks/WindowDimension';
 import MapDescriptionComponents from '../components/MapDescriptionComponents';

--- a/src/frontend/src/views/Submissions.tsx
+++ b/src/frontend/src/views/Submissions.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect } from 'react';
 // import '../styles/home.css'
-import '../../node_modules/ol/ol.css';
 import CoreModules from '../shared/CoreModules';
 // import { useLocation, useNavigate } from 'react-router-dom';
 import Avatar from '../assets/images/avatar.png';

--- a/src/frontend/src/views/Tasks.tsx
+++ b/src/frontend/src/views/Tasks.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 // import '../styles/home.css'
-import '../../node_modules/ol/ol.css';
 import CoreModules from '../shared/CoreModules';
 import AssetModules from '../shared/AssetModules';
 // import { useLocation, useNavigate } from 'react-router-dom';


### PR DESCRIPTION
Fixes #942

For website analytics.

This only activates on the prod setup (fmtm.hotosm.org).
The approach I settled on:

```js
const MatomoTrackingInit = () => {
  useEffect(() => {
    if (import.meta.env.MODE !== 'development' && import.meta.env.BASE_URL === 'fmtm.hotosm.org') {
      return;
    }
    // Set matomo tracking id
    window.site_id = environment.mamotoTrackingId;
​
    // Create optout-form div for banner
    const optoutDiv = document.createElement('div');
    optoutDiv.id = 'optout-form'; // Set an ID if needed
    document.body.appendChild(optoutDiv);
​
    // Load CDN script after
    const script = document.createElement('script');
    script.src = 'https://cdn.hotosm.org/tracking-v3.js';
    document.body.appendChild(script);
    // Manually trigger DOMContentLoaded, that script hooks
    // https://github.com/hotosm/matomo-tracking/blob/9b95230cb5f0bf2a902f00379152f3af9204c641/tracking-v3.js#L125
    script.onload = () => {
      optoutDiv.dispatchEvent(
        new Event('DOMContentLoaded', {
          bubbles: true,
          cancelable: true,
        }),
      );
    };
​
    // Cleanup on unmount
    return () => {
      document.body.removeChild(optoutDiv);
      document.body.removeChild(script);
    };
  }, []);
​
  return null; // Renders nothing
};
​
// The main App render
ReactDOM.render(
  <Provider store={store}>
    <PersistGate loading={null} persistor={persistor}>
      <RouterProvider router={routes} />
      <MatomoTrackingInit />
      <SentryInit />
    </PersistGate>
  </Provider>,
  document.getElementById('app'),
);
```