### PR TITLE
Separate task history end point

### DIFF
--- a/src/backend/app/db/db_models.py
+++ b/src/backend/app/db/db_models.py
@@ -367,6 +367,7 @@ class DbTaskHistory(Base):
     )
 
     # Define relationships
+    user = relationship(DbUser, uselist=False, backref="task_history_user")
     invalidation_history = relationship(
         DbTaskInvalidationHistory, lazy="dynamic", cascade="all"
     )
@@ -461,8 +462,14 @@ class DbProject(Base):
             server_default="20386219",
         ),
     )
-    author = relationship(DbUser, uselist=False, backref="user")
+    author = relationship(DbUser, uselist=False, backref="project_user")
     created = cast(datetime, Column(DateTime, default=timestamp, nullable=False))
+
+    task_split_type = Column(Enum(TaskSplitType), nullable=True)
+    # split_strategy = Column(Integer)
+    # grid_meters = Column(Integer)
+    # task_type = Column(Integer)
+    # target_number_of_features = Column(Integer)
 
     # PROJECT DETAILS
     project_name_prefix = cast(str, Column(String))
@@ -471,7 +478,7 @@ class DbProject(Base):
         DbProjectInfo,
         cascade="all, delete, delete-orphan",
         uselist=False,
-        backref="project",
+        backref="project_info",
     )
     location_str = cast(str, Column(String))
 

--- a/src/backend/app/db/db_models.py
+++ b/src/backend/app/db/db_models.py
@@ -462,7 +462,7 @@ class DbProject(Base):
             server_default="20386219",
         ),
     )
-    author = relationship(DbUser, uselist=False, backref="project_user")
+    author = relationship(DbUser, uselist=False, backref="user")
     created = cast(datetime, Column(DateTime, default=timestamp, nullable=False))
 
     task_split_type = Column(Enum(TaskSplitType), nullable=True)
@@ -478,7 +478,7 @@ class DbProject(Base):
         DbProjectInfo,
         cascade="all, delete, delete-orphan",
         uselist=False,
-        backref="project_info",
+        backref="project",
     )
     location_str = cast(str, Column(String))
 

--- a/src/backend/app/tasks/tasks_crud.py
+++ b/src/backend/app/tasks/tasks_crud.py
@@ -341,7 +341,7 @@ async def update_task_history(
     return tasks
 
 
-def get_task_history(
+def get_project_task_history(
     project_id: int,
     end_date: Optional[datetime],
     db: Session,
@@ -349,10 +349,10 @@ def get_task_history(
     """Retrieves the task history records for a specific project.
 
     Args:
-        project_id: The ID of the project.
-        end_date: The end date of the task history
-        records to retrieve (optional).
-        db: The database session.
+        project_id (int): The ID of the project.
+        end_date (datetime, optional): The end date of the task history
+            records to retrieve.
+        db (Session): The database session.
 
     Returns:
         A list of task history records for the specified project.
@@ -413,3 +413,18 @@ async def count_validated_and_mapped_tasks(
         entry.update({"validated": total_validated, "mapped": total_mapped})
 
     return results
+
+
+async def append(tasks:List, db: Session):
+    """Get task history of project."""
+    response = []
+
+    for task in tasks if isinstance(tasks, list) else [tasks]:
+        task_id = task.id
+        task_history = task.task_history
+        if isinstance(task_history, list):
+            for history_entry in task_history:
+                user = db.query(db_models.DbUser).filter_by(id=history_entry.user_id).first()
+                response.append(tasks_schemas.TaskHistory.map_entry_to_model(task_id, history_entry, user))
+
+    return response

--- a/src/backend/app/tasks/tasks_crud.py
+++ b/src/backend/app/tasks/tasks_crud.py
@@ -341,7 +341,7 @@ async def update_task_history(
     return tasks
 
 
-def get_project_task_history(
+async def get_project_task_history(
     project_id: int,
     end_date: Optional[datetime],
     db: Session,
@@ -413,18 +413,3 @@ async def count_validated_and_mapped_tasks(
         entry.update({"validated": total_validated, "mapped": total_mapped})
 
     return results
-
-
-async def append(tasks:List, db: Session):
-    """Get task history of project."""
-    response = []
-
-    for task in tasks if isinstance(tasks, list) else [tasks]:
-        task_id = task.id
-        task_history = task.task_history
-        if isinstance(task_history, list):
-            for history_entry in task_history:
-                user = db.query(db_models.DbUser).filter_by(id=history_entry.user_id).first()
-                response.append(tasks_schemas.TaskHistory.map_entry_to_model(task_id, history_entry, user))
-
-    return response

--- a/src/backend/app/tasks/tasks_routes.py
+++ b/src/backend/app/tasks/tasks_routes.py
@@ -206,17 +206,17 @@ async def task_activity(
     """Retrieves the validate and mapped task count for a specific project.
 
     Args:
-        project_id: The ID of the project.
-        days: The number of days to consider for the
-        task activity (default: 10).
-        db: The database session.
+        project_id (int): The ID of the project.
+        days (int): The number of days to consider for the
+            task activity (default: 10).
+        db (Session): The database session.
 
     Returns:
         list[TaskHistoryCount]: A list of task history counts.
 
     """
     end_date = datetime.now() - timedelta(days=days)
-    task_history = tasks_crud.get_project_task_history(project_id, end_date, db)
+    task_history = await tasks_crud.get_project_task_history(project_id, end_date, db)
 
     return await tasks_crud.count_validated_and_mapped_tasks(
         task_history,
@@ -224,19 +224,20 @@ async def task_activity(
     )
 
 
-@router.get("/task_history/", response_model = List[tasks_schemas.TaskHistory])
-async def task_history(project_id: int, days: int = 10, db: Session = Depends(database.get_db)):
-    """
-    Get the detailed task history for a project.
+@router.get("/task_history/", response_model=List[tasks_schemas.TaskHistory])
+async def task_history(
+    project_id: int, days: int = 10, db: Session = Depends(database.get_db)
+):
+    """Get the detailed task history for a project.
 
     Args:
         project_id (int): The ID of the project.
-        db (Session): The database session. (default: Depends(database.get_db))
+        days (int): The number of days to consider for the
+            task activity (default: 10).
+        db (Session): The database session.
 
     Returns:
         List[TaskHistory]: A list of task history.
     """
     end_date = datetime.now() - timedelta(days=days)
-    task_history = tasks_crud.get_project_task_history(project_id, end_date, db)
-
-    return await tasks_crud.get_task_history(tasks, db)
+    return await tasks_crud.get_project_task_history(project_id, end_date, db)

--- a/src/backend/app/tasks/tasks_routes.py
+++ b/src/backend/app/tasks/tasks_routes.py
@@ -216,9 +216,27 @@ async def task_activity(
 
     """
     end_date = datetime.now() - timedelta(days=days)
-    task_history = tasks_crud.get_task_history(project_id, end_date, db)
+    task_history = tasks_crud.get_project_task_history(project_id, end_date, db)
 
     return await tasks_crud.count_validated_and_mapped_tasks(
         task_history,
         end_date,
     )
+
+
+@router.get("/task_history/", response_model = List[tasks_schemas.TaskHistory])
+async def task_history(project_id: int, days: int = 10, db: Session = Depends(database.get_db)):
+    """
+    Get the detailed task history for a project.
+
+    Args:
+        project_id (int): The ID of the project.
+        db (Session): The database session. (default: Depends(database.get_db))
+
+    Returns:
+        List[TaskHistory]: A list of task history.
+    """
+    end_date = datetime.now() - timedelta(days=days)
+    task_history = tasks_crud.get_project_task_history(project_id, end_date, db)
+
+    return await tasks_crud.get_task_history(tasks, db)

--- a/src/backend/app/tasks/tasks_schemas.py
+++ b/src/backend/app/tasks/tasks_schemas.py
@@ -135,3 +135,24 @@ class ReadTask(Task):
     """Task details plus updated task history."""
 
     task_history: Optional[List[TaskHistoryOut]] = None
+
+
+class TaskHistory(BaseModel):
+    """Task history details."""
+    task_id: int
+    action_text: str
+    action_date: datetime
+    status: str
+    username: str
+    profile_img: Optional[str]
+
+    @classmethod
+    def map_entry_to_model(cls, task_id, history_entry, user):
+        return cls(
+            task_id=task_id,
+            action_text=history_entry.action_text,
+            action_date=history_entry.action_date,
+            status=history_entry.action_text.split()[5],
+            username=user.username if user else None,
+            profile_img=user.profile_img if user else None
+        )


### PR DESCRIPTION
# Updates

I tried updating task history in task-list. It was working fine. But to apply sorting and filtering operations for history list, it will be quite hectic since it is inside list of nested json. Using separate endpoint for only task history seems good idea and makes easy to apply filter.
This PR address this feature.
And yes, there are so many schemas with similar name, I will restructure those and use only required schemas.