### PR TITLE
hotfix: location str in create project

### DIFF
--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -198,7 +198,7 @@ async def search_project(
     return response
 
 
-@router.get("/{project_id}", response_model=project_schemas.ProjectOut)
+@router.get("/{project_id}", response_model=project_schemas.ReadProject)
 async def read_project(project_id: int, db: Session = Depends(database.get_db)):
     project = await project_crud.get_project_by_id(db, project_id)
     if not project:

--- a/src/backend/app/projects/project_schemas.py
+++ b/src/backend/app/projects/project_schemas.py
@@ -130,7 +130,7 @@ class ProjectBase(BaseModel):
     author: User
     project_info: ProjectInfo
     status: ProjectStatus
-    location_str: str
+    # location_str: str
     outline_geojson: Optional[GeojsonFeature] = None
     project_tasks: Optional[List[tasks_schemas.Task]]
     xform_title: Optional[str] = None
@@ -140,6 +140,10 @@ class ProjectBase(BaseModel):
 
 class ProjectOut(ProjectBase):
     project_uuid: uuid.UUID = uuid.uuid4()
+
+class ReadProject(ProjectBase):
+    project_uuid: uuid.UUID = uuid.uuid4()
+    location_str: str
 
 
 class BackgroundTaskStatus(BaseModel):


### PR DESCRIPTION
# Updates
I had previously uncommented the location string to enable its usage in the `read_project` function. However, the `create_project` also utilizes the same schema. In this case, only the project's general information is created, lacking the boundary data. Consequently, it fails to generate the location string, as these strings are derived from the centroid of the boundary.

This pull request addresses this issue by introducing a separate schema for the `read_project` function, resolving the problem associated with the location string.