### PR TITLE
delete projects api made authenticated

### DIFF
--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -44,6 +44,7 @@ from osm_rawdata.postgres import PostgresClient
 from shapely.geometry import mapping, shape
 from shapely.ops import unary_union
 from sqlalchemy.orm import Session
+from app.auth.osm import AuthUser, login_required
 
 from ..central import central_crud
 from ..db import database, db_models
@@ -205,7 +206,10 @@ async def read_project(project_id: int, db: Session = Depends(database.get_db)):
 
 
 @router.delete("/delete/{project_id}")
-async def delete_project(project_id: int, db: Session = Depends(database.get_db)):
+async def delete_project(project_id: int,
+                         db: Session = Depends(database.get_db),
+                         user_data: AuthUser = Depends(login_required)
+                         ):
     """Delete a project from ODK Central and the local database."""
     # FIXME: should check for error
 

--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -44,6 +44,7 @@ from osm_rawdata.postgres import PostgresClient
 from shapely.geometry import mapping, shape
 from shapely.ops import unary_union
 from sqlalchemy.orm import Session
+
 from app.auth.osm import AuthUser, login_required
 
 from ..central import central_crud
@@ -206,10 +207,11 @@ async def read_project(project_id: int, db: Session = Depends(database.get_db)):
 
 
 @router.delete("/delete/{project_id}")
-async def delete_project(project_id: int,
-                         db: Session = Depends(database.get_db),
-                         user_data: AuthUser = Depends(login_required)
-                         ):
+async def delete_project(
+    project_id: int,
+    db: Session = Depends(database.get_db),
+    user_data: AuthUser = Depends(login_required),
+):
     """Delete a project from ODK Central and the local database."""
     # FIXME: should check for error
 


### PR DESCRIPTION
Delete project API is public as of now. I have made this endpoint authenticated. 
Now, we need to pass the access-token as well. This adds a small level of security to this endpoint.
 
## Todo
We will have to check the user roles and make this endpoint  accessible only by the admin user.