### PR TITLE
Endpoint for submission page, return submission count by date

### DIFF
--- a/src/backend/app/submission/submission_crud.py
+++ b/src/backend/app/submission/submission_crud.py
@@ -853,12 +853,14 @@ async def get_submissions_by_date(db:Session, project_id:int, days:int):
             content = file_in_zip.read()
 
     content = json.loads(content)
-    end_dates = [entry["end"] for entry in content if entry.get("end")]
-    dates = [datetime.fromisoformat(date.split('+')[0]) for date in end_dates]
-    end_dates = [date for date in dates if datetime.now() - date <= timedelta(days=days)]
+    end_dates = [datetime.fromisoformat(date.split('+')[0]) for date in (entry["end"] for entry in content if entry.get("end"))]
+    dates = [date.strftime('%m/%d') for date in end_dates if datetime.now() - date <= timedelta(days=days)]
 
-    dates = [date.strftime('%Y-%m-%d') for date in end_dates]
+    submission_counts = Counter(sorted(dates))
+    response = [
+        {"date": key, "count": value} 
+        for key, value in submission_counts.items()
+        ]
 
-    submission_counts = Counter(dates)
-    return dict(submission_counts)
+    return response
 

--- a/src/backend/app/submission/submission_crud.py
+++ b/src/backend/app/submission/submission_crud.py
@@ -844,9 +844,10 @@ async def get_submissions_by_date(db: Session, project_id: int, days: int, plann
     s3_project_path = f"/{project.organisation_id}/{project_id}"
     s3_submission_path = f"/{s3_project_path}/submission.zip"
 
-    if s3_submission_path is None:
-        return Response("Submissions not found, please upload it first")
-    file = get_obj_from_bucket(settings.S3_BUCKET_NAME, s3_submission_path)
+    try:
+        file = get_obj_from_bucket(settings.S3_BUCKET_NAME, s3_submission_path)
+    except ValueError as e:
+        return []
 
     with zipfile.ZipFile(file, "r") as zip_ref:
         with zip_ref.open("submissions.json") as file_in_zip:
@@ -860,7 +861,7 @@ async def get_submissions_by_date(db: Session, project_id: int, days: int, plann
     submission_counts = Counter(sorted(dates))
 
     response = [
-        {"date": key, "count": value, "planned": planned_task} 
+        {"date": key, "count": value} 
         for key, value in submission_counts.items()
         ]
     if planned_task:

--- a/src/backend/app/submission/submission_routes.py
+++ b/src/backend/app/submission/submission_routes.py
@@ -308,18 +308,20 @@ async def get_osm_xml(
 
 
 @router.get("/submission_page/{project_id}")
-async def get_submission_page(project_id: int,
-                              days: int,
-                              background_tasks: BackgroundTasks,
-                              db: Session = Depends(database.get_db)
-                              ):
+async def get_submission_page(
+    project_id: int,
+    days: int,
+    background_tasks: BackgroundTasks,
+    planned_task: Optional[int] = None,
+    db: Session = Depends(database.get_db),
+):
     """
     This api returns the submission page of a project.
     It takes one parameter: project_id.
     project_id: The ID of the project. This endpoint returns the submission page of this project.
     """
     
-    data = await submission_crud.get_submissions_by_date(db, project_id, days)
+    data = await submission_crud.get_submissions_by_date(db, project_id, days, planned_task)
 
     # Update submission cache in the background
     background_task_id = await project_crud.insert_background_task_into_database(

--- a/src/backend/app/submission/submission_routes.py
+++ b/src/backend/app/submission/submission_routes.py
@@ -30,8 +30,7 @@ from app.config import settings
 from app.db import database
 from app.projects import project_crud, project_schemas
 
-from . import submission_crud
-from .submission_crud import *
+from app.submission import submission_crud
 
 router = APIRouter(
     prefix="/submission",
@@ -316,4 +315,4 @@ async def get_submission_page(project_id: int, days: int, db: Session = Depends(
     project_id: The ID of the project. This endpoint returns the submission page of this project.
     """
     
-    return await get_submissions_by_date(db, project_id, days)
+    return await submission_crud.get_submissions_by_date(db, project_id, days)

--- a/src/backend/app/submission/submission_routes.py
+++ b/src/backend/app/submission/submission_routes.py
@@ -31,6 +31,7 @@ from app.db import database
 from app.projects import project_crud, project_schemas
 
 from . import submission_crud
+from .submission_crud import *
 
 router = APIRouter(
     prefix="/submission",
@@ -305,3 +306,14 @@ async def get_osm_xml(
     # Create a plain XML response
     response = Response(content=processed_xml_string, media_type="application/xml")
     return response
+
+
+@router.get("/submission_page/{project_id}")
+async def get_submission_page(project_id: int, days: int, db: Session = Depends(database.get_db)):
+    """
+    This api returns the submission page of a project.
+    It takes one parameter: project_id.
+    project_id: The ID of the project. This endpoint returns the submission page of this project.
+    """
+    
+    return await get_submissions_by_date(db, project_id, days)


### PR DESCRIPTION
 The API fetches submissions from S3, utilizing the `project_id` to construct the relevant paths. Submissions are then processed, and counts are determined based on the specified time range `days`.