### PR TITLE
Replace synchronous database driver with async (sqalchemy)

### DIFF
--- a/src/backend/app/config.py
+++ b/src/backend/app/config.py
@@ -89,7 +89,7 @@ class Settings(BaseSettings):
         if isinstance(v, str):
             return v
         pg_url = PostgresDsn.build(
-            scheme="postgresql",
+            scheme="postgresql+psycopg",
             username=info.data.get("FMTM_DB_USER"),
             password=info.data.get("FMTM_DB_PASSWORD"),
             host=info.data.get("FMTM_DB_HOST"),

--- a/src/backend/app/db/database.py
+++ b/src/backend/app/db/database.py
@@ -18,22 +18,73 @@
 
 """Config for the FMTM database connection."""
 
-from sqlalchemy import create_engine
-from sqlalchemy.orm import declarative_base, sessionmaker
+import contextlib
+from typing import AsyncIterator
+
+from sqlalchemy.ext.asyncio import (
+    AsyncConnection,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+from sqlalchemy.orm import declarative_base
 
 from app.config import settings
-
-engine = create_engine(settings.FMTM_DB_URL.unicode_string())
-SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 Base = declarative_base()
 FmtmMetadata = Base.metadata
 
 
-def get_db():
+class DatabaseSessionManager:
+    """Manage the database sessions for FastAPI."""
+
+    def __init__(self, host: str):
+        """Init DatabaseSessionManager object."""
+        self._engine = create_async_engine(host)
+        self._sessionmaker = async_sessionmaker(autocommit=False, bind=self._engine)
+
+    async def close(self):
+        """Close database engine and session."""
+        if self._engine is None:
+            raise Exception("DatabaseSessionManager is not initialized")
+        await self._engine.dispose()
+
+        self._engine = None
+        self._sessionmaker = None
+
+    @contextlib.asynccontextmanager
+    async def connect(self) -> AsyncIterator[AsyncConnection]:
+        """Connect to database engine."""
+        if self._engine is None:
+            raise Exception("DatabaseSessionManager is not initialized")
+
+        async with self._engine.begin() as connection:
+            try:
+                yield connection
+            except Exception:
+                await connection.rollback()
+                raise
+
+    @contextlib.asynccontextmanager
+    async def session(self) -> AsyncIterator[AsyncSession]:
+        """Create a session, handling error rollback and closing."""
+        if self._sessionmaker is None:
+            raise Exception("DatabaseSessionManager is not initialized")
+
+        session = self._sessionmaker()
+        try:
+            yield session
+        except Exception:
+            await session.rollback()
+            raise
+        finally:
+            await session.close()
+
+
+sessionmanager = DatabaseSessionManager(settings.FMTM_DB_URL.unicode_string())
+
+
+async def get_db():
     """Create SQLAlchemy DB session."""
-    db = SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
+    async with sessionmanager.session() as session:
+        yield session

--- a/src/backend/app/projects/project_crud.py
+++ b/src/backend/app/projects/project_crud.py
@@ -960,11 +960,11 @@ async def update_project_with_zip(
 # ---------------------------
 
 
-async def read_xlsforms(
+async def insert_xlsforms_in_db(
     db: Session,
     directory: str,
 ):
-    """Read the list of XLSForms from the disk."""
+    """Read the list of XLSForms from the disk and insert in database."""
     xlsforms = list()
     package_name = "osm_fieldwork"
     package_files = pkg_files(package_name)
@@ -998,8 +998,8 @@ async def read_xlsforms(
         sql = ins.on_conflict_do_update(
             constraint="xlsforms_title_key", set_=dict(title=name, xls=data)
         )
-        db.execute(sql)
-        db.commit()
+        await db.execute(sql)
+        await db.commit()
 
     return xlsforms
 

--- a/src/backend/pdm.lock
+++ b/src/backend/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "debug", "dev", "docs", "test"]
 strategy = ["cross_platform"]
 lock_version = "4.4.1"
-content_hash = "sha256:d73a7c181c5594d5f391a5c715559194fb5c6c4a923e5a4d15e3c1a57b073e27"
+content_hash = "sha256:1187cacb94c3233a46fe6ecf1907ad08953f3e9e80e64ebf3be6d83132ca2190"
 
 [[package]]
 name = "annotated-types"
@@ -1518,6 +1518,20 @@ dependencies = [
 files = [
     {file = "prompt_toolkit-3.0.36-py3-none-any.whl", hash = "sha256:aa64ad242a462c5ff0363a7b9cfe696c20d55d9fc60c11fd8e632d064804d305"},
     {file = "prompt_toolkit-3.0.36.tar.gz", hash = "sha256:3e163f254bef5a03b146397d7c1963bd3e2812f0964bb9a24e6ec761fd28db63"},
+]
+
+[[package]]
+name = "psycopg"
+version = "3.1.17"
+requires_python = ">=3.7"
+summary = "PostgreSQL database adapter for Python"
+dependencies = [
+    "typing-extensions>=4.1",
+    "tzdata; sys_platform == \"win32\"",
+]
+files = [
+    {file = "psycopg-3.1.17-py3-none-any.whl", hash = "sha256:96b7b13af6d5a514118b759a66b2799a8a4aa78675fa6bb0d3f7d52d67eff002"},
+    {file = "psycopg-3.1.17.tar.gz", hash = "sha256:437e7d7925459f21de570383e2e10542aceb3b9cb972ce957fdd3826ca47edc6"},
 ]
 
 [[package]]

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "osm-fieldwork==0.4.1",
     "osm-rawdata==0.1.7",
     "fmtm-splitter==1.0.0rc0",
+    "psycopg>=3.1.17",
 ]
 requires-python = ">=3.10"
 readme = "../../README.md"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Issue

Related to #254

## Describe this PR

WORK IN PROGRESS

**We should probably do this alongside #254 to avoid having to implement in SQLAlchemy**
(the structure remains mostly the same when using the underlying driver)

Either (if using SQLAlchemy):

- [ ] Replace all `db.query` code with `db.select` or similar.

OR (if using psycopg/asyncpg):

- [ ] Replace all `db.query` code with direct driver usage via SQL.

Also:
- [ ] Add `await` to every instance of db usage...
- [ ] Fix running of test cases (untested).

Useful reference: https://praciano.com.br/fastapi-and-async-sqlalchemy-20-with-pytest-done-right.html

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the FMTM Code of Conduct: <https://github.com/hotosm/fmtm/blob/main/CODE_OF_CONDUCT.md>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
