### PR TITLE
Minor Fixes in task split process

### DIFF
--- a/src/backend/app/projects/project_crud.py
+++ b/src/backend/app/projects/project_crud.py
@@ -2337,8 +2337,14 @@ def check_crs(input_geojson: Union[dict, FeatureCollection]):
     )
     if geometry_type == "MultiPolygon":
         first_coordinate = (
-            coordinates[0][0][0] if coordinates and coordinates[0] else None
+            coordinates[0][0] if coordinates and coordinates[0] else None
         )
+    elif geometry_type == "Point":
+        first_coordinate = coordinates if coordinates else None
+
+    elif geometry_type == "LineString":
+        first_coordinate = coordinates[0] if coordinates else None
+    
     else:
         first_coordinate = coordinates[0][0] if coordinates else None
 

--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -434,6 +434,16 @@ async def task_split(
 
     # read data extract
     parsed_extract = geojson.loads(await extract_geojson.read())
+
+    # Tags received are stringified
+    # Check if 'tags' is a string before attempting to load it and load to json if required.
+    for feature in parsed_extract.get('features', []):
+        properties = feature.get('properties', {})
+        tags_value = properties.get('tags', None)
+        
+        if isinstance(tags_value, str):
+            properties['tags'] = json.loads(tags_value)
+
     check_crs(parsed_extract)
 
     return await project_crud.split_geojson_into_tasks(

--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -435,15 +435,6 @@ async def task_split(
     # read data extract
     parsed_extract = geojson.loads(await extract_geojson.read())
 
-    # Tags received are stringified
-    # Check if 'tags' is a string before attempting to load it and load to json if required.
-    for feature in parsed_extract.get('features', []):
-        properties = feature.get('properties', {})
-        tags_value = properties.get('tags', None)
-        
-        if isinstance(tags_value, str):
-            properties['tags'] = json.loads(tags_value)
-
     check_crs(parsed_extract)
 
     return await project_crud.split_geojson_into_tasks(

--- a/src/frontend/src/components/createnewproject/DataExtract.tsx
+++ b/src/frontend/src/components/createnewproject/DataExtract.tsx
@@ -67,7 +67,7 @@ const DataExtract = ({ flag, customLineUpload, setCustomLineUpload, customPolygo
         const uint8ArrayData = new Uint8Array(binaryData);
         // Deserialize the binary data
         const geojsonExtract = await fgbGeojson.deserialize(uint8ArrayData);
-        dispatch(CreateProjectActions.setDataExtractGeojson(geojsonExtract));
+        await dispatch(CreateProjectActions.setDataExtractGeojson(geojsonExtract));
       } catch (error) {
         // TODO add error message for user
         console.error('Error getting data extract:', error);
@@ -134,7 +134,7 @@ const DataExtract = ({ flag, customLineUpload, setCustomLineUpload, customPolygo
     }
 
     // View on map
-    dispatch(CreateProjectActions.setDataExtractGeojson(extractFeatCol));
+    await dispatch(CreateProjectActions.setDataExtractGeojson(extractFeatCol));
   };
 
   const resetFile = (setDataExtractToState) => {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert


### Description
This PR tries to solve the issues in split algorithm, fixes #1090

### Problems and their Solutions
1.**Frontend:** task_split endpoint did not receive any data extracts, it rather received a file with `null` in it. 
    I have awaited setDataExtractGeojson in frontend which in result provide the data extracts obtained from get_data_extracts to this endpoint

      ```
       await dispatch(CreateProjectActions.setDataExtractGeojson(geojsonExtract));
      ```
2.  **Backend;** After the task_split endpoint received the data extracts, it had the tags in the stringified form. `split_by_sql` required tags in the json format, I needed to update that in the json format.

```
    # Tags received are stringified
    # Check if 'tags' is a string before attempting to load it and load to json if required.
    for feature in parsed_extract.get('features', []):
        properties = feature.get('properties', {})
        tags_value = properties.get('tags', None)

        if isinstance(tags_value, str):
            properties['tags'] = json.loads(tags_value)

```