### PR TITLE
Use flatgeobuf data extracts

### DIFF
--- a/src/backend/app/db/postgis_utils.py
+++ b/src/backend/app/db/postgis_utils.py
@@ -66,7 +66,7 @@ def get_centroid(geometry: Geometry, properties: str = {}, id: int = None):
     return {}
 
 
-def geojson_to_flatgeobuf(db: Session, geojson: FeatureCollection) -> bytes:
+async def geojson_to_flatgeobuf(db: Session, geojson: FeatureCollection) -> bytes:
     """From a given FeatureCollection, return a memory flatgeobuf obj.
 
     Args:
@@ -101,7 +101,13 @@ def geojson_to_flatgeobuf(db: Session, geojson: FeatureCollection) -> bytes:
     # Run the SQL
     result = db.execute(text(sql))
     # Get a memoryview object, then extract to Bytes
-    flatgeobuf = result.fetchone()[0].tobytes()
+    flatgeobuf = result.fetchone()[0]
+
     # Cleanup table
     db.execute(text("DROP TABLE IF EXISTS public.temp_features CASCADE;"))
-    return flatgeobuf
+
+    if flatgeobuf:
+        return flatgeobuf.tobytes()
+
+    # Nothing returned (either no features passed, or failed)
+    return None

--- a/src/backend/app/db/postgis_utils.py
+++ b/src/backend/app/db/postgis_utils.py
@@ -66,8 +66,16 @@ def get_centroid(geometry: Geometry, properties: str = {}, id: int = None):
     return {}
 
 
-def geojson_to_flatgeobuf(db: Session, geojson: FeatureCollection):
-    """From a given FeatureCollection, return a memory flatgeobuf obj."""
+def geojson_to_flatgeobuf(db: Session, geojson: FeatureCollection) -> bytes:
+    """From a given FeatureCollection, return a memory flatgeobuf obj.
+
+    Args:
+        db (Session): SQLAlchemy db session.
+        geojson (FeatureCollection): a geojson.FeatureCollection object.
+
+    Returns:
+        flatgeobuf (bytes): a Python bytes representation of a flatgeobuf file.
+    """
     sql = f"""
         DROP TABLE IF EXISTS public.temp_features CASCADE;
 

--- a/src/backend/app/organization/organization_crud.py
+++ b/src/backend/app/organization/organization_crud.py
@@ -127,7 +127,8 @@ async def create_organization(
         db.refresh(db_organization)
 
         # Update the logo field in the database with the correct path
-        db_organization.logo = await upload_logo_to_s3(db_organization, logo)
+        if logo:
+            db_organization.logo = await upload_logo_to_s3(db_organization, logo)
         db.commit()
 
     except Exception as e:

--- a/src/backend/app/projects/project_crud.py
+++ b/src/backend/app/projects/project_crud.py
@@ -1092,7 +1092,6 @@ async def upload_custom_data_extract(
     ]
     featcol_filtered = FeatureCollection(features_filtered)
 
-    log.warning(featcol_filtered)
     log.debug(
         "Generating fgb object from geojson with "
         f"{len(featcol_filtered.get('features', []))} features"

--- a/src/backend/app/projects/project_crud.py
+++ b/src/backend/app/projects/project_crud.py
@@ -630,7 +630,7 @@ async def get_data_extract_url(
             shape(feature.get("geometry")) for feature in aoi.get("features", [])
         ]
         merged_geom = unary_union(geometries)
-    elif geom_type == "Feature":
+    elif geom_type := aoi.get("type") == "Feature":
         merged_geom = shape(aoi.get("geometry"))
     else:
         merged_geom = shape(aoi)

--- a/src/backend/app/projects/project_crud.py
+++ b/src/backend/app/projects/project_crud.py
@@ -2328,7 +2328,7 @@ def check_crs(input_geojson: Union[dict, FeatureCollection]):
         coordinates = (
             features[-1].get("geometry", {}).get("coordinates", []) if features else []
         )
-    elif input_geojson_type == "Feature":
+    elif input_geojson_type := input_geojson.get("type") == "Feature":
         coordinates = input_geojson.get("geometry", {}).get("coordinates", [])
 
     geometry_type = (

--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -37,11 +37,8 @@ from fastapi import (
 )
 from fastapi.responses import FileResponse, JSONResponse
 from loguru import logger as log
-from osm_fieldwork.data_models import data_models_path
 from osm_fieldwork.make_data_extract import getChoices
 from osm_fieldwork.xlsforms import xlsforms_path
-from osm_rawdata.postgres import PostgresClient
-
 from sqlalchemy.orm import Session
 
 from app.auth.osm import AuthUser, login_required
@@ -805,9 +802,8 @@ async def get_data_extract(
     project_id: int = Query(None, description="Project ID"),
     db: Session = Depends(database.get_db),
 ):
-    """
-    Get the data extract for a given project AOI.
-    
+    """Get the data extract for a given project AOI.
+
     Use for both generating a new data extract and for getting
     and existing extract.
     """
@@ -819,7 +815,7 @@ async def get_data_extract(
         project_id,
     )
     return JSONResponse(status_code=200, content={"url": fgb_url})
-    
+
 
 @router.post("/upload_custom_extract/")
 async def upload_custom_extract(

--- a/src/backend/app/projects/project_schemas.py
+++ b/src/backend/app/projects/project_schemas.py
@@ -58,6 +58,7 @@ class ProjectUpload(BaseModel):
     task_split_type: Optional[TaskSplitType] = None
     task_split_dimension: Optional[int] = None
     task_num_buildings: Optional[int] = None
+    data_extract_type: Optional[str] = None
 
     # city: str
     # country: str

--- a/src/backend/pdm.lock
+++ b/src/backend/pdm.lock
@@ -6,7 +6,82 @@ groups = ["default", "debug", "dev", "docs", "test"]
 cross_platform = true
 static_urls = false
 lock_version = "4.3"
-content_hash = "sha256:e038b9453bf68f42caf71d86d0c3c5c6ca8756964eb70a22249c4acfc628a332"
+content_hash = "sha256:9556561c676e33e67720017892e8e0516fa484a976288ce3050d4da30fefe1ec"
+
+[[package]]
+name = "aiohttp"
+version = "3.9.1"
+requires_python = ">=3.8"
+summary = "Async http client/server framework (asyncio)"
+dependencies = [
+    "aiosignal>=1.1.2",
+    "async-timeout<5.0,>=4.0; python_version < \"3.11\"",
+    "attrs>=17.3.0",
+    "frozenlist>=1.1.1",
+    "multidict<7.0,>=4.5",
+    "yarl<2.0,>=1.0",
+]
+files = [
+    {file = "aiohttp-3.9.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:e1f80197f8b0b846a8d5cf7b7ec6084493950d0882cc5537fb7b96a69e3c8590"},
+    {file = "aiohttp-3.9.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c72444d17777865734aa1a4d167794c34b63e5883abb90356a0364a28904e6c0"},
+    {file = "aiohttp-3.9.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9b05d5cbe9dafcdc733262c3a99ccf63d2f7ce02543620d2bd8db4d4f7a22f83"},
+    {file = "aiohttp-3.9.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5c4fa235d534b3547184831c624c0b7c1e262cd1de847d95085ec94c16fddcd5"},
+    {file = "aiohttp-3.9.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:289ba9ae8e88d0ba16062ecf02dd730b34186ea3b1e7489046fc338bdc3361c4"},
+    {file = "aiohttp-3.9.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bff7e2811814fa2271be95ab6e84c9436d027a0e59665de60edf44e529a42c1f"},
+    {file = "aiohttp-3.9.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:81b77f868814346662c96ab36b875d7814ebf82340d3284a31681085c051320f"},
+    {file = "aiohttp-3.9.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3b9c7426923bb7bd66d409da46c41e3fb40f5caf679da624439b9eba92043fa6"},
+    {file = "aiohttp-3.9.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:8d44e7bf06b0c0a70a20f9100af9fcfd7f6d9d3913e37754c12d424179b4e48f"},
+    {file = "aiohttp-3.9.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:22698f01ff5653fe66d16ffb7658f582a0ac084d7da1323e39fd9eab326a1f26"},
+    {file = "aiohttp-3.9.1-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:ca7ca5abfbfe8d39e653870fbe8d7710be7a857f8a8386fc9de1aae2e02ce7e4"},
+    {file = "aiohttp-3.9.1-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:8d7f98fde213f74561be1d6d3fa353656197f75d4edfbb3d94c9eb9b0fc47f5d"},
+    {file = "aiohttp-3.9.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:5216b6082c624b55cfe79af5d538e499cd5f5b976820eac31951fb4325974501"},
+    {file = "aiohttp-3.9.1-cp310-cp310-win32.whl", hash = "sha256:0e7ba7ff228c0d9a2cd66194e90f2bca6e0abca810b786901a569c0de082f489"},
+    {file = "aiohttp-3.9.1-cp310-cp310-win_amd64.whl", hash = "sha256:c7e939f1ae428a86e4abbb9a7c4732bf4706048818dfd979e5e2839ce0159f23"},
+    {file = "aiohttp-3.9.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:df9cf74b9bc03d586fc53ba470828d7b77ce51b0582d1d0b5b2fb673c0baa32d"},
+    {file = "aiohttp-3.9.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ecca113f19d5e74048c001934045a2b9368d77b0b17691d905af18bd1c21275e"},
+    {file = "aiohttp-3.9.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8cef8710fb849d97c533f259103f09bac167a008d7131d7b2b0e3a33269185c0"},
+    {file = "aiohttp-3.9.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bea94403a21eb94c93386d559bce297381609153e418a3ffc7d6bf772f59cc35"},
+    {file = "aiohttp-3.9.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:91c742ca59045dce7ba76cab6e223e41d2c70d79e82c284a96411f8645e2afff"},
+    {file = "aiohttp-3.9.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6c93b7c2e52061f0925c3382d5cb8980e40f91c989563d3d32ca280069fd6a87"},
+    {file = "aiohttp-3.9.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ee2527134f95e106cc1653e9ac78846f3a2ec1004cf20ef4e02038035a74544d"},
+    {file = "aiohttp-3.9.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:11ff168d752cb41e8492817e10fb4f85828f6a0142b9726a30c27c35a1835f01"},
+    {file = "aiohttp-3.9.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:b8c3a67eb87394386847d188996920f33b01b32155f0a94f36ca0e0c635bf3e3"},
+    {file = "aiohttp-3.9.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:c7b5d5d64e2a14e35a9240b33b89389e0035e6de8dbb7ffa50d10d8b65c57449"},
+    {file = "aiohttp-3.9.1-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:69985d50a2b6f709412d944ffb2e97d0be154ea90600b7a921f95a87d6f108a2"},
+    {file = "aiohttp-3.9.1-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:c9110c06eaaac7e1f5562caf481f18ccf8f6fdf4c3323feab28a93d34cc646bd"},
+    {file = "aiohttp-3.9.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d737e69d193dac7296365a6dcb73bbbf53bb760ab25a3727716bbd42022e8d7a"},
+    {file = "aiohttp-3.9.1-cp311-cp311-win32.whl", hash = "sha256:4ee8caa925aebc1e64e98432d78ea8de67b2272252b0a931d2ac3bd876ad5544"},
+    {file = "aiohttp-3.9.1-cp311-cp311-win_amd64.whl", hash = "sha256:a34086c5cc285be878622e0a6ab897a986a6e8bf5b67ecb377015f06ed316587"},
+    {file = "aiohttp-3.9.1-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:f800164276eec54e0af5c99feb9494c295118fc10a11b997bbb1348ba1a52065"},
+    {file = "aiohttp-3.9.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:500f1c59906cd142d452074f3811614be04819a38ae2b3239a48b82649c08821"},
+    {file = "aiohttp-3.9.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0b0a6a36ed7e164c6df1e18ee47afbd1990ce47cb428739d6c99aaabfaf1b3af"},
+    {file = "aiohttp-3.9.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69da0f3ed3496808e8cbc5123a866c41c12c15baaaead96d256477edf168eb57"},
+    {file = "aiohttp-3.9.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:176df045597e674fa950bf5ae536be85699e04cea68fa3a616cf75e413737eb5"},
+    {file = "aiohttp-3.9.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b796b44111f0cab6bbf66214186e44734b5baab949cb5fb56154142a92989aeb"},
+    {file = "aiohttp-3.9.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f27fdaadce22f2ef950fc10dcdf8048407c3b42b73779e48a4e76b3c35bca26c"},
+    {file = "aiohttp-3.9.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bcb6532b9814ea7c5a6a3299747c49de30e84472fa72821b07f5a9818bce0f66"},
+    {file = "aiohttp-3.9.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:54631fb69a6e44b2ba522f7c22a6fb2667a02fd97d636048478db2fd8c4e98fe"},
+    {file = "aiohttp-3.9.1-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:4b4c452d0190c5a820d3f5c0f3cd8a28ace48c54053e24da9d6041bf81113183"},
+    {file = "aiohttp-3.9.1-cp312-cp312-musllinux_1_1_ppc64le.whl", hash = "sha256:cae4c0c2ca800c793cae07ef3d40794625471040a87e1ba392039639ad61ab5b"},
+    {file = "aiohttp-3.9.1-cp312-cp312-musllinux_1_1_s390x.whl", hash = "sha256:565760d6812b8d78d416c3c7cfdf5362fbe0d0d25b82fed75d0d29e18d7fc30f"},
+    {file = "aiohttp-3.9.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:54311eb54f3a0c45efb9ed0d0a8f43d1bc6060d773f6973efd90037a51cd0a3f"},
+    {file = "aiohttp-3.9.1-cp312-cp312-win32.whl", hash = "sha256:85c3e3c9cb1d480e0b9a64c658cd66b3cfb8e721636ab8b0e746e2d79a7a9eed"},
+    {file = "aiohttp-3.9.1-cp312-cp312-win_amd64.whl", hash = "sha256:11cb254e397a82efb1805d12561e80124928e04e9c4483587ce7390b3866d213"},
+    {file = "aiohttp-3.9.1.tar.gz", hash = "sha256:8fc49a87ac269d4529da45871e2ffb6874e87779c3d0e2ccd813c0899221239d"},
+]
+
+[[package]]
+name = "aiosignal"
+version = "1.3.1"
+requires_python = ">=3.7"
+summary = "aiosignal: a list of registered asynchronous callbacks"
+dependencies = [
+    "frozenlist>=1.1.0",
+]
+files = [
+    {file = "aiosignal-1.3.1-py3-none-any.whl", hash = "sha256:f8376fb07dd1e86a584e4fcdec80b36b7f81aac666ebc724e2c090300dd83b17"},
+    {file = "aiosignal-1.3.1.tar.gz", hash = "sha256:54cd96e15e1649b75d6c87526a6ff0b6c1b0dd3459f43d9ca11d48c339b68cfc"},
+]
 
 [[package]]
 name = "annotated-types"
@@ -114,6 +189,16 @@ files = [
 ]
 
 [[package]]
+name = "async-timeout"
+version = "4.0.3"
+requires_python = ">=3.7"
+summary = "Timeout context manager for asyncio programs"
+files = [
+    {file = "async-timeout-4.0.3.tar.gz", hash = "sha256:4640d96be84d82d02ed59ea2b7105a0f7b33abe8703703cd0ab0bf87c427522f"},
+    {file = "async_timeout-4.0.3-py3-none-any.whl", hash = "sha256:7405140ff1230c310e51dc27b3145b9092d659ce68ff733fb0cefe3ee42be028"},
+]
+
+[[package]]
 name = "attrs"
 version = "23.1.0"
 requires_python = ">=3.7"
@@ -125,23 +210,21 @@ files = [
 
 [[package]]
 name = "babel"
-version = "2.13.1"
+version = "2.14.0"
 requires_python = ">=3.7"
 summary = "Internationalization utilities"
-dependencies = [
-    "setuptools; python_version >= \"3.12\"",
-]
 files = [
-    {file = "Babel-2.13.1-py3-none-any.whl", hash = "sha256:7077a4984b02b6727ac10f1f7294484f737443d7e2e66c5e4380e41a3ae0b4ed"},
-    {file = "Babel-2.13.1.tar.gz", hash = "sha256:33e0952d7dd6374af8dbf6768cc4ddf3ccfefc244f9986d4074704f2fbd18900"},
+    {file = "Babel-2.14.0-py3-none-any.whl", hash = "sha256:efb1a25b7118e67ce3a259bed20545c29cb68be8ad2c784c83689981b7a57287"},
+    {file = "Babel-2.14.0.tar.gz", hash = "sha256:6919867db036398ba21eb5c7a0f6b28ab8cbc3ae7a73a44ebe34ae74a4e7d363"},
 ]
 
 [[package]]
 name = "black"
-version = "23.11.0"
+version = "23.12.0"
 requires_python = ">=3.8"
 summary = "The uncompromising code formatter."
 dependencies = [
+    "aiohttp>=3.7.4; sys_platform != \"win32\" or implementation_name != \"pypy\" and extra == \"d\"",
     "click>=8.0.0",
     "mypy-extensions>=0.4.3",
     "packaging>=22.0",
@@ -151,16 +234,20 @@ dependencies = [
     "typing-extensions>=4.0.1; python_version < \"3.11\"",
 ]
 files = [
-    {file = "black-23.11.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:dbea0bb8575c6b6303cc65017b46351dc5953eea5c0a59d7b7e3a2d2f433a911"},
-    {file = "black-23.11.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:412f56bab20ac85927f3a959230331de5614aecda1ede14b373083f62ec24e6f"},
-    {file = "black-23.11.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d136ef5b418c81660ad847efe0e55c58c8208b77a57a28a503a5f345ccf01394"},
-    {file = "black-23.11.0-cp310-cp310-win_amd64.whl", hash = "sha256:6c1cac07e64433f646a9a838cdc00c9768b3c362805afc3fce341af0e6a9ae9f"},
-    {file = "black-23.11.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cf57719e581cfd48c4efe28543fea3d139c6b6f1238b3f0102a9c73992cbb479"},
-    {file = "black-23.11.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:698c1e0d5c43354ec5d6f4d914d0d553a9ada56c85415700b81dc90125aac244"},
-    {file = "black-23.11.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:760415ccc20f9e8747084169110ef75d545f3b0932ee21368f63ac0fee86b221"},
-    {file = "black-23.11.0-cp311-cp311-win_amd64.whl", hash = "sha256:58e5f4d08a205b11800332920e285bd25e1a75c54953e05502052738fe16b3b5"},
-    {file = "black-23.11.0-py3-none-any.whl", hash = "sha256:54caaa703227c6e0c87b76326d0862184729a69b73d3b7305b6288e1d830067e"},
-    {file = "black-23.11.0.tar.gz", hash = "sha256:4c68855825ff432d197229846f971bc4d6666ce90492e5b02013bcaca4d9ab05"},
+    {file = "black-23.12.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:67f19562d367468ab59bd6c36a72b2c84bc2f16b59788690e02bbcb140a77175"},
+    {file = "black-23.12.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:bbd75d9f28a7283b7426160ca21c5bd640ca7cd8ef6630b4754b6df9e2da8462"},
+    {file = "black-23.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:593596f699ca2dcbbbdfa59fcda7d8ad6604370c10228223cd6cf6ce1ce7ed7e"},
+    {file = "black-23.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:12d5f10cce8dc27202e9a252acd1c9a426c83f95496c959406c96b785a92bb7d"},
+    {file = "black-23.12.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:e73c5e3d37e5a3513d16b33305713237a234396ae56769b839d7c40759b8a41c"},
+    {file = "black-23.12.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ba09cae1657c4f8a8c9ff6cfd4a6baaf915bb4ef7d03acffe6a2f6585fa1bd01"},
+    {file = "black-23.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ace64c1a349c162d6da3cef91e3b0e78c4fc596ffde9413efa0525456148873d"},
+    {file = "black-23.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:72db37a2266b16d256b3ea88b9affcdd5c41a74db551ec3dd4609a59c17d25bf"},
+    {file = "black-23.12.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:fdf6f23c83078a6c8da2442f4d4eeb19c28ac2a6416da7671b72f0295c4a697b"},
+    {file = "black-23.12.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:39dda060b9b395a6b7bf9c5db28ac87b3c3f48d4fdff470fa8a94ab8271da47e"},
+    {file = "black-23.12.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7231670266ca5191a76cb838185d9be59cfa4f5dd401b7c1c70b993c58f6b1b5"},
+    {file = "black-23.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:193946e634e80bfb3aec41830f5d7431f8dd5b20d11d89be14b84a97c6b8bc75"},
+    {file = "black-23.12.0-py3-none-any.whl", hash = "sha256:a7c07db8200b5315dc07e331dda4d889a56f6bf4db6a9c2a526fa3166a81614f"},
+    {file = "black-23.12.0.tar.gz", hash = "sha256:330a327b422aca0634ecd115985c1c7fd7bdb5b5a2ef8aa9888a82e2ebe9437a"},
 ]
 
 [[package]]
@@ -413,11 +500,11 @@ files = [
 
 [[package]]
 name = "distlib"
-version = "0.3.7"
+version = "0.3.8"
 summary = "Distribution utilities"
 files = [
-    {file = "distlib-0.3.7-py2.py3-none-any.whl", hash = "sha256:2e24928bc811348f0feb63014e97aaae3037f2cf48712d51ae61df7fd6075057"},
-    {file = "distlib-0.3.7.tar.gz", hash = "sha256:9dafe54b34a028eafd95039d5e5d4851a13734540f1331060d31c9916e7147a8"},
+    {file = "distlib-0.3.8-py2.py3-none-any.whl", hash = "sha256:034db59a0b96f8ca18035f36290806a9a6e6bd9d1ff91e45a7f172eb17e51784"},
+    {file = "distlib-0.3.8.tar.gz", hash = "sha256:1530ea13e350031b6312d8580ddb6b27a104275a31106523b8f123787f494f64"},
 ]
 
 [[package]]
@@ -516,7 +603,7 @@ files = [
 
 [[package]]
 name = "fmtm-splitter"
-version = "0.2.4"
+version = "0.2.5"
 requires_python = ">=3.10"
 summary = "A program for splitting a large AOI into smaller tasks."
 dependencies = [
@@ -529,8 +616,63 @@ dependencies = [
     "sqlalchemy>=2.0.0",
 ]
 files = [
-    {file = "fmtm-splitter-0.2.4.tar.gz", hash = "sha256:e23edaabbc2ab1982a82aea0187bb10820844ea4130522d941f2dc04ddf66d7e"},
-    {file = "fmtm_splitter-0.2.4-py3-none-any.whl", hash = "sha256:6ba37e16d291ac09e2a2b31dfe6eb9f122ecae521fec202ef137f7467fb74211"},
+    {file = "fmtm-splitter-0.2.5.tar.gz", hash = "sha256:03b40cf80ca9d6593d24737df0edd4cc1f0ed91a05f7eee4bdeadb2c810a0300"},
+    {file = "fmtm_splitter-0.2.5-py3-none-any.whl", hash = "sha256:b6f6247f06bb30e511ddc22aaba4ccb9e89b7463ce47a7bc9dc9038eac39408b"},
+]
+
+[[package]]
+name = "frozenlist"
+version = "1.4.1"
+requires_python = ">=3.8"
+summary = "A list-like structure which implements collections.abc.MutableSequence"
+files = [
+    {file = "frozenlist-1.4.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f9aa1878d1083b276b0196f2dfbe00c9b7e752475ed3b682025ff20c1c1f51ac"},
+    {file = "frozenlist-1.4.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:29acab3f66f0f24674b7dc4736477bcd4bc3ad4b896f5f45379a67bce8b96868"},
+    {file = "frozenlist-1.4.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:74fb4bee6880b529a0c6560885fce4dc95936920f9f20f53d99a213f7bf66776"},
+    {file = "frozenlist-1.4.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:590344787a90ae57d62511dd7c736ed56b428f04cd8c161fcc5e7232c130c69a"},
+    {file = "frozenlist-1.4.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:068b63f23b17df8569b7fdca5517edef76171cf3897eb68beb01341131fbd2ad"},
+    {file = "frozenlist-1.4.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5c849d495bf5154cd8da18a9eb15db127d4dba2968d88831aff6f0331ea9bd4c"},
+    {file = "frozenlist-1.4.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9750cc7fe1ae3b1611bb8cfc3f9ec11d532244235d75901fb6b8e42ce9229dfe"},
+    {file = "frozenlist-1.4.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a9b2de4cf0cdd5bd2dee4c4f63a653c61d2408055ab77b151c1957f221cabf2a"},
+    {file = "frozenlist-1.4.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:0633c8d5337cb5c77acbccc6357ac49a1770b8c487e5b3505c57b949b4b82e98"},
+    {file = "frozenlist-1.4.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:27657df69e8801be6c3638054e202a135c7f299267f1a55ed3a598934f6c0d75"},
+    {file = "frozenlist-1.4.1-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:f9a3ea26252bd92f570600098783d1371354d89d5f6b7dfd87359d669f2109b5"},
+    {file = "frozenlist-1.4.1-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:4f57dab5fe3407b6c0c1cc907ac98e8a189f9e418f3b6e54d65a718aaafe3950"},
+    {file = "frozenlist-1.4.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:e02a0e11cf6597299b9f3bbd3f93d79217cb90cfd1411aec33848b13f5c656cc"},
+    {file = "frozenlist-1.4.1-cp310-cp310-win32.whl", hash = "sha256:a828c57f00f729620a442881cc60e57cfcec6842ba38e1b19fd3e47ac0ff8dc1"},
+    {file = "frozenlist-1.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:f56e2333dda1fe0f909e7cc59f021eba0d2307bc6f012a1ccf2beca6ba362439"},
+    {file = "frozenlist-1.4.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:a0cb6f11204443f27a1628b0e460f37fb30f624be6051d490fa7d7e26d4af3d0"},
+    {file = "frozenlist-1.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b46c8ae3a8f1f41a0d2ef350c0b6e65822d80772fe46b653ab6b6274f61d4a49"},
+    {file = "frozenlist-1.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:fde5bd59ab5357e3853313127f4d3565fc7dad314a74d7b5d43c22c6a5ed2ced"},
+    {file = "frozenlist-1.4.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:722e1124aec435320ae01ee3ac7bec11a5d47f25d0ed6328f2273d287bc3abb0"},
+    {file = "frozenlist-1.4.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2471c201b70d58a0f0c1f91261542a03d9a5e088ed3dc6c160d614c01649c106"},
+    {file = "frozenlist-1.4.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:c757a9dd70d72b076d6f68efdbb9bc943665ae954dad2801b874c8c69e185068"},
+    {file = "frozenlist-1.4.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f146e0911cb2f1da549fc58fc7bcd2b836a44b79ef871980d605ec392ff6b0d2"},
+    {file = "frozenlist-1.4.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f9c515e7914626b2a2e1e311794b4c35720a0be87af52b79ff8e1429fc25f19"},
+    {file = "frozenlist-1.4.1-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:c302220494f5c1ebeb0912ea782bcd5e2f8308037b3c7553fad0e48ebad6ad82"},
+    {file = "frozenlist-1.4.1-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:442acde1e068288a4ba7acfe05f5f343e19fac87bfc96d89eb886b0363e977ec"},
+    {file = "frozenlist-1.4.1-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:1b280e6507ea8a4fa0c0a7150b4e526a8d113989e28eaaef946cc77ffd7efc0a"},
+    {file = "frozenlist-1.4.1-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:fe1a06da377e3a1062ae5fe0926e12b84eceb8a50b350ddca72dc85015873f74"},
+    {file = "frozenlist-1.4.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:db9e724bebd621d9beca794f2a4ff1d26eed5965b004a97f1f1685a173b869c2"},
+    {file = "frozenlist-1.4.1-cp311-cp311-win32.whl", hash = "sha256:e774d53b1a477a67838a904131c4b0eef6b3d8a651f8b138b04f748fccfefe17"},
+    {file = "frozenlist-1.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:fb3c2db03683b5767dedb5769b8a40ebb47d6f7f45b1b3e3b4b51ec8ad9d9825"},
+    {file = "frozenlist-1.4.1-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:1979bc0aeb89b33b588c51c54ab0161791149f2461ea7c7c946d95d5f93b56ae"},
+    {file = "frozenlist-1.4.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:cc7b01b3754ea68a62bd77ce6020afaffb44a590c2289089289363472d13aedb"},
+    {file = "frozenlist-1.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c9c92be9fd329ac801cc420e08452b70e7aeab94ea4233a4804f0915c14eba9b"},
+    {file = "frozenlist-1.4.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5c3894db91f5a489fc8fa6a9991820f368f0b3cbdb9cd8849547ccfab3392d86"},
+    {file = "frozenlist-1.4.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ba60bb19387e13597fb059f32cd4d59445d7b18b69a745b8f8e5db0346f33480"},
+    {file = "frozenlist-1.4.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8aefbba5f69d42246543407ed2461db31006b0f76c4e32dfd6f42215a2c41d09"},
+    {file = "frozenlist-1.4.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:780d3a35680ced9ce682fbcf4cb9c2bad3136eeff760ab33707b71db84664e3a"},
+    {file = "frozenlist-1.4.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9acbb16f06fe7f52f441bb6f413ebae6c37baa6ef9edd49cdd567216da8600cd"},
+    {file = "frozenlist-1.4.1-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:23b701e65c7b36e4bf15546a89279bd4d8675faabc287d06bbcfac7d3c33e1e6"},
+    {file = "frozenlist-1.4.1-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:3e0153a805a98f5ada7e09826255ba99fb4f7524bb81bf6b47fb702666484ae1"},
+    {file = "frozenlist-1.4.1-cp312-cp312-musllinux_1_1_ppc64le.whl", hash = "sha256:dd9b1baec094d91bf36ec729445f7769d0d0cf6b64d04d86e45baf89e2b9059b"},
+    {file = "frozenlist-1.4.1-cp312-cp312-musllinux_1_1_s390x.whl", hash = "sha256:1a4471094e146b6790f61b98616ab8e44f72661879cc63fa1049d13ef711e71e"},
+    {file = "frozenlist-1.4.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:5667ed53d68d91920defdf4035d1cdaa3c3121dc0b113255124bcfada1cfa1b8"},
+    {file = "frozenlist-1.4.1-cp312-cp312-win32.whl", hash = "sha256:beee944ae828747fd7cb216a70f120767fc9f4f00bacae8543c14a6831673f89"},
+    {file = "frozenlist-1.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:64536573d0a2cb6e625cf309984e2d873979709f2cf22839bf2d61790b448ad5"},
+    {file = "frozenlist-1.4.1-py3-none-any.whl", hash = "sha256:04ced3e6a46b4cfffe20f9ae482818e34eba9b5fb0ce4056e4cc9b6e212d09b7"},
+    {file = "frozenlist-1.4.1.tar.gz", hash = "sha256:c037a86e8513059a2613aaba4d817bb90b9d9b6b69aace3ce9c877e8c8ed402b"},
 ]
 
 [[package]]
@@ -1120,6 +1262,45 @@ dependencies = [
 files = [
     {file = "mkdocstrings_python-1.7.5-py3-none-any.whl", hash = "sha256:5f6246026353f0c0785135db70c3fe9a5d9318990fc7ceb11d62097b8ffdd704"},
     {file = "mkdocstrings_python-1.7.5.tar.gz", hash = "sha256:c7d143728257dbf1aa550446555a554b760dcd40a763f077189d298502b800be"},
+]
+
+[[package]]
+name = "multidict"
+version = "6.0.4"
+requires_python = ">=3.7"
+summary = "multidict implementation"
+files = [
+    {file = "multidict-6.0.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:0b1a97283e0c85772d613878028fec909f003993e1007eafa715b24b377cb9b8"},
+    {file = "multidict-6.0.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:eeb6dcc05e911516ae3d1f207d4b0520d07f54484c49dfc294d6e7d63b734171"},
+    {file = "multidict-6.0.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:d6d635d5209b82a3492508cf5b365f3446afb65ae7ebd755e70e18f287b0adf7"},
+    {file = "multidict-6.0.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c048099e4c9e9d615545e2001d3d8a4380bd403e1a0578734e0d31703d1b0c0b"},
+    {file = "multidict-6.0.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ea20853c6dbbb53ed34cb4d080382169b6f4554d394015f1bef35e881bf83547"},
+    {file = "multidict-6.0.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:16d232d4e5396c2efbbf4f6d4df89bfa905eb0d4dc5b3549d872ab898451f569"},
+    {file = "multidict-6.0.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:36c63aaa167f6c6b04ef2c85704e93af16c11d20de1d133e39de6a0e84582a93"},
+    {file = "multidict-6.0.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:64bdf1086b6043bf519869678f5f2757f473dee970d7abf6da91ec00acb9cb98"},
+    {file = "multidict-6.0.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:43644e38f42e3af682690876cff722d301ac585c5b9e1eacc013b7a3f7b696a0"},
+    {file = "multidict-6.0.4-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:7582a1d1030e15422262de9f58711774e02fa80df0d1578995c76214f6954988"},
+    {file = "multidict-6.0.4-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:ddff9c4e225a63a5afab9dd15590432c22e8057e1a9a13d28ed128ecf047bbdc"},
+    {file = "multidict-6.0.4-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:ee2a1ece51b9b9e7752e742cfb661d2a29e7bcdba2d27e66e28a99f1890e4fa0"},
+    {file = "multidict-6.0.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:a2e4369eb3d47d2034032a26c7a80fcb21a2cb22e1173d761a162f11e562caa5"},
+    {file = "multidict-6.0.4-cp310-cp310-win32.whl", hash = "sha256:574b7eae1ab267e5f8285f0fe881f17efe4b98c39a40858247720935b893bba8"},
+    {file = "multidict-6.0.4-cp310-cp310-win_amd64.whl", hash = "sha256:4dcbb0906e38440fa3e325df2359ac6cb043df8e58c965bb45f4e406ecb162cc"},
+    {file = "multidict-6.0.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:0dfad7a5a1e39c53ed00d2dd0c2e36aed4650936dc18fd9a1826a5ae1cad6f03"},
+    {file = "multidict-6.0.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:64da238a09d6039e3bd39bb3aee9c21a5e34f28bfa5aa22518581f910ff94af3"},
+    {file = "multidict-6.0.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ff959bee35038c4624250473988b24f846cbeb2c6639de3602c073f10410ceba"},
+    {file = "multidict-6.0.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:01a3a55bd90018c9c080fbb0b9f4891db37d148a0a18722b42f94694f8b6d4c9"},
+    {file = "multidict-6.0.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c5cb09abb18c1ea940fb99360ea0396f34d46566f157122c92dfa069d3e0e982"},
+    {file = "multidict-6.0.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:666daae833559deb2d609afa4490b85830ab0dfca811a98b70a205621a6109fe"},
+    {file = "multidict-6.0.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:11bdf3f5e1518b24530b8241529d2050014c884cf18b6fc69c0c2b30ca248710"},
+    {file = "multidict-6.0.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7d18748f2d30f94f498e852c67d61261c643b349b9d2a581131725595c45ec6c"},
+    {file = "multidict-6.0.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:458f37be2d9e4c95e2d8866a851663cbc76e865b78395090786f6cd9b3bbf4f4"},
+    {file = "multidict-6.0.4-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:b1a2eeedcead3a41694130495593a559a668f382eee0727352b9a41e1c45759a"},
+    {file = "multidict-6.0.4-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:7d6ae9d593ef8641544d6263c7fa6408cc90370c8cb2bbb65f8d43e5b0351d9c"},
+    {file = "multidict-6.0.4-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:5979b5632c3e3534e42ca6ff856bb24b2e3071b37861c2c727ce220d80eee9ed"},
+    {file = "multidict-6.0.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:dcfe792765fab89c365123c81046ad4103fcabbc4f56d1c1997e6715e8015461"},
+    {file = "multidict-6.0.4-cp311-cp311-win32.whl", hash = "sha256:3601a3cece3819534b11d4efc1eb76047488fddd0c85a3948099d5da4d504636"},
+    {file = "multidict-6.0.4-cp311-cp311-win_amd64.whl", hash = "sha256:81a4f0b34bd92df3da93315c6a59034df95866014ac08535fc819f043bfd51f0"},
+    {file = "multidict-6.0.4.tar.gz", hash = "sha256:3666906492efb76453c0e7b97f2cf459b0682e7402c0489a95484965dbc1da49"},
 ]
 
 [[package]]
@@ -2407,6 +2588,65 @@ summary = "Makes working with XML feel like you are working with JSON"
 files = [
     {file = "xmltodict-0.13.0-py2.py3-none-any.whl", hash = "sha256:aa89e8fd76320154a40d19a0df04a4695fb9dc5ba977cbb68ab3e4eb225e7852"},
     {file = "xmltodict-0.13.0.tar.gz", hash = "sha256:341595a488e3e01a85a9d8911d8912fd922ede5fecc4dce437eb4b6c8d037e56"},
+]
+
+[[package]]
+name = "yarl"
+version = "1.9.4"
+requires_python = ">=3.7"
+summary = "Yet another URL library"
+dependencies = [
+    "idna>=2.0",
+    "multidict>=4.0",
+]
+files = [
+    {file = "yarl-1.9.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:a8c1df72eb746f4136fe9a2e72b0c9dc1da1cbd23b5372f94b5820ff8ae30e0e"},
+    {file = "yarl-1.9.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a3a6ed1d525bfb91b3fc9b690c5a21bb52de28c018530ad85093cc488bee2dd2"},
+    {file = "yarl-1.9.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c38c9ddb6103ceae4e4498f9c08fac9b590c5c71b0370f98714768e22ac6fa66"},
+    {file = "yarl-1.9.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d9e09c9d74f4566e905a0b8fa668c58109f7624db96a2171f21747abc7524234"},
+    {file = "yarl-1.9.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b8477c1ee4bd47c57d49621a062121c3023609f7a13b8a46953eb6c9716ca392"},
+    {file = "yarl-1.9.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d5ff2c858f5f6a42c2a8e751100f237c5e869cbde669a724f2062d4c4ef93551"},
+    {file = "yarl-1.9.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:357495293086c5b6d34ca9616a43d329317feab7917518bc97a08f9e55648455"},
+    {file = "yarl-1.9.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:54525ae423d7b7a8ee81ba189f131054defdb122cde31ff17477951464c1691c"},
+    {file = "yarl-1.9.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:801e9264d19643548651b9db361ce3287176671fb0117f96b5ac0ee1c3530d53"},
+    {file = "yarl-1.9.4-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:e516dc8baf7b380e6c1c26792610230f37147bb754d6426462ab115a02944385"},
+    {file = "yarl-1.9.4-cp310-cp310-musllinux_1_1_ppc64le.whl", hash = "sha256:7d5aaac37d19b2904bb9dfe12cdb08c8443e7ba7d2852894ad448d4b8f442863"},
+    {file = "yarl-1.9.4-cp310-cp310-musllinux_1_1_s390x.whl", hash = "sha256:54beabb809ffcacbd9d28ac57b0db46e42a6e341a030293fb3185c409e626b8b"},
+    {file = "yarl-1.9.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:bac8d525a8dbc2a1507ec731d2867025d11ceadcb4dd421423a5d42c56818541"},
+    {file = "yarl-1.9.4-cp310-cp310-win32.whl", hash = "sha256:7855426dfbddac81896b6e533ebefc0af2f132d4a47340cee6d22cac7190022d"},
+    {file = "yarl-1.9.4-cp310-cp310-win_amd64.whl", hash = "sha256:848cd2a1df56ddbffeb375535fb62c9d1645dde33ca4d51341378b3f5954429b"},
+    {file = "yarl-1.9.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:35a2b9396879ce32754bd457d31a51ff0a9d426fd9e0e3c33394bf4b9036b099"},
+    {file = "yarl-1.9.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:4c7d56b293cc071e82532f70adcbd8b61909eec973ae9d2d1f9b233f3d943f2c"},
+    {file = "yarl-1.9.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d8a1c6c0be645c745a081c192e747c5de06e944a0d21245f4cf7c05e457c36e0"},
+    {file = "yarl-1.9.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4b3c1ffe10069f655ea2d731808e76e0f452fc6c749bea04781daf18e6039525"},
+    {file = "yarl-1.9.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:549d19c84c55d11687ddbd47eeb348a89df9cb30e1993f1b128f4685cd0ebbf8"},
+    {file = "yarl-1.9.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a7409f968456111140c1c95301cadf071bd30a81cbd7ab829169fb9e3d72eae9"},
+    {file = "yarl-1.9.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e23a6d84d9d1738dbc6e38167776107e63307dfc8ad108e580548d1f2c587f42"},
+    {file = "yarl-1.9.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d8b889777de69897406c9fb0b76cdf2fd0f31267861ae7501d93003d55f54fbe"},
+    {file = "yarl-1.9.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:03caa9507d3d3c83bca08650678e25364e1843b484f19986a527630ca376ecce"},
+    {file = "yarl-1.9.4-cp311-cp311-musllinux_1_1_i686.whl", hash = "sha256:4e9035df8d0880b2f1c7f5031f33f69e071dfe72ee9310cfc76f7b605958ceb9"},
+    {file = "yarl-1.9.4-cp311-cp311-musllinux_1_1_ppc64le.whl", hash = "sha256:c0ec0ed476f77db9fb29bca17f0a8fcc7bc97ad4c6c1d8959c507decb22e8572"},
+    {file = "yarl-1.9.4-cp311-cp311-musllinux_1_1_s390x.whl", hash = "sha256:ee04010f26d5102399bd17f8df8bc38dc7ccd7701dc77f4a68c5b8d733406958"},
+    {file = "yarl-1.9.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:49a180c2e0743d5d6e0b4d1a9e5f633c62eca3f8a86ba5dd3c471060e352ca98"},
+    {file = "yarl-1.9.4-cp311-cp311-win32.whl", hash = "sha256:81eb57278deb6098a5b62e88ad8281b2ba09f2f1147c4767522353eaa6260b31"},
+    {file = "yarl-1.9.4-cp311-cp311-win_amd64.whl", hash = "sha256:d1d2532b340b692880261c15aee4dc94dd22ca5d61b9db9a8a361953d36410b1"},
+    {file = "yarl-1.9.4-cp312-cp312-macosx_10_9_universal2.whl", hash = "sha256:0d2454f0aef65ea81037759be5ca9947539667eecebca092733b2eb43c965a81"},
+    {file = "yarl-1.9.4-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:44d8ffbb9c06e5a7f529f38f53eda23e50d1ed33c6c869e01481d3fafa6b8142"},
+    {file = "yarl-1.9.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:aaaea1e536f98754a6e5c56091baa1b6ce2f2700cc4a00b0d49eca8dea471074"},
+    {file = "yarl-1.9.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3777ce5536d17989c91696db1d459574e9a9bd37660ea7ee4d3344579bb6f129"},
+    {file = "yarl-1.9.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9fc5fc1eeb029757349ad26bbc5880557389a03fa6ada41703db5e068881e5f2"},
+    {file = "yarl-1.9.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea65804b5dc88dacd4a40279af0cdadcfe74b3e5b4c897aa0d81cf86927fee78"},
+    {file = "yarl-1.9.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aa102d6d280a5455ad6a0f9e6d769989638718e938a6a0a2ff3f4a7ff8c62cc4"},
+    {file = "yarl-1.9.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:09efe4615ada057ba2d30df871d2f668af661e971dfeedf0c159927d48bbeff0"},
+    {file = "yarl-1.9.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:008d3e808d03ef28542372d01057fd09168419cdc8f848efe2804f894ae03e51"},
+    {file = "yarl-1.9.4-cp312-cp312-musllinux_1_1_i686.whl", hash = "sha256:6f5cb257bc2ec58f437da2b37a8cd48f666db96d47b8a3115c29f316313654ff"},
+    {file = "yarl-1.9.4-cp312-cp312-musllinux_1_1_ppc64le.whl", hash = "sha256:992f18e0ea248ee03b5a6e8b3b4738850ae7dbb172cc41c966462801cbf62cf7"},
+    {file = "yarl-1.9.4-cp312-cp312-musllinux_1_1_s390x.whl", hash = "sha256:0e9d124c191d5b881060a9e5060627694c3bdd1fe24c5eecc8d5d7d0eb6faabc"},
+    {file = "yarl-1.9.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:3986b6f41ad22988e53d5778f91855dc0399b043fc8946d4f2e68af22ee9ff10"},
+    {file = "yarl-1.9.4-cp312-cp312-win32.whl", hash = "sha256:4b21516d181cd77ebd06ce160ef8cc2a5e9ad35fb1c5930882baff5ac865eee7"},
+    {file = "yarl-1.9.4-cp312-cp312-win_amd64.whl", hash = "sha256:a9bd00dc3bc395a662900f33f74feb3e757429e545d831eef5bb280252631984"},
+    {file = "yarl-1.9.4-py3-none-any.whl", hash = "sha256:928cecb0ef9d5a7946eb6ff58417ad2fe9375762382f1bf5c55e61645f2c43ad"},
+    {file = "yarl-1.9.4.tar.gz", hash = "sha256:566db86717cf8080b99b58b083b773a908ae40f06681e87e589a976faf8246bf"},
 ]
 
 [[package]]

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "osm-login-python==1.0.1",
     "osm-fieldwork==0.4.0",
     "osm-rawdata==0.1.7",
-    "fmtm-splitter==0.2.4",
+    "fmtm-splitter==0.2.5",
 ]
 requires-python = ">=3.10"
 readme = "../../README.md"

--- a/src/backend/tests/test_projects_routes.py
+++ b/src/backend/tests/test_projects_routes.py
@@ -172,8 +172,8 @@ async def test_generate_appuser_files(db, project):
 
     # Upload data extracts
     log.debug(f"Uploading custom data extracts: {str(data_extracts)[:100]}...")
-    data_extract_uploaded = await project_crud.upload_custom_data_extracts(
-        db, project_id, data_extracts
+    data_extract_uploaded = await project_crud.upload_custom_data_extract(
+        db, project_id, data_extracts,
     )
     assert data_extract_uploaded is True
 

--- a/src/backend/tests/test_projects_routes.py
+++ b/src/backend/tests/test_projects_routes.py
@@ -24,6 +24,7 @@ import uuid
 from unittest.mock import Mock, patch
 
 import pytest
+import requests
 import sozipfile.sozipfile as zipfile
 from fastapi.concurrency import run_in_threadpool
 from geoalchemy2.elements import WKBElement
@@ -172,10 +173,16 @@ async def test_generate_appuser_files(db, project):
 
     # Upload data extracts
     log.debug(f"Uploading custom data extracts: {str(data_extracts)[:100]}...")
-    data_extract_uploaded = await project_crud.upload_custom_data_extract(
-        db, project_id, data_extracts,
+    data_extract_s3_path = await project_crud.upload_custom_data_extract(
+        db,
+        project_id,
+        data_extracts,
     )
-    assert data_extract_uploaded is True
+    assert data_extract_s3_path is not None
+    # Test url, but first sub alias for docker network
+    internal_file_path = f"http://s3:9000{data_extract_s3_path.split('7050')[1]}"
+    response = requests.head(internal_file_path, allow_redirects=True)
+    assert response.status_code < 400
 
     # Get project tasks list
     task_ids = await tasks_crud.get_task_id_list(db, project_id)

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -67,6 +67,7 @@
     "eslint": "^8.44.0",
     "eslint-config-prettier": "^8.8.0",
     "eslint-plugin-prettier": "^5.0.0",
+    "flatgeobuf": "^3.27.1",
     "geojson-validation": "^1.0.2",
     "install": "^0.13.0",
     "lucide-react": "^0.276.0",

--- a/src/frontend/pnpm-lock.yaml
+++ b/src/frontend/pnpm-lock.yaml
@@ -80,6 +80,9 @@ dependencies:
   eslint-plugin-prettier:
     specifier: ^5.0.0
     version: 5.0.0(eslint-config-prettier@8.10.0)(eslint@8.51.0)(prettier@3.0.3)
+  flatgeobuf:
+    specifier: ^3.27.1
+    version: 3.27.1(ol@8.1.0)
   geojson-validation:
     specifier: ^1.0.2
     version: 1.0.2
@@ -2806,6 +2809,10 @@ packages:
     engines: {node: '>=14.0.0'}
     dev: false
 
+  /@repeaterjs/repeater@3.0.5:
+    resolution: {integrity: sha512-l3YHBLAol6d/IKnB9LhpD0cEZWAoe3eFKUyTYWmFmCO2Q/WOckxLQAUyMZWwZV2M/m3+4vgRoaolFqaII82/TA==}
+    dev: false
+
   /@rollup/plugin-babel@5.3.1(@babel/core@7.23.0)(rollup@2.79.1):
     resolution: {integrity: sha512-WFfdLWU/xVWKeRQnKmIAQULUI7Il0gZnBIH/ZFO069wYIfPu+8zrfp/KMW0atmELoRDq8FbiP3VCss9MhCut7Q==}
     engines: {node: '>= 10.0.0'}
@@ -4892,6 +4899,21 @@ packages:
       flatted: 3.2.9
       keyv: 4.5.4
       rimraf: 3.0.2
+
+  /flatbuffers@23.5.26:
+    resolution: {integrity: sha512-vE+SI9vrJDwi1oETtTIFldC/o9GsVKRM+s6EL0nQgxXlYV1Vc4Tk30hj4xGICftInKQKj1F3up2n8UbIVobISQ==}
+    dev: false
+
+  /flatgeobuf@3.27.1(ol@8.1.0):
+    resolution: {integrity: sha512-KQ8GyE1x3QR/HMWW489Z0poXkHw13kGDalv/oll2FntFlvnamYSa3etT6ONz4v3Dnu+yOBrl8ZFAN3vAcIcOqw==}
+    peerDependencies:
+      ol: ^7 || ^8
+    dependencies:
+      '@repeaterjs/repeater': 3.0.5
+      flatbuffers: 23.5.26
+      ol: 8.1.0
+      slice-source: 0.4.1
+    dev: false
 
   /flatted@3.2.9:
     resolution: {integrity: sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==}
@@ -7001,6 +7023,10 @@ packages:
   /slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
+
+  /slice-source@0.4.1:
+    resolution: {integrity: sha512-YiuPbxpCj4hD9Qs06hGAz/OZhQ0eDuALN0lRWJez0eD/RevzKqGdUx1IOMUnXgpr+sXZLq3g8ERwbAH0bCb8vg==}
+    dev: false
 
   /source-map-js@1.0.2:
     resolution: {integrity: sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==}

--- a/src/frontend/src/api/CreateProjectService.ts
+++ b/src/frontend/src/api/CreateProjectService.ts
@@ -51,19 +51,17 @@ const CreateProjectService: Function = (
         );
         if (dataExtractFile) {
           const dataExtractFormData = new FormData();
-          dataExtractFormData.append('upload', dataExtractFile);
-          const postDataExtract = await axios.post(
-            `${import.meta.env.VITE_API_URL}/projects/upload_custom_extract/?project_id=${
-              resp.id
-            }&feature_type=buildings`,
+          dataExtractFormData.append('custom_extract_file', dataExtractFile);
+          await axios.post(
+            `${import.meta.env.VITE_API_URL}/projects/upload_custom_extract/?project_id=${resp.id}`,
             dataExtractFormData,
           );
         }
         if (lineExtractFile) {
           const lineExtractFormData = new FormData();
-          lineExtractFormData.append('upload', lineExtractFile);
-          const postLineExtract = await axios.post(
-            `${import.meta.env.VITE_API_URL}/projects/upload_custom_extract/?project_id=${resp.id}&feature_type=lines`,
+          lineExtractFormData.append('custom_extract_file', lineExtractFile);
+          await axios.post(
+            `${import.meta.env.VITE_API_URL}/projects/upload_custom_extract/?project_id=${resp.id}`,
             lineExtractFormData,
           );
         }
@@ -330,8 +328,8 @@ const GetIndividualProjectDetails: Function = (url: string, payload: any) => {
 const TaskSplittingPreviewService: Function = (
   url: string,
   fileUpload: any,
-  no_of_buildings: string,
   dataExtractFile: any,
+  no_of_buildings: string,
 ) => {
   return async (dispatch) => {
     dispatch(CreateProjectActions.GetTaskSplittingPreviewLoading(true));
@@ -340,10 +338,8 @@ const TaskSplittingPreviewService: Function = (
       try {
         const taskSplittingFileFormData = new FormData();
         taskSplittingFileFormData.append('project_geojson', fileUpload);
+        taskSplittingFileFormData.append('extract_geojson', dataExtractFile);
         taskSplittingFileFormData.append('no_of_buildings', no_of_buildings);
-        if (dataExtractFile) {
-          taskSplittingFileFormData.append('custom_data_extract', dataExtractFile);
-        }
 
         const getTaskSplittingResponse = await axios.post(url, taskSplittingFileFormData);
         const resp: OrganisationListModel = getTaskSplittingResponse.data;

--- a/src/frontend/src/components/ProjectInfo/ProjectInfomap.jsx
+++ b/src/frontend/src/components/ProjectInfo/ProjectInfomap.jsx
@@ -104,7 +104,7 @@ const getChoroplethColor = (value, colorCodesOutput) => {
 const ProjectInfomap = () => {
   const dispatch = CoreModules.useAppDispatch();
   const [taskBoundaries, setTaskBoundaries] = useState(null);
-  const [buildingGeojson, setBuildingGeojson] = useState(null);
+  const [dataExtractGeojson, setDataExtractGeojson] = useState(null);
   const projectTaskBoundries = CoreModules.useAppSelector((state) => state.project.projectTaskBoundries);
 
   const taskInfo = CoreModules.useAppSelector((state) => state.task.taskInfo);
@@ -159,7 +159,7 @@ const ProjectInfomap = () => {
     //     })),
     //   ],
     // };
-    // setBuildingGeojson(taskBuildingGeojsonFeatureCollection);
+    // setDataExtractGeojson(taskBuildingGeojsonFeatureCollection);
   }, [projectTaskBoundries]);
   useEffect(() => {
     if (!projectBuildingGeojson) return;
@@ -172,7 +172,7 @@ const ProjectInfomap = () => {
         })),
       ],
     };
-    setBuildingGeojson(taskBuildingGeojsonFeatureCollection);
+    setDataExtractGeojson(taskBuildingGeojsonFeatureCollection);
   }, [projectBuildingGeojson]);
 
   useEffect(() => {
@@ -287,7 +287,7 @@ const ProjectInfomap = () => {
             collapsed={true}
           />
         </div>
-        {buildingGeojson && <VectorLayer key={buildingGeojson} geojson={buildingGeojson} zIndex={15} />}
+        {dataExtractGeojson && <VectorLayer key={dataExtractGeojson} geojson={dataExtractGeojson} zIndex={15} />}
       </MapComponent>
     </CoreModules.Box>
   );

--- a/src/frontend/src/components/createnewproject/DataExtract.tsx
+++ b/src/frontend/src/components/createnewproject/DataExtract.tsx
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import { geojson as fgbGeojson } from 'flatgeobuf';
 import React, { useEffect } from 'react';
 import Button from '../../components/common/Button';
@@ -30,8 +31,7 @@ const DataExtract = ({ flag, customLineUpload, setCustomLineUpload, customPolygo
 
   const projectDetails: any = useAppSelector((state) => state.createproject.projectDetails);
   const drawnGeojson = useAppSelector((state) => state.createproject.drawnGeojson);
-  const buildingGeojson = useAppSelector((state) => state.createproject.buildingGeojson);
-  const lineGeojson = useAppSelector((state) => state.createproject.lineGeojson);
+  const dataExtractGeojson = useAppSelector((state) => state.createproject.dataExtractGeojson);
 
   const submission = async () => {
     dispatch(CreateProjectActions.SetIndividualProjectDetailsData(formValues));
@@ -85,37 +85,60 @@ const DataExtract = ({ flag, customLineUpload, setCustomLineUpload, customPolygo
     dispatch(CommonActions.SetCurrentStepFormStep({ flag: flag, step: step }));
     navigate(url);
   };
-  const changeFileHandler = (event, setFileUploadToState, fileType) => {
-    const { files } = event.target;
-    setFileUploadToState(files[0]);
-    convertFileToGeojson(files[0], fileType);
-  };
 
-  const resetFile = (setFileUploadToState) => {
-    setFileUploadToState(null);
-  };
-  const convertFileToGeojson = async (file, fileType) => {
+  const convertFileToFeatureCol = async (file) => {
     if (!file) return;
+    // Parse file as JSON
     const fileReader = new FileReader();
     const fileLoaded = await new Promise((resolve) => {
       fileReader.onload = (e) => resolve(e.target.result);
       fileReader.readAsText(file, 'UTF-8');
     });
     const parsedJSON = JSON.parse(fileLoaded);
+
+    // Convert to FeatureCollection
     let geojsonConversion;
     if (parsedJSON.type === 'FeatureCollection') {
       geojsonConversion = parsedJSON;
+    } else if (parsedJSON.type === 'Feature') {
+      geojsonConversion = {
+        type: 'FeatureCollection',
+        features: [parsedJSON],
+      };
     } else {
       geojsonConversion = {
         type: 'FeatureCollection',
         features: [{ type: 'Feature', properties: null, geometry: parsedJSON }],
       };
     }
-    if (fileType === 'building') {
-      dispatch(CreateProjectActions.SetBuildingGeojson(geojsonConversion));
-    } else if (fileType === 'line') {
-      dispatch(CreateProjectActions.SetLineGeojson(geojsonConversion));
+    return geojsonConversion;
+  };
+
+  const changeFileHandler = async (event, setDataExtractToState) => {
+    const { files } = event.target;
+    const uploadedFile = files[0];
+    const fileType = uploadedFile.name.split('.').pop();
+
+    // Handle geojson and fgb types, return featurecollection geojson
+    let extractFeatCol;
+    if (['json', 'geojson'].includes(fileType)) {
+      // Set to state immediately for splitting
+      setDataExtractToState(uploadedFile);
+      extractFeatCol = await convertFileToFeatureCol(uploadedFile);
+    } else if (['fgb'].includes(fileType)) {
+      const arrayBuffer = new Uint8Array(await uploadedFile.arrayBuffer());
+      extractFeatCol = fgbGeojson.deserialize(arrayBuffer);
+      // Set converted geojson to state for splitting
+      const geojsonFile = new File([extractFeatCol], 'custom_extract.geojson', { type: 'application/json' });
+      setDataExtractToState(geojsonFile);
     }
+
+    // View on map
+    dispatch(CreateProjectActions.setDataExtractGeojson(extractFeatCol));
+  };
+
+  const resetFile = (setDataExtractToState) => {
+    setDataExtractToState(null);
   };
 
   useEffect(() => {
@@ -149,20 +172,6 @@ const DataExtract = ({ flag, customLineUpload, setCustomLineUpload, customPolygo
             className="fmtm-flex fmtm-flex-col fmtm-gap-6 lg:fmtm-w-[40%] fmtm-justify-between"
           >
             <div>
-              {/* <div className="fmtm-mb-5">
-                <CustomSelect
-                  title="Select form category"
-                  placeholder="Select form category"
-                  data={formCategoryList}
-                  dataKey="id"
-                  valueKey="id"
-                  label="title"
-                  value={formValues.formCategorySelection}
-                  onValueChange={(value) => {
-                    handleCustomChange('formCategorySelection', value);
-                  }}
-                />
-              </div> */}
               <RadioButton
                 topic="You may choose to use OSM data or upload your own data extract"
                 options={dataExtractOptions}
@@ -191,27 +200,27 @@ const DataExtract = ({ flag, customLineUpload, setCustomLineUpload, customPolygo
                 <>
                   <FileInputComponent
                     onChange={(e) => {
-                      changeFileHandler(e, setCustomPolygonUpload, 'building');
+                      changeFileHandler(e, setCustomPolygonUpload);
                       handleCustomChange('customPolygonUpload', e.target.files[0]);
                     }}
                     onResetFile={() => resetFile(setCustomPolygonUpload)}
                     customFile={customPolygonUpload}
                     btnText="Upload Polygons"
-                    accept=".geojson,.json"
-                    fileDescription="*The supported file formats are .geojson, .json"
+                    accept=".geojson,.json,.fgb"
+                    fileDescription="*The supported file formats are .geojson, .json, .fgb"
                     errorMsg={errors.customPolygonUpload}
                   />
                   <FileInputComponent
                     onChange={(e) => {
-                      changeFileHandler(e, setCustomLineUpload, 'line');
+                      changeFileHandler(e, setCustomLineUpload);
                       handleCustomChange('customLineUpload', e.target.files[0]);
                     }}
                     onResetFile={() => resetFile(setCustomLineUpload)}
                     customFile={customLineUpload}
                     btnText="Upload Lines"
-                    accept=".geojson,.json"
-                    fileDescription="*The supported file formats are .geojson, .json"
-                    errorMsg={errors.setCustomLineUpload}
+                    accept=".geojson,.json,.fgb"
+                    fileDescription="*The supported file formats are .geojson, .json, .fgb"
+                    errorMsg={errors.customLineUpload}
                   />
                 </>
               )}
@@ -228,11 +237,7 @@ const DataExtract = ({ flag, customLineUpload, setCustomLineUpload, customPolygo
             </div>
           </form>
           <div className="fmtm-w-full lg:fmtm-w-[60%] fmtm-flex fmtm-flex-col fmtm-gap-6 fmtm-bg-gray-300 fmtm-h-[60vh] lg:fmtm-h-full">
-            <NewDefineAreaMap
-              uploadedOrDrawnGeojsonFile={drawnGeojson}
-              buildingExtractedGeojson={buildingGeojson}
-              lineExtractedGeojson={lineGeojson}
-            />
+            <NewDefineAreaMap uploadedOrDrawnGeojsonFile={drawnGeojson} buildingExtractedGeojson={dataExtractGeojson} />
           </div>
         </div>
       </div>

--- a/src/frontend/src/components/createnewproject/SelectForm.tsx
+++ b/src/frontend/src/components/createnewproject/SelectForm.tsx
@@ -39,6 +39,7 @@ const SelectForm = ({ flag, geojsonFile, customFormFile, setCustomFormFile }) =>
     errors,
   }: any = useForm(projectDetails, submission, SelectFormValidation);
   const formCategoryList = useAppSelector((state) => state.createproject.formCategoryList);
+  const sortedFormCategoryList = formCategoryList.slice().sort((a, b) => a.title.localeCompare(b.title));
 
   /**
    * Function to handle the change event of a file input.
@@ -95,9 +96,9 @@ const SelectForm = ({ flag, geojsonFile, customFormFile, setCustomFormFile }) =>
             <div className="fmtm-flex fmtm-flex-col  fmtm-gap-6">
               <div className="">
                 <CustomSelect
-                  title="Select the most suitable category that defines your survey"
-                  placeholder="Form category"
-                  data={formCategoryList}
+                  title="Select form category"
+                  placeholder="Select form category"
+                  data={sortedFormCategoryList}
                   dataKey="id"
                   valueKey="title"
                   label="title"

--- a/src/frontend/src/components/createnewproject/SplitTasks.tsx
+++ b/src/frontend/src/components/createnewproject/SplitTasks.tsx
@@ -34,15 +34,7 @@ const alogrithmList = [
 ];
 let generateProjectLogIntervalCb: any = null;
 
-const SplitTasks = ({
-  flag,
-  geojsonFile,
-  setGeojsonFile,
-  customLineUpload,
-  customPolygonUpload,
-  customFormFile,
-  dataExtractFile,
-}) => {
+const SplitTasks = ({ flag, geojsonFile, setGeojsonFile, customLineUpload, customPolygonUpload, customFormFile }) => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
 
@@ -53,8 +45,7 @@ const SplitTasks = ({
   const splitTasksSelection = CoreModules.useAppSelector((state) => state.createproject.splitTasksSelection);
   const drawnGeojson = CoreModules.useAppSelector((state) => state.createproject.drawnGeojson);
   const projectDetails = CoreModules.useAppSelector((state) => state.createproject.projectDetails);
-  const buildingGeojson = useAppSelector((state) => state.createproject.buildingGeojson);
-  const lineGeojson = useAppSelector((state) => state.createproject.lineGeojson);
+  const dataExtractGeojson = useAppSelector((state) => state.createproject.dataExtractGeojson);
   const userDetails: any = CoreModules.useAppSelector((state) => state.login.loginToken);
 
   const generateQrSuccess: any = CoreModules.useAppSelector((state) => state.createproject.generateQrSuccess);
@@ -96,10 +87,11 @@ const SplitTasks = ({
   const submission = () => {
     dispatch(CreateProjectActions.SetIsUnsavedChanges(false));
 
-    const blob = new Blob([JSON.stringify(dividedTaskGeojson || drawnGeojson)], { type: 'application/json' });
-
+    const projectAreaBlob = new Blob([JSON.stringify(dividedTaskGeojson || drawnGeojson)], {
+      type: 'application/json',
+    });
     // Create a file object from the Blob
-    const drawnGeojsonFile = new File([blob], 'data.json', { type: 'application/json' });
+    const drawnGeojsonFile = new File([projectAreaBlob], 'data.json', { type: 'application/json' });
 
     dispatch(CreateProjectActions.SetIndividualProjectDetailsData(formValues));
     const hashtags = projectDetails.hashtags;
@@ -131,6 +123,7 @@ const SplitTasks = ({
       data_extractWays: projectDetails.data_extractWays,
       hashtags: arrayHashtag,
       organisation_id: projectDetails.organisation_id,
+      data_extract_type: projectDetails.data_extract_type,
     };
     if (splitTasksSelection === task_split_type['task_splitting_algorithm']) {
       projectData = { ...projectData, task_num_buildings: projectDetails.average_buildings_per_task };
@@ -170,10 +163,14 @@ const SplitTasks = ({
 
     e.preventDefault();
     e.stopPropagation();
-    const blob = new Blob([JSON.stringify(drawnGeojson)], { type: 'application/json' });
+    // Create a file object from the project area Blob
+    const projectAreaBlob = new Blob([JSON.stringify(drawnGeojson)], { type: 'application/json' });
+    const drawnGeojsonFile = new File([projectAreaBlob], 'outline.json', { type: 'application/json' });
 
-    // Create a file object from the Blob
-    const drawnGeojsonFile = new File([blob], 'data.json', { type: 'application/json' });
+    // Create a file object from the data extract Blob
+    const dataExtractBlob = new Blob([JSON.stringify(dataExtractGeojson)], { type: 'application/json' });
+    const dataExtractFile = new File([dataExtractBlob], 'extract.json', { type: 'application/json' });
+
     if (splitTasksSelection === task_split_type['divide_on_square']) {
       dispatch(
         GetDividedTaskFromGeojson(`${import.meta.env.VITE_API_URL}/projects/preview_split_by_square/`, {
@@ -190,8 +187,8 @@ const SplitTasks = ({
         TaskSplittingPreviewService(
           `${import.meta.env.VITE_API_URL}/projects/task_split`,
           drawnGeojsonFile,
-          formValues?.average_buildings_per_task,
           dataExtractFile,
+          formValues?.average_buildings_per_task,
         ),
       );
     }
@@ -428,8 +425,7 @@ const SplitTasks = ({
                 <NewDefineAreaMap
                   splittedGeojson={dividedTaskGeojson}
                   uploadedOrDrawnGeojsonFile={drawnGeojson}
-                  buildingExtractedGeojson={buildingGeojson}
-                  lineExtractedGeojson={lineGeojson}
+                  buildingExtractedGeojson={dataExtractGeojson}
                 />
               </div>
               {generateProjectLog ? (

--- a/src/frontend/src/components/createnewproject/validation/DataExtractValidation.tsx
+++ b/src/frontend/src/components/createnewproject/validation/DataExtractValidation.tsx
@@ -27,11 +27,13 @@ function DataExtractValidation(values: ProjectValues) {
   if (values.dataExtractWays && values.dataExtractWays === 'osm_data_extract' && !values.dataExtractFeatureType) {
     errors.dataExtractFeatureType = 'OSM Feature Type is Required.';
   }
-  if (values.dataExtractWays && values.dataExtractWays === 'custom_data_extract' && !values.customPolygonUpload) {
-    errors.customPolygonUpload = 'Custom Polygon is Required.';
-  }
-  if (values.dataExtractWays && values.dataExtractWays === 'custom_data_extract' && !values.customLineUpload) {
-    errors.customLineUpload = 'Custom Line is required';
+  if (
+    values.dataExtractWays &&
+    values.dataExtractWays === 'custom_data_extract' &&
+    !values.customPolygonUpload &&
+    !values.customLineUpload
+  ) {
+    errors.customPolygonUpload = 'A GeoJSON file is required.';
   }
 
   console.log(errors);

--- a/src/frontend/src/components/createproject/DefineTasks.tsx
+++ b/src/frontend/src/components/createproject/DefineTasks.tsx
@@ -54,41 +54,31 @@ const DefineTasks: React.FC<any> = ({ geojsonFile, setGeojsonFile, dataExtractFi
   const generateTasksOnMap = () => {
     if (drawnGeojson) {
       const drawnGeojsonString = JSON.stringify(drawnGeojson, null, 2);
-
-      const blob = new Blob([drawnGeojsonString], { type: 'application/json' });
-
+      const projectAreaBlob = new Blob([drawnGeojsonString], { type: 'application/json' });
       // Create a file object from the Blob
-      const drawnGeojsonFile = new File([blob], 'data.json', { type: 'application/json' });
-      dispatch(
-        GetDividedTaskFromGeojson(`${import.meta.env.VITE_API_URL}/projects/preview_split_by_square/`, {
-          geojson: drawnGeojsonFile,
-          dimension: formValues?.dimension,
-        }),
-      );
-    } else {
-      dispatch(
-        GetDividedTaskFromGeojson(`${import.meta.env.VITE_API_URL}/projects/preview_split_by_square/`, {
-          geojson: geojsonFile,
-          dimension: formValues?.dimension,
-        }),
-      );
+      geojsonFile = new File([projectAreaBlob], 'data.json', { type: 'application/json' });
     }
+    dispatch(
+      GetDividedTaskFromGeojson(`${import.meta.env.VITE_API_URL}/projects/preview_split_by_square/`, {
+        geojson: geojsonFile,
+        dimension: formValues?.dimension,
+      }),
+    );
   };
 
   const generateTaskWithSplittingAlgorithm = () => {
     if (drawnGeojson) {
       const drawnGeojsonString = JSON.stringify(drawnGeojson, null, 2);
-
-      const blob = new Blob([drawnGeojsonString], { type: 'application/json' });
+      const projectAreaBlob = new Blob([drawnGeojsonString], { type: 'application/json' });
 
       // Create a file object from the Blob
-      const drawnGeojsonFile = new File([blob], 'data.json', { type: 'application/json' });
+      const drawnGeojsonFile = new File([projectAreaBlob], 'data.json', { type: 'application/json' });
       dispatch(
         TaskSplittingPreviewService(
           `${import.meta.env.VITE_API_URL}/projects/task_split`,
           drawnGeojsonFile,
-          formValues?.no_of_buildings,
           dataExtractFile,
+          formValues?.no_of_buildings,
         ),
       );
     } else {
@@ -96,8 +86,8 @@ const DefineTasks: React.FC<any> = ({ geojsonFile, setGeojsonFile, dataExtractFi
         TaskSplittingPreviewService(
           `${import.meta.env.VITE_API_URL}/projects/task_split`,
           geojsonFile,
-          formValues?.no_of_buildings,
           dataExtractFile,
+          formValues?.no_of_buildings,
         ),
       );
     }

--- a/src/frontend/src/store/slices/CreateProjectSlice.ts
+++ b/src/frontend/src/store/slices/CreateProjectSlice.ts
@@ -43,8 +43,7 @@ export const initialState: CreateProjectStateTypes = {
   uploadAreaSelection: null,
   totalAreaSelection: null,
   splitTasksSelection: null,
-  buildingGeojson: null,
-  lineGeojson: null,
+  dataExtractGeojson: null,
   createProjectValidations: {},
   isUnsavedChanges: false,
   canSwitchCreateProjectSteps: false,
@@ -81,8 +80,7 @@ const CreateProject = createSlice({
       state.projectArea = null;
       state.totalAreaSelection = null;
       state.splitTasksSelection = null;
-      state.buildingGeojson = null;
-      state.lineGeojson = null;
+      state.dataExtractGeojson = null;
       state.taskSplittingGeojson = null;
       state.drawnGeojson = null;
       state.generateProjectLog = null;
@@ -196,11 +194,8 @@ const CreateProject = createSlice({
     SetSplitTasksSelection(state, action) {
       state.splitTasksSelection = action.payload;
     },
-    SetBuildingGeojson(state, action) {
-      state.buildingGeojson = action.payload;
-    },
-    SetLineGeojson(state, action) {
-      state.lineGeojson = action.payload;
+    setDataExtractGeojson(state, action) {
+      state.dataExtractGeojson = action.payload;
     },
     SetCreateProjectValidations(state, action) {
       state.createProjectValidations = {

--- a/src/frontend/src/store/types/ICreateProject.ts
+++ b/src/frontend/src/store/types/ICreateProject.ts
@@ -29,8 +29,7 @@ export type CreateProjectStateTypes = {
   uploadAreaSelection: string | null;
   totalAreaSelection: string | null;
   splitTasksSelection: string | null;
-  buildingGeojson: null;
-  lineGeojson: null;
+  dataExtractGeojson: null;
   createProjectValidations: {};
   isUnsavedChanges: boolean;
   canSwitchCreateProjectSteps: boolean;

--- a/src/frontend/src/store/types/ICreateProject.ts
+++ b/src/frontend/src/store/types/ICreateProject.ts
@@ -95,6 +95,7 @@ export type EditProjectDetailsTypes = {
 };
 
 export type ProjectDetailsTypes = {
+  data_extract_type: string;
   task_split_dimension: number;
   task_num_buildings: number;
   no_of_buildings: number;


### PR DESCRIPTION
Fixes #934 and addresses part of #381 and #889

### Updates

Custom data extract:
- If user uploads a flatgeobuf, this is deserialised as geojson for display on the map. The file is uploaded to our S3.
- If user uploads geojson, this is converted to flatgeobuf on the backend and file uploaded to our S3.
- In either case, a URL to the `.fgb` is stored in `public.projects.data_extract_type` (abusing this param for now, but it should be migrated to `public.projects.data_extract_url` eventually).

> Custom data extracts are stored in the FMTM S3 bucket and managed by us.

OSM data extract:
- When the user continues from the 'Data Extract' page to the 'Split Tasks' page, the endpoint is called to generate a new data extract in the background.
  - This same endpoint can also accept a `project_id` param to return an already existing data extract URL.
- The data extract is generated in flatgeobuf format and stored in the S3 bucket that is part of `raw-data-api`. The URL to this extract is stored in our database.
- The data extract is converted to GeoJSON file during the project creation and passed in as a param to the task splitting `/task_split` endpoint (eventually the splitting algorithm may accept flatgeobuf instead).

> OSM data extracts are stored in the raw-data-api S3 bucket and managed by that service.

### Checks

- I have given this quite a few tests with different scenarios, but please thoroughly test this code @nrjadkry and @varun2948 before we merge.
- The frontend implementation is a bit messy and could probably do with cleaning up.
- The backend tests need to also be updated accordingly - should be pretty simple.

### Future updates

As a consequence of this big change, we need to update a few things.

Frontend:
- Improve the error handling and user feedback during this flow.
- We need to block the user generating splits using the 'task splitting algorithm' until the data extract generation completes.
- This data extract should be loaded in OpenLayers directly as flatgeobuf format throughout the frontend. [There are helpers for this](https://github.com/flatgeobuf/flatgeobuf/blob/master/examples/openlayers/filtered.html). We can even filter the data returned based on the viewport, or only return the extract data for a given task area.
- References to 'buildings' and 'lines' uploaded extracts should be consolidated into one reference (dataExtractFile), as the type of geometries can be determined on the backend instead. 
  - On the project creation Data Extract page we can also remove the radio to select the type of extract. The user can just upload an extract and we handle the rest.
  - The extracts are stored externally and no longer in our database, so this simplifies code on both backend and frontend.

Backend:
- To do this quickly, I ended up reusing an endpoint that uses `raw-data-api` directly.
- We have a partial implementation in place to do this via `osm-rawdata` instead: project_crud.get_data_extract_from_osm_rawdata.
- We need to update osm-rawdata to support the `bind_zip=False` param, then use the package instead.

### Note

We also need to consider regeneration of the extract, as it lasts 90 days.

This should be enough time for most projects, however if the user calls the `get_data_extract` endpoint and the extract is missing (deleted) a new file should be generated (already implemented). 

We just need to make sure this endpoint is called on the project detail page, to return the flatgeobuf URL and display it on the map.