### PR TITLE
Map default odk credentials to organisations

### DIFF
--- a/src/backend/app/central/central_crud.py
+++ b/src/backend/app/central/central_crud.py
@@ -35,12 +35,12 @@ from app.db import db_models
 from app.projects import project_schemas
 
 
-def get_odk_project(odk_central: project_schemas.ODKCentral = None):
+def get_odk_project(odk_central: project_schemas.ODKCentralDecrypted = None):
     """Helper function to get the OdkProject with credentials."""
     if odk_central:
         url = odk_central.odk_central_url
         user = odk_central.odk_central_user
-        pw = odk_central.odk_central_password.get_secret_value()
+        pw = odk_central.odk_central_password
     else:
         log.debug("ODKCentral connection variables not set in function")
         log.debug("Attempting extraction from environment variables")
@@ -60,12 +60,12 @@ def get_odk_project(odk_central: project_schemas.ODKCentral = None):
     return project
 
 
-def get_odk_form(odk_central: project_schemas.ODKCentral = None):
+def get_odk_form(odk_central: project_schemas.ODKCentralDecrypted = None):
     """Helper function to get the OdkForm with credentials."""
     if odk_central:
         url = odk_central.odk_central_url
         user = odk_central.odk_central_user
-        pw = odk_central.odk_central_password.get_secret_value()
+        pw = odk_central.odk_central_password
 
     else:
         log.debug("ODKCentral connection variables not set in function")
@@ -86,12 +86,12 @@ def get_odk_form(odk_central: project_schemas.ODKCentral = None):
     return form
 
 
-def get_odk_app_user(odk_central: project_schemas.ODKCentral = None):
+def get_odk_app_user(odk_central: project_schemas.ODKCentralDecrypted = None):
     """Helper function to get the OdkAppUser with credentials."""
     if odk_central:
         url = odk_central.odk_central_url
         user = odk_central.odk_central_user
-        pw = odk_central.odk_central_password.get_secret_value()
+        pw = odk_central.odk_central_password
     else:
         log.debug("ODKCentral connection variables not set in function")
         log.debug("Attempting extraction from environment variables")
@@ -111,13 +111,15 @@ def get_odk_app_user(odk_central: project_schemas.ODKCentral = None):
     return form
 
 
-def list_odk_projects(odk_central: project_schemas.ODKCentral = None):
+def list_odk_projects(odk_central: project_schemas.ODKCentralDecrypted = None):
     """List all projects on a remote ODK Server."""
     project = get_odk_project(odk_central)
     return project.listProjects()
 
 
-def create_odk_project(name: str, odk_central: project_schemas.ODKCentral = None):
+def create_odk_project(
+    name: str, odk_central: project_schemas.ODKCentralDecrypted = None
+):
     """Create a project on a remote ODK Server."""
     project = get_odk_project(odk_central)
 
@@ -144,7 +146,7 @@ def create_odk_project(name: str, odk_central: project_schemas.ODKCentral = None
 
 
 async def delete_odk_project(
-    project_id: int, odk_central: project_schemas.ODKCentral = None
+    project_id: int, odk_central: project_schemas.ODKCentralDecrypted = None
 ):
     """Delete a project from a remote ODK Server."""
     # FIXME: when a project is deleted from Central, we have to update the
@@ -159,7 +161,7 @@ async def delete_odk_project(
 
 
 def delete_odk_app_user(
-    project_id: int, name: str, odk_central: project_schemas.ODKCentral = None
+    project_id: int, name: str, odk_central: project_schemas.ODKCentralDecrypted = None
 ):
     """Delete an app-user from a remote ODK Server."""
     odk_app_user = get_odk_app_user(odk_central)
@@ -202,7 +204,7 @@ def create_odk_xform(
     project_id: int,
     xform_id: str,
     filespec: str,
-    odk_credentials: project_schemas.ODKCentral = None,
+    odk_credentials: project_schemas.ODKCentralDecrypted = None,
     create_draft: bool = False,
     upload_media=True,
     convert_to_draft_when_publishing=True,
@@ -213,7 +215,7 @@ def create_odk_xform(
     # Pass odk credentials of project in xform
 
     if not odk_credentials:
-        odk_credentials = project_schemas.ODKCentral(
+        odk_credentials = project_schemas.ODKCentralDecrypted(
             odk_central_url=settings.ODK_CENTRAL_URL,
             odk_central_user=settings.ODK_CENTRAL_USER,
             odk_central_password=settings.ODK_CENTRAL_PASSWD,
@@ -245,7 +247,7 @@ def delete_odk_xform(
     project_id: int,
     xform_id: str,
     filespec: str,
-    odk_central: project_schemas.ODKCentral = None,
+    odk_central: project_schemas.ODKCentralDecrypted = None,
 ):
     """Delete an XForm from a remote ODK Central server."""
     xform = get_odk_form(odk_central)
@@ -256,7 +258,7 @@ def delete_odk_xform(
 
 def list_odk_xforms(
     project_id: int,
-    odk_central: project_schemas.ODKCentral = None,
+    odk_central: project_schemas.ODKCentralDecrypted = None,
     metadata: bool = False,
 ):
     """List all XForms in an ODK Central project."""
@@ -267,7 +269,7 @@ def list_odk_xforms(
 
 
 def get_form_full_details(
-    odk_project_id: int, form_id: str, odk_central: project_schemas.ODKCentral
+    odk_project_id: int, form_id: str, odk_central: project_schemas.ODKCentralDecrypted
 ):
     """Get additional metadata for ODK Form."""
     form = get_odk_form(odk_central)
@@ -276,7 +278,7 @@ def get_form_full_details(
 
 
 def get_odk_project_full_details(
-    odk_project_id: int, odk_central: project_schemas.ODKCentral
+    odk_project_id: int, odk_central: project_schemas.ODKCentralDecrypted
 ):
     """Get additional metadata for ODK project."""
     project = get_odk_project(odk_central)
@@ -284,7 +286,9 @@ def get_odk_project_full_details(
     return project_details
 
 
-def list_submissions(project_id: int, odk_central: project_schemas.ODKCentral = None):
+def list_submissions(
+    project_id: int, odk_central: project_schemas.ODKCentralDecrypted = None
+):
     """List all submissions for a project, aggregated from associated users."""
     project = get_odk_project(odk_central)
     xform = get_odk_form(odk_central)
@@ -326,7 +330,7 @@ def download_submissions(
     xform_id: str,
     submission_id: str = None,
     get_json: bool = True,
-    odk_central: project_schemas.ODKCentral = None,
+    odk_central: project_schemas.ODKCentralDecrypted = None,
 ):
     """Download all submissions for an XForm."""
     xform = get_odk_form(odk_central)
@@ -506,7 +510,7 @@ def upload_media(
     project_id: int,
     xform_id: str,
     filespec: str,
-    odk_central: project_schemas.ODKCentral = None,
+    odk_central: project_schemas.ODKCentralDecrypted = None,
 ):
     """Upload a data file to Central."""
     xform = get_odk_form(odk_central)
@@ -517,7 +521,7 @@ def download_media(
     project_id: int,
     xform_id: str,
     filespec: str,
-    odk_central: project_schemas.ODKCentral = None,
+    odk_central: project_schemas.ODKCentralDecrypted = None,
 ):
     """Upload a data file to Central."""
     xform = get_odk_form(odk_central)

--- a/src/backend/app/central/central_routes.py
+++ b/src/backend/app/central/central_routes.py
@@ -211,7 +211,7 @@ async def get_submission(
             return {"error": "No such project!"}
 
         # ODK Credentials
-        odk_credentials = project_schemas.ODKCentral(
+        odk_credentials = project_schemas.ODKCentralDecrypted(
             odk_central_url=first.odk_central_url,
             odk_central_user=first.odk_central_user,
             odk_central_password=first.odk_central_password,

--- a/src/backend/app/config.py
+++ b/src/backend/app/config.py
@@ -19,11 +19,16 @@
 
 import base64
 from functools import lru_cache
-from typing import Any, Optional, Union
+from typing import Annotated, Any, Optional, Union
 
 from cryptography.fernet import Fernet
-from pydantic import PostgresDsn, ValidationInfo, field_validator
+from pydantic import BeforeValidator, TypeAdapter, ValidationInfo, field_validator
+from pydantic.networks import HttpUrl, PostgresDsn
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+HttpUrlStr = Annotated[
+    str, BeforeValidator(lambda value: str(TypeAdapter(HttpUrl).validate_python(value)))
+]
 
 
 class Settings(BaseSettings):
@@ -100,14 +105,14 @@ class Settings(BaseSettings):
         )
         return pg_url
 
-    ODK_CENTRAL_URL: Optional[str] = ""
+    ODK_CENTRAL_URL: Optional[HttpUrlStr] = ""
     ODK_CENTRAL_USER: Optional[str] = ""
     ODK_CENTRAL_PASSWD: Optional[str] = ""
 
     OSM_CLIENT_ID: str
     OSM_CLIENT_SECRET: str
     OSM_SECRET_KEY: str
-    OSM_URL: str = "https://www.openstreetmap.org"
+    OSM_URL: HttpUrlStr = "https://www.openstreetmap.org"
     OSM_SCOPE: str = "read_prefs"
     OSM_LOGIN_REDIRECT_URI: str = "http://127.0.0.1:7051/osmauth/"
 
@@ -147,7 +152,7 @@ class Settings(BaseSettings):
                 return f"http://s3.{fmtm_domain}:{dev_port}"
             return f"https://s3.{fmtm_domain}"
 
-    UNDERPASS_API_URL: str = "https://api-prod.raw-data.hotosm.org/v1/"
+    UNDERPASS_API_URL: HttpUrlStr = "https://api-prod.raw-data.hotosm.org/v1/"
     SENTRY_DSN: Optional[str] = None
 
     model_config = SettingsConfigDict(

--- a/src/backend/app/organisations/organisation_crud.py
+++ b/src/backend/app/organisations/organisation_crud.py
@@ -98,7 +98,7 @@ async def create_organisation(
     if await get_organisation_by_name(db, org_name=org_model.name):
         raise HTTPException(
             status_code=HTTPStatus.CONFLICT,
-            detail=f"Organisation already exists with the name {org_model.name}",
+            detail=f"Organisation already exists with the name ({org_model.name})",
         )
 
     # Required to check if exists on error

--- a/src/backend/app/organisations/organisation_routes.py
+++ b/src/backend/app/organisations/organisation_routes.py
@@ -53,7 +53,6 @@ async def get_organisations(
 @router.get("/{org_id}", response_model=organisation_schemas.OrganisationOut)
 async def get_organisation_detail(
     organisation: DbOrganisation = Depends(org_exists),
-    db: Session = Depends(database.get_db),
 ):
     """Get a specific organisation by id or name."""
     return organisation
@@ -61,6 +60,7 @@ async def get_organisation_detail(
 
 @router.post("/", response_model=organisation_schemas.OrganisationOut)
 async def create_organisation(
+    # Depends required below to allow logo upload
     org: organisation_schemas.OrganisationIn = Depends(),
     logo: UploadFile = File(None),
     db: Session = Depends(database.get_db),

--- a/src/backend/app/organisations/organisation_schemas.py
+++ b/src/backend/app/organisations/organisation_schemas.py
@@ -38,18 +38,18 @@ class OrganisationIn(BaseModel):
     description: Optional[str] = Field(
         Form(None, description="Organisation description")
     )
-    url: Optional[HttpUrl] = Field(Form(None, description=("Organisation website URL")))
-    odk_central_url: Optional[str] = Field(
-        Form(None, description="Organisation default ODK URL")
+    url: Optional[HttpUrl] = Field(Form(None, description="Organisation website URL"))
+    odk_central_url: Optional[HttpUrl] = Field(
+        Form(None, description="Default ODK Central URL")
     )
     odk_central_user: Optional[str] = Field(
-        Form(None, description="Organisation default ODK User")
+        Form(None, description="Default ODK Central User")
     )
-    odk_central_password: Optional[SecretStr] = Field(
-        Form(None, description="Organisation default ODK Password")
+    odk_central_password: Optional[str] = Field(
+        Form(None, description="Default ODK Central Password")
     )
 
-    @field_validator("url", mode="after")
+    @field_validator("url", "odk_central_url", mode="after")
     @classmethod
     def convert_url_to_str(cls, value: HttpUrl) -> str:
         """Convert Pydantic Url type to string.

--- a/src/backend/app/projects/project_crud.py
+++ b/src/backend/app/projects/project_crud.py
@@ -1607,7 +1607,13 @@ async def convert_to_app_project(db_project: db_models.DbProject):
         return None
 
     log.debug("Converting db project to app project")
-    app_project: project_schemas.Project = db_project
+    app_project = db_project
+
+    if db_project.outline:
+        log.debug("Converting project outline to geojson")
+        app_project.outline_geojson = geometry_to_geojson(
+            db_project.outline, {"id": db_project.id}, db_project.id
+        )
 
     app_project.project_tasks = db_project.tasks
 

--- a/src/backend/app/projects/project_crud.py
+++ b/src/backend/app/projects/project_crud.py
@@ -57,6 +57,7 @@ from sqlalchemy import and_, column, func, inspect, select, table, text
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session
 
+from app.auth.osm import AuthUser
 from app.central import central_crud
 from app.config import encrypt_value, settings
 from app.db import db_models
@@ -203,7 +204,9 @@ async def partial_update_project_info(
 
 
 async def update_project_info(
-    db: Session, project_metadata: project_schemas.ProjectUpload, project_id
+    db: Session,
+    project_metadata: project_schemas.ProjectUpload,
+    project_id: int,
 ):
     """Full project update for PUT."""
     user = project_metadata.author
@@ -251,35 +254,18 @@ async def update_project_info(
 
 
 async def create_project_with_project_info(
-    db: Session, project_metadata: project_schemas.ProjectUpload, odk_project_id: int
+    db: Session,
+    project_metadata: project_schemas.ProjectUpload,
+    odk_project_id: int,
+    current_user: AuthUser,
 ):
     """Create a new project, including all associated info."""
     # FIXME the ProjectUpload model should be converted to the db model directly
     # FIXME we don't need to extract each variable and pass manually
     # project_data = project_metadata.model_dump()
 
-    project_user = project_metadata.author
-    project_info = project_metadata.project_info
-    xform_title = project_metadata.xform_title
-    odk_credentials = project_metadata.odk_central
-    hashtags = project_metadata.hashtags
-    organisation_id = project_metadata.organisation_id
-    task_split_type = project_metadata.task_split_type
-    task_split_dimension = project_metadata.task_split_dimension
-    task_num_buildings = project_metadata.task_num_buildings
-    data_extract_type = project_metadata.task_num_buildings
+    log.warning(project_metadata.model_dump())
 
-    # verify data coming in
-    if not project_user:
-        raise HTTPException(
-            status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
-            detail="User details are missing",
-        )
-    if not project_info:
-        raise HTTPException(
-            status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
-            detail="Project info is missing",
-        )
     if not odk_project_id:
         raise HTTPException(
             status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
@@ -288,71 +274,33 @@ async def create_project_with_project_info(
 
     log.debug(
         "Creating project in FMTM database with vars: "
-        f"project_user: {project_user} | "
-        f"project_info: {project_info} | "
-        f"xform_title: {xform_title} | "
-        f"hashtags: {hashtags}| "
-        f"organisation_id: {organisation_id}"
+        f"project_user: {current_user.username} | "
+        f"project_name: {project_metadata.project_info.name} | "
+        f"xform_title: {project_metadata.xform_title} | "
+        f"hashtags: {project_metadata.hashtags} | "
+        f"organisation_id: {project_metadata.organisation_id}"
     )
 
-    # Check / set credentials
-    if odk_credentials:
-        url = odk_credentials.odk_central_url
-        user = odk_credentials.odk_central_user
-        pw = odk_credentials.odk_central_password.get_secret_value()
+    # Extract project_info details, then remove key
+    project_name = project_metadata.project_info.name
+    project_description = project_metadata.project_info.description
+    project_short_description = project_metadata.project_info.short_description
 
-    else:
-        log.debug("ODKCentral connection variables not set in function")
-        log.debug("Attempting extraction from environment variables")
-        url = settings.ODK_CENTRAL_URL
-        user = settings.ODK_CENTRAL_USER
-        pw = settings.ODK_CENTRAL_PASSWD
-
-    # get db user
-    # TODO: get this from logged in user / request instead,
-    # return 403 (forbidden) if not authorized
-    db_user = await user_crud.get_user(db, project_user.id)
-    if not db_user:
-        raise HTTPException(
-            status_code=400, detail=f"User {project_user.username} does not exist"
-        )
-
-    hashtags = (
-        list(
-            map(
-                lambda hashtag: hashtag if hashtag.startswith("#") else f"#{hashtag}",
-                hashtags,
-            )
-        )
-        if hashtags
-        else None
-    )
     # create new project
     db_project = db_models.DbProject(
-        author=db_user,
+        author_id=current_user.id,
         odkid=odk_project_id,
-        project_name_prefix=project_info.name,
-        xform_title=xform_title,
-        odk_central_url=url,
-        odk_central_user=user,
-        odk_central_password=pw,
-        hashtags=hashtags,
-        organisation_id=organisation_id,
-        task_split_type=task_split_type,
-        task_split_dimension=task_split_dimension,
-        task_num_buildings=task_num_buildings,
-        data_extract_type=data_extract_type,
-        # country=[project_metadata.country],
-        # location_str=f"{project_metadata.city}, {project_metadata.country}",
+        project_name_prefix=project_name,
+        **project_metadata.model_dump(exclude=["project_info"]),
     )
     db.add(db_project)
 
     # add project info (project id needed to create project info)
     db_project_info = db_models.DbProjectInfo(
         project=db_project,
-        name=project_info.name,
-        short_description=project_info.short_description,
-        description=project_info.description,
+        name=project_name,
+        short_description=project_short_description,
+        description=project_description,
     )
     db.add(db_project_info)
 
@@ -1171,7 +1119,7 @@ def generate_task_files(
     task_id: int,
     xlsform: str,
     form_type: str,
-    odk_credentials: project_schemas.ODKCentral,
+    odk_credentials: project_schemas.ODKCentralDecrypted,
 ):
     """Generate all files for a task."""
     project_log = log.bind(task="create_project", project_id=project_id)
@@ -1194,7 +1142,7 @@ def generate_task_files(
     appuser = OdkAppUser(
         odk_credentials.odk_central_url,
         odk_credentials.odk_central_user,
-        odk_credentials.odk_central_password.get_secret_value(),
+        odk_credentials.odk_central_password,
     )
     appuser_json = appuser.create(odk_id, appuser_name)
 
@@ -1370,7 +1318,7 @@ def generate_appuser_files(
                 "odk_central_password": one.odk_central_password,
             }
 
-            odk_credentials = project_schemas.ODKCentral(**odk_credentials)
+            odk_credentials = project_schemas.ODKCentralDecrypted(**odk_credentials)
 
             xform_title = one.xform_title if one.xform_title else None
 
@@ -1661,12 +1609,6 @@ async def convert_to_app_project(db_project: db_models.DbProject):
     log.debug("Converting db project to app project")
     app_project: project_schemas.Project = db_project
 
-    if db_project.outline:
-        log.debug("Converting project outline to geojson")
-        app_project.outline_geojson = geometry_to_geojson(
-            db_project.outline, {"id": db_project.id}, db_project.id
-        )
-
     app_project.project_tasks = db_project.tasks
 
     return app_project
@@ -1883,7 +1825,7 @@ async def update_project_form(
     odk_id = project.odkid
 
     # ODK Credentials
-    odk_credentials = project_schemas.ODKCentral(
+    odk_credentials = project_schemas.ODKCentralDecrypted(
         odk_central_url=project.odk_central_url,
         odk_central_user=project.odk_central_user,
         odk_central_password=project.odk_central_password,

--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -89,7 +89,7 @@ async def get_projet_details(project_id: int, db: Session = Depends(database.get
         raise HTTPException(status_code=404, details={"Project not found"})
 
     # ODK Credentials
-    odk_credentials = project_schemas.ODKCentral(
+    odk_credentials = project_schemas.ODKCentralDecrypted(
         odk_central_url=project.odk_central_url,
         odk_central_user=project.odk_central_user,
         odk_central_password=project.odk_central_password,
@@ -223,7 +223,7 @@ async def delete_project(
         f"User {current_user.username} attempting deletion of project {project.id}"
     )
     # Odk crendentials
-    odk_credentials = project_schemas.ODKCentral(
+    odk_credentials = project_schemas.ODKCentralDecrypted(
         odk_central_url=project.odk_central_url,
         odk_central_user=project.odk_central_user,
         odk_central_password=project.odk_central_password,
@@ -240,6 +240,7 @@ async def delete_project(
 @router.post("/create_project", response_model=project_schemas.ProjectOut)
 async def create_project(
     project_info: project_schemas.ProjectUpload,
+    current_user: AuthUser = Depends(login_required),
     db: Session = Depends(database.get_db),
 ):
     """Create a project in ODK Central and the local database.
@@ -247,14 +248,36 @@ async def create_project(
     TODO refactor to standard REST POST to /projects
     TODO but first check doesn't break other endpoints
     """
+    # Check if organisation exists
+    org = await organisation_deps.check_org_exists(db, project_info.organisation_id)
+
     log.debug(f"Creating project {project_info.project_info.name}")
 
+    # Must decrypt ODK password & connect to ODK Central before proj created
+    if project_info.odk_central_url:
+        odk_creds_decrypted = project_schemas.ODKCentralDecrypted(
+            odk_central_url=project_info.odk_central_url,
+            odk_central_user=project_info.odk_central_user,
+            odk_central_password=project_info.odk_central_password,
+        )
+    else:
+        # Use default org credentials if none passed
+        log.debug(
+            "No odk credentials passed during project creation. "
+            "Defaulting to organisation credentials."
+        )
+        odk_creds_decrypted = await organisation_deps.get_org_odk_creds(org)
+
     odkproject = central_crud.create_odk_project(
-        project_info.project_info.name, project_info.odk_central
+        project_info.project_info.name,
+        odk_creds_decrypted,
     )
 
     project = await project_crud.create_project_with_project_info(
-        db, project_info, odkproject["id"]
+        db,
+        project_info,
+        odkproject["id"],
+        current_user,
     )
     if not project:
         raise HTTPException(status_code=404, detail="Project creation failed")
@@ -266,6 +289,7 @@ async def create_project(
 async def update_project(
     id: int,
     project_info: project_schemas.ProjectUpload,
+    current_user: AuthUser = Depends(login_required),
     db: Session = Depends(database.get_db),
 ):
     """Update an existing project by ID.
@@ -275,7 +299,6 @@ async def update_project(
 
     Parameters:
     - id: ID of the project to update
-    - author: Author username and id
     - project_info: Updated project information
 
     Returns:
@@ -544,7 +567,7 @@ async def generate_files(
     xls_form_config_file: Optional[UploadFile] = File(None),
     data_extracts: Optional[UploadFile] = File(None),
     db: Session = Depends(database.get_db),
-    # current_user: AuthUser = Depends(login_required),
+    current_user: AuthUser = Depends(login_required),
 ):
     """Generate additional content to initialise the project.
 
@@ -568,6 +591,7 @@ async def generate_files(
         xls_form_config_file (UploadFile, optional): The config YAML for the XLS form.
         data_extracts (UploadFile, optional): Custom data extract GeoJSON.
         db (Session): Database session, provided automatically.
+        current_user (AuthUser): Current logged in user.
 
     Returns:
         json (JSONResponse): A success message containing the project ID.

--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -215,8 +215,8 @@ async def read_project(project_id: int, db: Session = Depends(database.get_db)):
 @router.delete("/{project_id}")
 async def delete_project(
     project: db_models.DbProject = Depends(project_deps.get_project_by_id),
-    db: Session = Depends(database.get_db),
     current_user: AuthUser = Depends(login_required),
+    db: Session = Depends(database.get_db),
 ):
     """Delete a project from both ODK Central and the local database."""
     log.info(
@@ -251,7 +251,10 @@ async def create_project(
     # Check if organisation exists
     org = await organisation_deps.check_org_exists(db, project_info.organisation_id)
 
-    log.debug(f"Creating project {project_info.project_info.name}")
+    log.info(
+        f"User {current_user.username} attempting creation of project "
+        f"{project_info.project_info.name}"
+    )
 
     # Must decrypt ODK password & connect to ODK Central before proj created
     if project_info.odk_central_url:

--- a/src/backend/app/projects/project_schemas.py
+++ b/src/backend/app/projects/project_schemas.py
@@ -62,7 +62,6 @@ class ODKCentralIn(BaseModel):
     @model_validator(mode="after")
     def all_odk_vars_together(self) -> Self:
         """Ensure if one ODK variable is set, then all are."""
-        log.warning(self.odk_central_url)
         if any(
             [
                 self.odk_central_url,

--- a/src/backend/app/submissions/submission_crud.py
+++ b/src/backend/app/submissions/submission_crud.py
@@ -72,7 +72,7 @@ def get_submission_of_project(db: Session, project_id: int, task_id: int = None)
         )
 
     # ODK Credentials
-    odk_credentials = project_schemas.ODKCentral(
+    odk_credentials = project_schemas.ODKCentralDecrypted(
         odk_central_url=project_info.odk_central_url,
         odk_central_user=project_info.odk_central_user,
         odk_central_password=project_info.odk_central_password,
@@ -151,7 +151,7 @@ def convert_to_osm(db: Session, project_id: int, task_id: int):
     form_category = project_info.xform_title
 
     # ODK Credentials
-    odk_credentials = project_schemas.ODKCentral(
+    odk_credentials = project_schemas.ODKCentralDecrypted(
         odk_central_url=project_info.odk_central_url,
         odk_central_user=project_info.odk_central_user,
         odk_central_password=project_info.odk_central_password,
@@ -235,7 +235,7 @@ def gather_all_submission_csvs(db, project_id):
     project_tasks = project_info.tasks
 
     # ODK Credentials
-    odk_credentials = project_schemas.ODKCentral(
+    odk_credentials = project_schemas.ODKCentralDecrypted(
         odk_central_url=project_info.odk_central_url,
         odk_central_user=project_info.odk_central_user,
         odk_central_password=project_info.odk_central_password,
@@ -330,7 +330,7 @@ def update_submission_in_s3(
         project = get_project_sync(db, project_id)
 
         # Gather metadata
-        odk_credentials = project_schemas.ODKCentral(
+        odk_credentials = project_schemas.ODKCentralDecrypted(
             odk_central_url=project.odk_central_url,
             odk_central_user=project.odk_central_user,
             odk_central_password=project.odk_central_password,
@@ -427,7 +427,7 @@ def get_all_submissions_json(db: Session, project_id):
     project_info = get_project_sync(db, project_id)
 
     # ODK Credentials
-    odk_credentials = project_schemas.ODKCentral(
+    odk_credentials = project_schemas.ODKCentralDecrypted(
         odk_central_url=project_info.odk_central_url,
         odk_central_user=project_info.odk_central_user,
         odk_central_password=project_info.odk_central_password,
@@ -457,7 +457,7 @@ def get_all_submissions_json(db: Session, project_id):
 #     project_tasks = project_info.tasks
 
 #     # ODK Credentials
-#     odk_credentials = project_schemas.ODKCentral(
+#     odk_credentials = project_schemas.ODKCentralDecrypted(
 #         odk_central_url=project_info.odk_central_url,
 #         odk_central_user=project_info.odk_central_user,
 #         odk_central_password=project_info.odk_central_password,
@@ -499,7 +499,7 @@ async def download_submission(
     project_tasks = project_info.tasks
 
     # ODK Credentials
-    odk_credentials = project_schemas.ODKCentral(
+    odk_credentials = project_schemas.ODKCentralDecrypted(
         odk_central_url=project_info.odk_central_url,
         odk_central_user=project_info.odk_central_user,
         odk_central_password=project_info.odk_central_password,
@@ -609,7 +609,7 @@ async def get_submission_points(db: Session, project_id: int, task_id: int = Non
     form_category = project_info.xform_title
 
     # ODK Credentials
-    odk_credentials = project_schemas.ODKCentral(
+    odk_credentials = project_schemas.ODKCentralDecrypted(
         odk_central_url=project_info.odk_central_url,
         odk_central_user=project_info.odk_central_user,
         odk_central_password=project_info.odk_central_password,
@@ -674,7 +674,7 @@ async def get_submission_count_of_a_project(db: Session, project_id: int):
     project_tasks = project_info.tasks
 
     # ODK Credentials
-    odk_credentials = project_schemas.ODKCentral(
+    odk_credentials = project_schemas.ODKCentralDecrypted(
         odk_central_url=project_info.odk_central_url,
         odk_central_user=project_info.odk_central_user,
         odk_central_password=project_info.odk_central_password,
@@ -818,7 +818,7 @@ async def get_submission_by_task(
     Returns:
         Tuple: A tuple containing the list of submissions and the count.
     """
-    odk_credentials = project_schemas.ODKCentral(
+    odk_credentials = project_schemas.ODKCentralDecrypted(
         odk_central_url=project.odk_central_url,
         odk_central_user=project.odk_central_user,
         odk_central_password=project.odk_central_password,

--- a/src/backend/app/tasks/tasks_routes.py
+++ b/src/backend/app/tasks/tasks_routes.py
@@ -162,7 +162,7 @@ async def task_features_count(
     project = await project_crud.get_project(db, project_id)
 
     # ODK Credentials
-    odk_credentials = project_schemas.ODKCentral(
+    odk_credentials = project_schemas.ODKCentralDecrypted(
         odk_central_url=project.odk_central_url,
         odk_central_user=project.odk_central_user,
         odk_central_password=project.odk_central_password,

--- a/src/backend/app/tasks/tasks_schemas.py
+++ b/src/backend/app/tasks/tasks_schemas.py
@@ -20,7 +20,7 @@
 from datetime import datetime
 from typing import Any, List, Optional
 
-from geojson_pydantic import Feature
+from geojson_pydantic import Feature as GeojsonFeature
 from loguru import logger as log
 from pydantic import BaseModel, ConfigDict, Field, ValidationInfo
 from pydantic.functional_serializers import field_serializer
@@ -71,8 +71,8 @@ class Task(BaseModel):
     project_id: int
     project_task_index: int
     project_task_name: str
-    outline_geojson: Optional[Feature] = None
-    outline_centroid: Optional[Feature] = None
+    outline_geojson: Optional[GeojsonFeature] = None
+    outline_centroid: Optional[GeojsonFeature] = None
     initial_feature_count: Optional[int] = None
     task_status: TaskStatus
     locked_by_uid: Optional[int] = None

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -29,14 +29,14 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy_utils import create_database, database_exists
 
+from app.auth.osm import AuthUser
 from app.central import central_crud
 from app.config import settings
 from app.db.database import Base, get_db
 from app.db.db_models import DbOrganisation, DbUser
 from app.main import get_application
 from app.projects import project_crud
-from app.projects.project_schemas import ODKCentral, ProjectInfo, ProjectUpload
-from app.users.user_schemas import User
+from app.projects.project_schemas import ODKCentralDecrypted, ProjectInfo, ProjectUpload
 
 engine = create_engine(settings.FMTM_DB_URL.unicode_string())
 TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
@@ -102,6 +102,7 @@ def organisation(db):
         description="test org",
         url="https://test.org",
         logo="none",
+        approved=True,
     )
     db.add(db_org)
     db.commit()
@@ -112,32 +113,30 @@ def organisation(db):
 async def project(db, user, organisation):
     """A test project, using the test user and org."""
     project_metadata = ProjectUpload(
-        author=User(username=user.username, id=user.id),
         project_info=ProjectInfo(
             name="test project",
             short_description="test",
             description="test",
         ),
         xform_title="buildings",
-        odk_central=ODKCentral(
-            odk_central_url=os.getenv("ODK_CENTRAL_URL"),
-            odk_central_user=os.getenv("ODK_CENTRAL_USER"),
-            odk_central_password=os.getenv("ODK_CENTRAL_PASSWD"),
-        ),
+        odk_central_url=os.getenv("ODK_CENTRAL_URL"),
+        odk_central_user=os.getenv("ODK_CENTRAL_USER"),
+        odk_central_password=os.getenv("ODK_CENTRAL_PASSWD"),
         hashtags=["hot-fmtm"],
         organisation_id=organisation.id,
     )
 
-    # Create ODK Central Project
-    if project_metadata.odk_central.odk_central_url.endswith("/"):
-        # Remove trailing slash
-        project_metadata.odk_central.odk_central_url = (
-            project_metadata.odk_central.odk_central_url[:-1]
-        )
+    odk_creds_decrypted = ODKCentralDecrypted(
+        odk_central_url=project_metadata.odk_central_url,
+        odk_central_user=project_metadata.odk_central_user,
+        odk_central_password=project_metadata.odk_central_password,
+    )
 
+    # Create ODK Central Project
     try:
         odkproject = central_crud.create_odk_project(
-            project_metadata.project_info.name, project_metadata.odk_central
+            project_metadata.project_info.name,
+            odk_creds_decrypted,
         )
         log.debug(f"ODK project returned: {odkproject}")
         assert odkproject is not None
@@ -148,7 +147,10 @@ async def project(db, user, organisation):
     # Create FMTM Project
     try:
         new_project = await project_crud.create_project_with_project_info(
-            db, project_metadata, odkproject["id"]
+            db,
+            project_metadata,
+            odkproject["id"],
+            AuthUser(username=user.username, id=user.id),
         )
         log.debug(f"Project returned: {new_project.__dict__}")
         assert new_project is not None

--- a/src/backend/tests/test_projects_routes.py
+++ b/src/backend/tests/test_projects_routes.py
@@ -33,7 +33,7 @@ from shapely import Polygon, wkb
 from shapely.geometry import shape
 
 from app.central.central_crud import create_odk_project
-from app.config import settings
+from app.config import encrypt_value, settings
 from app.db import db_models
 from app.projects import project_crud, project_schemas
 from app.tasks import tasks_crud
@@ -41,27 +41,29 @@ from tests.test_data import test_data_path
 
 odk_central_url = os.getenv("ODK_CENTRAL_URL")
 odk_central_user = os.getenv("ODK_CENTRAL_USER")
-odk_central_password = os.getenv("ODK_CENTRAL_PASSWD")
+odk_central_password = encrypt_value(os.getenv("ODK_CENTRAL_PASSWD", ""))
 
 
-async def test_create_project(client, organisation, user):
+async def test_create_project(client, organisation):
     """Test project creation endpoint."""
+    odk_credentials = {
+        "odk_central_url": odk_central_url,
+        "odk_central_user": odk_central_user,
+        "odk_central_password": odk_central_password,
+    }
+    odk_credentials = project_schemas.ODKCentralDecrypted(**odk_credentials)
+
     project_data = {
-        "author": {"username": user.username, "id": user.id},
         "project_info": {
             "name": "test project",
             "short_description": "test",
             "description": "test",
         },
         "xform_title": "buildings",
-        "odk_central": {
-            "odk_central_url": odk_central_url,
-            "odk_central_user": odk_central_user,
-            "odk_central_password": odk_central_password,
-        },
-        "hashtags": ["hot-fmtm"],
+        "hashtags": ["#FMTM"],
         "organisation_id": organisation.id,
     }
+    project_data.update(**odk_credentials.model_dump())
 
     response = client.post("/projects/create_project", json=project_data)
 
@@ -133,7 +135,7 @@ async def test_generate_appuser_files(db, project):
         "odk_central_user": odk_central_user,
         "odk_central_password": odk_central_password,
     }
-    odk_credentials = project_schemas.ODKCentral(**odk_credentials)
+    odk_credentials = project_schemas.ODKCentralDecrypted(**odk_credentials)
 
     project_id = project.id
     log.debug(f"Testing project ID: {project_id}")

--- a/src/frontend/src/components/MapComponent/OpenLayersComponent/LayerSwitcher/index.js
+++ b/src/frontend/src/components/MapComponent/OpenLayersComponent/LayerSwitcher/index.js
@@ -164,7 +164,7 @@ const LayerSwitcherControl = ({ map, visible = 'osm' }) => {
     if (
       location.pathname.includes('project_details') ||
       location.pathname.includes('upload-area') ||
-      location.pathname.includes('select-form') ||
+      location.pathname.includes('select-category') ||
       location.pathname.includes('data-extract') ||
       location.pathname.includes('split-tasks')
     ) {

--- a/src/frontend/src/components/createnewproject/DataExtract.tsx
+++ b/src/frontend/src/components/createnewproject/DataExtract.tsx
@@ -141,7 +141,7 @@ const DataExtract = ({ flag, customLineUpload, setCustomLineUpload, customPolygo
   }, [formValues?.dataExtractWays, formValues?.dataExtractFeatureType]);
 
   const toggleStep = (step, url) => {
-    if (url === '/select-form') {
+    if (url === '/select-category') {
       dispatch(
         CreateProjectActions.SetIndividualProjectDetailsData({
           ...formValues,
@@ -326,7 +326,7 @@ const DataExtract = ({ flag, customLineUpload, setCustomLineUpload, customPolygo
                 btnText="PREVIOUS"
                 btnType="secondary"
                 type="button"
-                onClick={() => toggleStep(3, '/select-form')}
+                onClick={() => toggleStep(3, '/select-category')}
                 className="fmtm-font-bold"
               />
               <Button

--- a/src/frontend/src/components/createnewproject/ProjectDetailsForm.tsx
+++ b/src/frontend/src/components/createnewproject/ProjectDetailsForm.tsx
@@ -51,27 +51,12 @@ const ProjectDetailsForm = ({ flag }) => {
     };
   }, []);
 
-  const hashtagPrefix = '#FMTM ';
-
   // Checks if hashtag value starts with hotosm-fmtm'
   const handleHashtagOnChange = (e) => {
     let enteredText = e.target.value;
-    if (!enteredText.startsWith(hashtagPrefix)) {
-      handleCustomChange('hashtags', hashtagPrefix);
-      return;
-    }
     handleCustomChange('hashtags', enteredText);
   };
 
-  // Doesn't let the user to press 'Backspace' or 'Delete' if input value is 'hotosm-fmtm '
-  const handleHashtagKeyPress = (e) => {
-    if (
-      ((e.key === 'Backspace' || e.key === 'Delete') && values.hashtags === hashtagPrefix) ||
-      (e.ctrlKey && e.key === 'Backspace')
-    ) {
-      e.preventDefault();
-    }
-  };
   const handleInputChanges = (e) => {
     handleChange(e);
     dispatch(CreateProjectActions.SetIsUnsavedChanges(true));
@@ -164,9 +149,6 @@ const ProjectDetailsForm = ({ flag }) => {
                 value={values?.hashtags}
                 onChange={(e) => {
                   handleHashtagOnChange(e);
-                }}
-                onKeyDown={(e) => {
-                  handleHashtagKeyPress(e);
                 }}
                 fieldType="text"
                 required

--- a/src/frontend/src/components/createnewproject/SelectForm.tsx
+++ b/src/frontend/src/components/createnewproject/SelectForm.tsx
@@ -73,7 +73,7 @@ const SelectForm = ({ flag, geojsonFile, customFormFile, setCustomFormFile }) =>
   return (
     <div className="fmtm-flex fmtm-gap-7 fmtm-flex-col lg:fmtm-flex-row">
       <div className="fmtm-bg-white lg:fmtm-w-[20%] xl:fmtm-w-[17%] fmtm-px-5 fmtm-py-6">
-        <h6 className="fmtm-text-xl fmtm-font-[600] fmtm-pb-2 lg:fmtm-pb-6">Select Form</h6>
+        <h6 className="fmtm-text-xl fmtm-font-[600] fmtm-pb-2 lg:fmtm-pb-6">Select Category</h6>
         <p className="fmtm-text-gray-500 lg:fmtm-flex lg:fmtm-flex-col lg:fmtm-gap-3">
           <span>You may choose an existing category or upload a custom XLS form.</span>
           <span>
@@ -96,8 +96,8 @@ const SelectForm = ({ flag, geojsonFile, customFormFile, setCustomFormFile }) =>
             <div className="fmtm-flex fmtm-flex-col  fmtm-gap-6">
               <div className="">
                 <CustomSelect
-                  title="Select form category"
-                  placeholder="Select form category"
+                  title="Select category"
+                  placeholder="Select category"
                   data={sortedFormCategoryList}
                   dataKey="id"
                   valueKey="title"

--- a/src/frontend/src/components/createnewproject/SplitTasks.tsx
+++ b/src/frontend/src/components/createnewproject/SplitTasks.tsx
@@ -45,7 +45,6 @@ const SplitTasks = ({ flag, geojsonFile, setGeojsonFile, customLineUpload, custo
   const drawnGeojson = CoreModules.useAppSelector((state) => state.createproject.drawnGeojson);
   const projectDetails = CoreModules.useAppSelector((state) => state.createproject.projectDetails);
   const dataExtractGeojson = useAppSelector((state) => state.createproject.dataExtractGeojson);
-  const userDetails: any = CoreModules.useAppSelector((state) => state.login.loginToken);
 
   const generateQrSuccess: any = CoreModules.useAppSelector((state) => state.createproject.generateQrSuccess);
   const projectDetailsResponse = CoreModules.useAppSelector((state) => state.createproject.projectDetailsResponse);
@@ -109,15 +108,9 @@ const SplitTasks = ({ flag, geojsonFile, setGeojsonFile, customLineUpload, custo
         short_description: projectDetails.short_description,
         description: projectDetails.description,
       },
-      author: {
-        username: userDetails.username,
-        id: userDetails.id,
-      },
-      odk_central: {
-        odk_central_url: projectDetails.odk_central_url,
-        odk_central_user: projectDetails.odk_central_user,
-        odk_central_password: projectDetails.odk_central_password,
-      },
+      odk_central_url: projectDetails.odk_central_url,
+      odk_central_user: projectDetails.odk_central_user,
+      odk_central_password: projectDetails.odk_central_password,
       // dont send xform_title if upload custom form is selected
       xform_title: projectDetails.formCategorySelection,
       task_split_type: splitTasksSelection,

--- a/src/frontend/src/components/createnewproject/UploadArea.tsx
+++ b/src/frontend/src/components/createnewproject/UploadArea.tsx
@@ -61,7 +61,7 @@ const UploadArea = ({ flag, geojsonFile, setGeojsonFile, setCustomLineUpload, se
     }
     dispatch(CreateProjectActions.SetIndividualProjectDetailsData(formValues));
     dispatch(CommonActions.SetCurrentStepFormStep({ flag: flag, step: 3 }));
-    navigate('/select-form');
+    navigate('/select-category');
   };
   const {
     handleSubmit,
@@ -73,14 +73,6 @@ const UploadArea = ({ flag, geojsonFile, setGeojsonFile, setCustomLineUpload, se
     dispatch(CommonActions.SetCurrentStepFormStep({ flag: flag, step: step }));
     navigate(url);
   };
-
-  // const onCreateProjectSubmission = () => {
-  //   if (!drawnGeojson && !geojsonFile) {
-  //     return;
-  //   } else {
-  //     toggleStep(3, '/new-select-form');
-  //   }
-  // };
 
   const convertFileToGeojson = async (file) => {
     if (!file) return;

--- a/src/frontend/src/components/organisation/OrganisationAddForm.tsx
+++ b/src/frontend/src/components/organisation/OrganisationAddForm.tsx
@@ -16,7 +16,6 @@ const OrganisationAddForm = () => {
     // eslint-disable-next-line no-use-before-define
     // submitForm();
     dispatch(OrganisationService(`${import.meta.env.VITE_API_URL}/organisation/`, values));
-    // navigate("/select-form", { replace: true, state: { values: values } });
   };
   const { handleSubmit, handleCustomChange, values, errors }: any = useForm(
     formData,

--- a/src/frontend/src/components/organisation/Validation/OrganisationAddValidation.tsx
+++ b/src/frontend/src/components/organisation/Validation/OrganisationAddValidation.tsx
@@ -4,6 +4,9 @@ interface OrganisationValues {
   description: string;
   url: string;
   type: number;
+  odk_central_url: string;
+  odk_central_user: string;
+  odk_central_password: string;
 }
 interface ValidationErrors {
   logo?: string;
@@ -11,6 +14,9 @@ interface ValidationErrors {
   description?: string;
   url?: string;
   type?: string;
+  odk_central_url?: string;
+  odk_central_user?: string;
+  odk_central_password?: string;
 }
 
 function isValidUrl(url: string) {
@@ -25,20 +31,27 @@ function isValidUrl(url: string) {
 function OrganisationAddValidation(values: OrganisationValues) {
   const errors: ValidationErrors = {};
 
-  // if (!values?.logo) {
-  //   errors.logo = 'Logo is Required.';
-  // }
   if (!values?.name) {
     errors.name = 'Name is Required.';
   }
+
   if (!values?.description) {
     errors.description = 'Description is Required.';
   }
+
   if (!values?.url) {
     errors.url = 'Organization Url is Required.';
   } else if (!isValidUrl(values.url)) {
     errors.url = 'Invalid URL.';
   }
+
+  if (values?.odk_central_url && !isValidUrl(values.odk_central_url)) {
+    errors.odk_central_url = 'Invalid URL.';
+  }
+
+  // if (!values?.logo) {
+  //   errors.logo = 'Logo is Required.';
+  // }
 
   return errors;
 }

--- a/src/frontend/src/constants/StepFormConstants.ts
+++ b/src/frontend/src/constants/StepFormConstants.ts
@@ -19,10 +19,10 @@ export const createProjectSteps: ICreateProjectSteps[] = [
     name: 'Upload Area',
   },
   {
-    url: '/select-form',
+    url: '/select-category',
     step: 3,
     label: '03',
-    name: 'Select Form',
+    name: 'Select Category',
   },
   {
     url: '/data-extract',

--- a/src/frontend/src/constants/blockerUrl.ts
+++ b/src/frontend/src/constants/blockerUrl.ts
@@ -1,2 +1,2 @@
-const pathNotToBlock = ['/select-form', '/data-extract', '/split-tasks', '/upload-area', '/create-project'];
+const pathNotToBlock = ['/select-category', '/data-extract', '/split-tasks', '/upload-area', '/create-project'];
 export default pathNotToBlock;

--- a/src/frontend/src/models/createproject/createProjectModel.ts
+++ b/src/frontend/src/models/createproject/createProjectModel.ts
@@ -1,10 +1,6 @@
 export interface ProjectDetailsModel {
   id: number;
   odkid: number;
-  author: {
-    username: string;
-    id: number;
-  };
   default_locale: string;
   project_info: {
     locale: string;

--- a/src/frontend/src/models/organisation/organisationModel.ts
+++ b/src/frontend/src/models/organisation/organisationModel.ts
@@ -28,12 +28,3 @@ export interface GetOrganisationDataModel {
   logo: string;
   url: string;
 }
-export interface PostOrganisationDataModel {
-  name: string;
-  slug: string;
-  description: string;
-  type: number;
-  id: number;
-  logo: string;
-  url: string;
-}

--- a/src/frontend/src/routes.jsx
+++ b/src/frontend/src/routes.jsx
@@ -172,6 +172,18 @@ const routes = createBrowserRouter([
         ),
       },
       {
+        path: '/basemap-selection',
+        element: (
+          <ProtectedRoute>
+            <Suspense fallback={<div>Loading...</div>}>
+              <ErrorBoundary>
+                <CreateProject />
+              </ErrorBoundary>
+            </Suspense>
+          </ProtectedRoute>
+        ),
+      },
+      {
         path: '/create-project',
         element: (
           <ProtectedRoute>
@@ -220,7 +232,7 @@ const routes = createBrowserRouter([
         ),
       },
       {
-        path: '/select-form',
+        path: '/select-category',
         element: (
           <ProtectedRoute>
             <Suspense fallback={<div>Loading...</div>}>
@@ -292,7 +304,7 @@ const routes = createBrowserRouter([
         ),
       },
       {
-        path: 'edit-project/select-form/:projectId',
+        path: 'edit-project/select-category/:projectId',
         element: (
           <ProtectedRoute>
             <Suspense fallback={<div>Loading...</div>}>

--- a/src/frontend/src/routes.jsx
+++ b/src/frontend/src/routes.jsx
@@ -172,18 +172,6 @@ const routes = createBrowserRouter([
         ),
       },
       {
-        path: '/basemap-selection',
-        element: (
-          <ProtectedRoute>
-            <Suspense fallback={<div>Loading...</div>}>
-              <ErrorBoundary>
-                <CreateProject />
-              </ErrorBoundary>
-            </Suspense>
-          </ProtectedRoute>
-        ),
-      },
-      {
         path: '/create-project',
         element: (
           <ProtectedRoute>

--- a/src/frontend/src/store/slices/CreateProjectSlice.ts
+++ b/src/frontend/src/store/slices/CreateProjectSlice.ts
@@ -7,7 +7,7 @@ export const initialState: CreateProjectStateTypes = {
   projectDetails: {
     dimension: 10,
     no_of_buildings: 5,
-    hashtags: '#FMTM ',
+    hashtags: '',
     name: '',
     short_description: '',
     odk_central_url: '',
@@ -70,7 +70,7 @@ const CreateProject = createSlice({
       state.projectDetails = {
         dimension: 10,
         no_of_buildings: 5,
-        hashtags: '#FMTM ',
+        hashtags: '',
         name: '',
         short_description: '',
         odk_central_url: '',

--- a/src/frontend/src/store/types/ICreateProject.ts
+++ b/src/frontend/src/store/types/ICreateProject.ts
@@ -40,10 +40,6 @@ export type CreateProjectStateTypes = {
 export type ValidateCustomFormResponse = {
   detail: { message: string; possible_reason: string };
 };
-export type AuthorTypes = {
-  username: string;
-  id: number;
-};
 
 export type GeometryTypes = {
   type: string;
@@ -82,7 +78,6 @@ export type ProjectInfoTypes = {
 type EditProjectResponseTypes = {
   id: number;
   odkid: number;
-  author: AuthorTypes;
   project_info: ProjectInfoTypes[];
   status: number;
   outline_geojson: GeoJSONFeatureTypes;

--- a/src/frontend/src/views/CreateNewProject.tsx
+++ b/src/frontend/src/views/CreateNewProject.tsx
@@ -41,7 +41,7 @@ const CreateNewProject = () => {
       case '/upload-area':
         dispatch(CommonActions.SetCurrentStepFormStep({ flag: 'create_project', step: 2 }));
         break;
-      case '/select-form':
+      case '/select-category':
         dispatch(CommonActions.SetCurrentStepFormStep({ flag: 'create_project', step: 3 }));
         break;
       case '/data-extract':
@@ -70,7 +70,7 @@ const CreateNewProject = () => {
             setCustomPolygonUpload={setCustomPolygonUpload}
           />
         );
-      case '/select-form':
+      case '/select-category':
         return (
           <SelectForm
             flag="create_project"

--- a/src/frontend/src/views/CreateOrganisation.tsx
+++ b/src/frontend/src/views/CreateOrganisation.tsx
@@ -132,6 +132,69 @@ const CreateOrganisationForm = () => {
                 FormHelperTextProps={inputFormStyles()}
               />
             </CoreModules.FormControl>
+            <CoreModules.FormControl sx={{ width: '100%' }}>
+              <CoreModules.Box sx={{ display: 'flex', flexDirection: 'row' }}>
+                <CoreModules.FormLabel sx={{}} component="h3">
+                  ODK Central URL (Optional)
+                </CoreModules.FormLabel>
+              </CoreModules.Box>
+              <CoreModules.TextField
+                id="odk_central_url"
+                label=""
+                variant="filled"
+                value={values.odk_central_url}
+                onChange={(e) => {
+                  handleCustomChange('odk_central_url', e.target.value);
+                }}
+                fullWidth
+                multiline
+                rows={1}
+                helperText={errors.odk_central_url}
+                FormHelperTextProps={inputFormStyles()}
+              />
+            </CoreModules.FormControl>
+            <CoreModules.FormControl sx={{ width: '100%' }}>
+              <CoreModules.Box sx={{ display: 'flex', flexDirection: 'row' }}>
+                <CoreModules.FormLabel sx={{}} component="h3">
+                  ODK Central User (Optional)
+                </CoreModules.FormLabel>
+              </CoreModules.Box>
+              <CoreModules.TextField
+                id="odk_central_user"
+                label=""
+                variant="filled"
+                value={values.odk_central_user}
+                onChange={(e) => {
+                  handleCustomChange('odk_central_user', e.target.value);
+                }}
+                fullWidth
+                multiline
+                rows={1}
+                helperText={errors.odk_central_user}
+                FormHelperTextProps={inputFormStyles()}
+              />
+            </CoreModules.FormControl>
+            <CoreModules.FormControl sx={{ width: '100%' }}>
+              <CoreModules.Box sx={{ display: 'flex', flexDirection: 'row' }}>
+                <CoreModules.FormLabel sx={{}} component="h3">
+                  ODK Central Password (Optional)
+                </CoreModules.FormLabel>
+              </CoreModules.Box>
+              <CoreModules.TextField
+                id="odk_central_password"
+                label=""
+                variant="filled"
+                value={values.odk_central_password}
+                onChange={(e) => {
+                  handleCustomChange('odk_central_password', e.target.value);
+                }}
+                fullWidth
+                multiline
+                rows={1}
+                helperText={errors.odk_central_password}
+                FormHelperTextProps={inputFormStyles()}
+              />
+            </CoreModules.FormControl>
             <CoreModules.FormControl fullWidth margin="normal" variant="filled" sx={{ gap: 1 }}>
               <CoreModules.Box
                 sx={{

--- a/src/frontend/src/views/CreateProject.tsx
+++ b/src/frontend/src/views/CreateProject.tsx
@@ -96,9 +96,9 @@ const CreateProject: React.FC = () => {
           ></CoreModules.Box>
           <CoreModules.Box
             sx={{
-              height: location.pathname !== '/select-form' ? '8px' : '12px',
+              height: location.pathname !== '/select-category' ? '8px' : '12px',
               width: '64px',
-              background: location.pathname !== '/select-form' ? '#68707F' : '#D73F3F',
+              background: location.pathname !== '/select-category' ? '#68707F' : '#D73F3F',
               mx: '16px',
               borderRadius: '10px',
             }}
@@ -175,14 +175,14 @@ const CreateProject: React.FC = () => {
           </Link>
           {/* END */}
           {/* Upload Area SideBar Button for uploading Area page  */}
-          <Link to="/select-form">
+          <Link to="/select-category">
             <CoreModules.Button
               sx={boxSX}
               variant="contained"
               color="error"
-              disabled={location.pathname !== '/select-form'}
+              disabled={location.pathname !== '/select-category'}
             >
-              Select Form
+              Select Category
             </CoreModules.Button>
           </Link>
           {/* END */}
@@ -228,7 +228,7 @@ const CreateProject: React.FC = () => {
             setLineExtractFileValue={setLineExtractFileValue}
           />
         ) : null}
-        {location.pathname === '/select-form' ? (
+        {location.pathname === '/select-category' ? (
           <FormSelection
             geojsonFile={geojsonFile}
             customFormFile={customFormFile}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Issue

Fixes https://github.com/hotosm/fmtm/issues/966

- [x] Database: fields added (added in https://github.com/hotosm/fmtm/pull/1126)
- [x] Backend: included in schemas
- [x] Backend: Add to organisation endpoints
- [x] Frontend: Add to organisation creation form
- [ ] Frontend: Checkbox to use default credentials during project creation 

## Describe this PR

- As discussed in the issue, we want to allow for default ODK Central credentials mapped to organisations, to avoid users having to remember and type in manually every time.
- I also took some time to refactor the project creation to allow for using the org credentials instead of project specific creds.
- And refactored the usage of OdkCentral Pydantic models slightly to make them easier. 

## Screenshots

N/A

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the FMTM Code of Conduct: <https://github.com/hotosm/fmtm/blob/main/CODE_OF_CONDUCT.md>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
