### PR TITLE
hotfix: geom type not populated with feature type

### DIFF
--- a/src/backend/app/projects/project_crud.py
+++ b/src/backend/app/projects/project_crud.py
@@ -617,7 +617,7 @@ async def get_data_extract_url(
         }
     }
 
-    if geom_type := aoi.get("type") == "FeatureCollection":
+    if (geom_type := aoi.get("type")) == "FeatureCollection":
         # Convert each feature into a Shapely geometry
         geometries = [
             shape(feature.get("geometry")) for feature in aoi.get("features", [])


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Issue

`geom_type` was saving values `True` or `False` instead of feature type. 

## Describe this PR

This PR addresses the issue and has made minor change where the `geom_type` is saved with the feature types from aoi.
This change in code first assigns the feature type to `geom_type` and compares with `FeatureCollection`.

## Screenshots

N/A

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the FMTM Code of Conduct: <https://github.com/hotosm/fmtm/blob/main/CODE_OF_CONDUCT.md>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
