### PR TITLE
Serialization for task_status and created project dashboard fields

### DIFF
--- a/src/backend/app/projects/project_schemas.py
+++ b/src/backend/app/projects/project_schemas.py
@@ -158,7 +158,7 @@ class ProjectDashboard(BaseModel):
     total_tasks: int
     total_submission: int
     total_contributors: int
-    created: datetime
+    created: str
     last_active: Optional[str] = None
 
     @field_validator("created", mode="before")

--- a/src/backend/app/projects/project_schemas.py
+++ b/src/backend/app/projects/project_schemas.py
@@ -161,7 +161,7 @@ class ProjectDashboard(BaseModel):
     total_contributors: Optional[int] = None
     last_active: Optional[str] = None
 
-    @field_validator("created", mode="before")
+    @field_validator("created", mode="after")
     def get_created(cls, value, values):
         date = value.strftime("%d %b %Y")
         return date

--- a/src/backend/app/projects/project_schemas.py
+++ b/src/backend/app/projects/project_schemas.py
@@ -18,11 +18,12 @@
 
 import uuid
 from datetime import datetime
-from dateutil import parser
 from typing import List, Optional
 
+from dateutil import parser
 from geojson_pydantic import Feature as GeojsonFeature
-from pydantic import BaseModel, field_validator
+from pydantic import BaseModel, ValidationInfo
+from pydantic.functional_serializers import field_serializer
 
 from app.db import db_models
 from app.models.enums import ProjectPriority, ProjectStatus, TaskSplitType
@@ -141,6 +142,7 @@ class ProjectBase(BaseModel):
 class ProjectOut(ProjectBase):
     project_uuid: uuid.UUID = uuid.uuid4()
 
+
 class ReadProject(ProjectBase):
     project_uuid: uuid.UUID = uuid.uuid4()
     location_str: str
@@ -161,13 +163,13 @@ class ProjectDashboard(BaseModel):
     total_contributors: Optional[int] = None
     last_active: Optional[str] = None
 
-    @field_validator("created", mode="after")
-    def get_created(cls, value, values):
+    @field_serializer("created")
+    def get_created(self, value: datetime, info: ValidationInfo):
         date = value.strftime("%d %b %Y")
         return date
-    
-    @field_validator("last_active", mode="before")
-    def get_last_active(cls, value, values):
+
+    @field_serializer("last_active")
+    def get_last_active(self, value: datetime, info: ValidationInfo):
         if value is None:
             return None
 
@@ -179,9 +181,9 @@ class ProjectDashboard(BaseModel):
         days_difference = time_difference.days
 
         if days_difference == 0:
-            return 'today'
+            return "today"
         elif days_difference == 1:
-            return 'yesterday'
+            return "yesterday"
         elif days_difference < 7:
             return f'{days_difference} day{"s" if days_difference > 1 else ""} ago'
         else:

--- a/src/backend/app/projects/project_schemas.py
+++ b/src/backend/app/projects/project_schemas.py
@@ -22,8 +22,7 @@ from typing import List, Optional
 
 from dateutil import parser
 from geojson_pydantic import Feature as GeojsonFeature
-from pydantic import BaseModel, ValidationInfo
-from pydantic.functional_serializers import field_serializer
+from pydantic import BaseModel
 
 from app.db import db_models
 from app.models.enums import ProjectPriority, ProjectStatus, TaskSplitType
@@ -163,13 +162,8 @@ class ProjectDashboard(BaseModel):
     total_contributors: Optional[int] = None
     last_active: Optional[str] = None
 
-    @field_serializer("created")
-    def get_created(self, value: datetime, info: ValidationInfo):
-        date = value.strftime("%d %b %Y")
-        return date
-
-    @field_serializer("last_active")
-    def get_last_active(self, value: datetime, info: ValidationInfo):
+    @field_validator("last_active", mode="before")
+    def get_last_active(cls, value, values):
         if value is None:
             return None
 

--- a/src/backend/app/tasks/tasks_schemas.py
+++ b/src/backend/app/tasks/tasks_schemas.py
@@ -66,7 +66,7 @@ class TaskBase(BaseModel):
     outline_geojson: Optional[Feature] = None
     outline_centroid: Optional[Feature] = None
     initial_feature_count: Optional[int] = None
-    task_status: TaskStatus
+    task_status: str
     locked_by_uid: Optional[int] = None
     locked_by_username: Optional[str] = None
     task_history: Optional[List[TaskHistoryBase]] = None

--- a/src/backend/app/tasks/tasks_schemas.py
+++ b/src/backend/app/tasks/tasks_schemas.py
@@ -66,12 +66,12 @@ class TaskBase(BaseModel):
     outline_geojson: Optional[Feature] = None
     outline_centroid: Optional[Feature] = None
     initial_feature_count: Optional[int] = None
-    task_status: str
+    task_status: TaskStatus
     locked_by_uid: Optional[int] = None
     locked_by_username: Optional[str] = None
     task_history: Optional[List[TaskHistoryBase]] = None
 
-    @field_validator("task_status", mode="before")
+    @field_validator("task_status", mode="after")
     def get_enum_name(cls, value, values):
         if isinstance(value, int):
             try:
@@ -80,8 +80,10 @@ class TaskBase(BaseModel):
                 raise ValueError(
                     f"Invalid integer value for task_status: {value}"
                 ) from e
-        return value
-
+        elif isinstance(value, TaskStatus):
+            return TaskStatus(value).name
+        else:
+            return value
     @field_validator("outline_geojson", mode="before")
     @classmethod
     def get_geojson_from_outline(cls, v: Any, info: ValidationInfo) -> str:

--- a/src/backend/app/tasks/tasks_schemas.py
+++ b/src/backend/app/tasks/tasks_schemas.py
@@ -73,20 +73,6 @@ class TaskBase(BaseModel):
     locked_by_username: Optional[str] = None
     task_history: Optional[List[TaskHistoryBase]] = None
 
-    @field_validator("task_status", mode="after")
-    def get_enum_name(cls, value: Any, info: ValidationInfo):
-        if isinstance(value, int):
-            try:
-                return TaskStatus(value).name
-            except ValueError as e:
-                raise ValueError(
-                    f"Invalid integer value for task_status: {value}"
-                ) from e
-        elif isinstance(value, TaskStatus):
-            return TaskStatus(value).name
-        else:
-            return value
-
     @field_validator("outline_geojson", mode="before")
     @classmethod
     def get_geojson_from_outline(cls, value: Any, info: ValidationInfo) -> str:

--- a/src/backend/app/tasks/tasks_schemas.py
+++ b/src/backend/app/tasks/tasks_schemas.py
@@ -25,6 +25,7 @@ from typing import Any, List, Optional
 from geojson_pydantic import Feature
 from loguru import logger as log
 from pydantic import BaseModel, ConfigDict, Field, ValidationInfo
+from pydantic.functional_serializers import field_serializer
 from pydantic.functional_validators import field_validator
 
 from app.db.postgis_utils import geometry_to_geojson, get_centroid
@@ -41,6 +42,7 @@ class TaskHistoryBase(BaseModel):
 
 class TaskHistoryOut(TaskHistoryBase):
     """Task mapping history display."""
+
     status: str
     username: str
     profile_img: Optional[str]
@@ -72,7 +74,7 @@ class TaskBase(BaseModel):
     task_history: Optional[List[TaskHistoryBase]] = None
 
     @field_validator("task_status", mode="after")
-    def get_enum_name(cls, value, values):
+    def get_enum_name(cls, value: Any, info: ValidationInfo):
         if isinstance(value, int):
             try:
                 return TaskStatus(value).name
@@ -84,9 +86,10 @@ class TaskBase(BaseModel):
             return TaskStatus(value).name
         else:
             return value
+
     @field_validator("outline_geojson", mode="before")
     @classmethod
-    def get_geojson_from_outline(cls, v: Any, info: ValidationInfo) -> str:
+    def get_geojson_from_outline(cls, value: Any, info: ValidationInfo) -> str:
         """Get outline_geojson from Shapely geom."""
         if outline := info.data.get("outline"):
             properties = {
@@ -100,7 +103,7 @@ class TaskBase(BaseModel):
 
     @field_validator("outline_centroid", mode="before")
     @classmethod
-    def get_centroid_from_outline(cls, v: Any, info: ValidationInfo) -> str:
+    def get_centroid_from_outline(cls, value: Any, info: ValidationInfo) -> str:
         """Get outline_centroid from Shapely geom."""
         if outline := info.data.get("outline"):
             properties = {
@@ -112,17 +115,15 @@ class TaskBase(BaseModel):
             return get_centroid(outline, properties, info.data.get("id"))
         return None
 
-    @field_validator("locked_by_uid", mode="before")
-    @classmethod
-    def get_lock_uid(cls, v: int, info: ValidationInfo) -> str:
+    @field_serializer("locked_by_uid")
+    def get_lock_uid(self, value: int, info: ValidationInfo) -> str:
         """Get lock uid from lock_holder details."""
         if lock_holder := info.data.get("lock_holder"):
             return lock_holder.id
         return None
 
-    @field_validator("locked_by_username", mode="before")
-    @classmethod
-    def get_lock_username(cls, v: str, info: ValidationInfo) -> str:
+    @field_serializer("locked_by_username")
+    def get_lock_username(self, value: str, info: ValidationInfo) -> str:
         """Get lock username from lock_holder details."""
         if lock_holder := info.data.get("lock_holder"):
             return lock_holder.username
@@ -136,7 +137,7 @@ class Task(TaskBase):
 
     @field_validator("qr_code_base64", mode="before")
     @classmethod
-    def get_qrcode_base64(cls, v: Any, info: ValidationInfo) -> str:
+    def get_qrcode_base64(cls, value: Any, info: ValidationInfo) -> str:
         """Get base64 encoded qrcode."""
         if qr_code := info.data.get("qr_code"):
             log.debug(
@@ -147,6 +148,7 @@ class Task(TaskBase):
         else:
             log.warning(f"No QR code found for task ID {info.data.get('id')}")
             return ""
+
 
 class ReadTask(Task):
     """Task details plus updated task history."""


### PR DESCRIPTION
# Updates
Previously, the `created` field in the `ProjectDashboard` model was of type `datetime` and `task_status` field in the `TaskBase` model was of type enum class `TaskStatus`, causing a validation issue. 
This pull request resolves this issue.
