### PR TITLE
Optimze the performance of project dashboard

### DIFF
--- a/src/backend/app/projects/project_schemas.py
+++ b/src/backend/app/projects/project_schemas.py
@@ -154,11 +154,11 @@ class BackgroundTaskStatus(BaseModel):
 class ProjectDashboard(BaseModel):
     project_name_prefix: str
     organization: str
-    organization_logo: Optional[str] = None
     total_tasks: int
-    total_submission: int
-    total_contributors: int
     created: datetime
+    organization_logo: Optional[str] = None
+    total_submission: Optional[int] = None
+    total_contributors: Optional[int] = None
     last_active: Optional[str] = None
 
     @field_validator("created", mode="before")


### PR DESCRIPTION
# Updates
Previously, the `project_dashboard` endpoint was taking longer time to respond since the submission count was done by fetching all submissions from odk-central.
![Screenshot from 2024-01-03 16-30-23](https://github.com/hotosm/fmtm/assets/109404840/810232f4-ff63-4146-b2da-f3ace25e164c)

Thought to use similar approach like in `submission_page` endpoint. Here, submissions are fetched directly from s3 which seems faster. If there aren't any submissions in s3, it will run background task to upload the submissions from odk-central to s3 meanwhile it will pass '0' for no submissions.
![Screenshot from 2024-01-03 16-32-04](https://github.com/hotosm/fmtm/assets/109404840/6f43c2c6-428c-46b7-bf4c-f74c62ede09a)

