### PR TITLE
Use organisation manager table for organisation admins

### DIFF
--- a/src/backend/app/models/enums.py
+++ b/src/backend/app/models/enums.py
@@ -110,7 +110,6 @@ class ProjectRole(IntEnum, Enum):
         - FIELD_MANAGER = can invite mappers and organise people
         - ASSOCIATE_PROJECT_MANAGER = helps the project manager, cannot delete project
         - PROJECT_MANAGER = has all permissions to manage a project, including delete
-        - ORGANIZATION_ADMIN = has project manager permissions for all projects in org
     """
 
     MAPPER = 0
@@ -118,7 +117,6 @@ class ProjectRole(IntEnum, Enum):
     FIELD_MANAGER = 2
     ASSOCIATE_PROJECT_MANAGER = 3
     PROJECT_MANAGER = 4
-    ORGANIZATION_ADMIN = 5
 
 
 class MappingLevel(IntEnum, Enum):

--- a/src/backend/migrations/003-project-roles.sql
+++ b/src/backend/migrations/003-project-roles.sql
@@ -10,8 +10,7 @@ CREATE TYPE public.projectrole as ENUM (
     'VALIDATOR',
     'FIELD_MANAGER',
     'ASSOCIATE_PROJECT_MANAGER',
-    'PROJECT_MANAGER',
-    'ORGANIZATION_ADMIN'
+    'PROJECT_MANAGER'
 );
 ALTER TABLE public.user_roles ALTER COLUMN "role" TYPE VARCHAR(24);
 ALTER TABLE public.user_roles ALTER COLUMN "role" TYPE public.projectrole USING role::public.projectrole;

--- a/src/backend/migrations/init/fmtm_base_schema.sql
+++ b/src/backend/migrations/init/fmtm_base_schema.sql
@@ -140,8 +140,7 @@ CREATE TYPE public.projectrole as ENUM (
     'VALIDATOR',
     'FIELD_MANAGER',
     'ASSOCIATE_PROJECT_MANAGER',
-    'PROJECT_MANAGER',
-    'ORGANIZATION_ADMIN'
+    'PROJECT_MANAGER'
 );
 ALTER TYPE public.projectrole OWNER TO fmtm;
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Describe this PR

- We missed that the organisation_managers table already exists in the schema.
- That is the correct place to track org admins, not in user_roles.

## Note

- While making this edit I noticed the inconsistency with naming between British and American English.
- The schema was 'inspired' by Tasking Manager, so both use British English in the DB.
  - This is hard to change, so we will keep it the same.
- For consistency we will update all code to use British English (organization --> organisation).
- Any user facing text will remain as American English `organization`.

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the FMTM Code of Conduct: <https://github.com/hotosm/fmtm/blob/main/CODE_OF_CONDUCT.md>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
