### PR TITLE
fix: login_required decorator return value converted to AuthUser

### DIFF
--- a/src/backend/app/auth/osm.py
+++ b/src/backend/app/auth/osm.py
@@ -85,4 +85,4 @@ async def login_required(
         log.error("Failed to deserialise access token")
         raise HTTPException(status_code=401, detail="Access token not valid") from e
 
-    return osm_user
+    return AuthUser(**osm_user)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Describe this PR
login_required deorator has this error.
```
File "/opt/app/auth/roles.py", line 41, in get_uid
  if user_id := user_data.id:
                └ {'id': 18764526, 'username': 'Niraj Adhikari', 'img_url': None}
AttributeError: 'dict' object has no attribute 'id'
```
`osm_auth.deserialize_access_token` function returns dict value. 
This change converts the dict into AuthUser.

## Screenshots

Please provide screenshots of the change.

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the FMTM Code of Conduct: <https://github.com/hotosm/fmtm/blob/main/CODE_OF_CONDUCT.md>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
