### PR TITLE
ZLib compress dynamic QR codes from frontend

### DIFF
--- a/contrib/qrcode_util/Dockerfile
+++ b/contrib/qrcode_util/Dockerfile
@@ -1,0 +1,67 @@
+# Copyright (c) 2022, 2023 Humanitarian OpenStreetMap Team
+# This file is part of FMTM.
+#
+#     FMTM is free software: you can redistribute it and/or modify
+#     it under the terms of the GNU General Public License as published by
+#     the Free Software Foundation, either version 3 of the License, or
+#     (at your option) any later version.
+#
+#     FMTM is distributed in the hope that it will be useful,
+#     but WITHOUT ANY WARRANTY; without even the implied warranty of
+#     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#     GNU General Public License for more details.
+#
+#     You should have received a copy of the GNU General Public License
+#     along with FMTM.  If not, see <https:#www.gnu.org/licenses/>.
+#
+ARG PYTHON_IMG_TAG=3.10
+
+
+# Includes all labels and timezone info to extend from
+FROM docker.io/python:${PYTHON_IMG_TAG}-slim-bookworm as base
+RUN set -ex \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install \
+    -y --no-install-recommends "locales" "ca-certificates" \
+    && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \
+    && rm -rf /var/lib/apt/lists/* \
+    && update-ca-certificates
+# Set locale
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && locale-gen
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
+
+# Build stage will all dependencies required to build Python wheels
+FROM base as build
+RUN set -ex \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install \
+    -y --no-install-recommends \
+        "build-essential" \
+        "gcc" \
+        "libzbar0" \
+    && rm -rf /var/lib/apt/lists/*
+RUN pip install --user --no-warn-script-location \
+    --no-cache-dir pillow==10.2.0 pyzbar==0.1.9 segno==1.6.0
+
+
+# Run stage will minimal dependencies required to run Python libraries
+FROM base as runtime
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    PYTHONFAULTHANDLER=1
+RUN set -ex \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install \
+    -y --no-install-recommends \
+        "libzbar0" \
+    && rm -rf /var/lib/apt/lists/*
+# Copy Python deps from build to runtime
+COPY --from=build \
+    /root/.local \
+    /root/.local
+WORKDIR /code
+COPY qrcode_util.py .
+ENTRYPOINT ["python", "qrcode_util.py"]

--- a/contrib/qrcode_util/README.md
+++ b/contrib/qrcode_util/README.md
@@ -1,0 +1,39 @@
+# QR Code Utils
+
+## Convert QR Code to JSON
+
+```bash
+cat /path/to/your/qrcode.png | \
+    docker run -i --rm ghcr.io/hotosm/fmtm/qrcodes:latest --read
+```
+
+This will output the JSON data to terminal.
+
+## Convert JSON to QR Code
+
+```bash
+cat file.json | \
+docker run -i --rm ghcr.io/hotosm/fmtm/qrcodes:latest --write > qr.png
+```
+
+Alternatively pipe from STDIN on the command line:
+
+```bash
+echo '{
+  "general": {
+    "server_url": "https://url/v1/key/token/projects/projectid",
+    "form_update_mode": "manual",
+    "basemap_source": "osm",
+    "autosend": "wifi_and_cellular",
+    "metadata_username": "svcfmtm",
+    "metadata_email": "test"
+  },
+  "project": {
+    "name": "task qrcode conversion"
+  },
+  "admin": {}
+}' | docker run -i --rm ghcr.io/hotosm/fmtm/qrcodes:latest --write \
+> qr.png
+```
+
+This will create a file `qr.png` from your data.

--- a/contrib/qrcode_util/build.sh
+++ b/contrib/qrcode_util/build.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+docker build . -t ghcr.io/hotosm/fmtm/qrcodes:latest
+
+docker push ghcr.io/hotosm/fmtm/qrcodes:latest

--- a/contrib/qrcode_util/qrcode_util.py
+++ b/contrib/qrcode_util/qrcode_util.py
@@ -1,0 +1,69 @@
+"""Convert between JSON and QRCode formats."""
+
+import sys
+import argparse
+import base64
+import json
+import zlib
+from io import BytesIO
+
+from PIL import Image
+from segno import make as make_qr
+from pyzbar.pyzbar import decode as decode_qr
+
+
+def qr_to_json(qr_code_bytes: bytes):
+    """Extract QR code content to JSON."""
+    qr_img = Image.open(BytesIO(qr_code_bytes))
+    qr_data = decode_qr(qr_img)[0].data
+
+    # Base64/zlib decoded
+    decoded_qr = zlib.decompress(base64.b64decode(qr_data))
+    odk_json = json.loads(decoded_qr.decode("utf-8"))
+    # Output to terminal
+    print(odk_json)
+
+def json_to_qr(json_bytes: bytes):
+    """Insert JSON content into QR code."""
+    json_string = json.loads(json_bytes.decode('utf8').replace("'", '"'))
+
+    # Base64/zlib encoded
+    qrcode_data = base64.b64encode(
+        zlib.compress(json.dumps(json_string).encode("utf-8"))
+    )
+    qrcode = make_qr(qrcode_data, micro=False)
+    buffer = BytesIO()
+    qrcode.save(buffer, kind="png", scale=5)
+    qrcode_binary = buffer.getvalue()
+    sys.stdout.buffer.write(qrcode_binary)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Encode or decode QR code data."
+    )
+    parser.add_argument(
+        "--write",
+        action="store_true",
+        help="Write data from STDIN to a QRCode.",
+    )
+    parser.add_argument(
+        "--read",
+        action="store_true",
+        help="Read QRCode data from STDIN and print to terminal.",
+    )
+
+    args = parser.parse_args()
+
+    # Read STDIN data, usage:
+    # $ cat file.png | docker run -i --rm ghcr.io/hotosm/fmtm/qrcodes:latest --write
+    data_in: bytes = sys.stdin.buffer.read()
+    if data_in == b"":
+        print("Data must be provided via STDIN.")
+        sys.exit(1)
+
+    if args.write:
+        json_to_qr(data_in)
+    elif args.read:
+        qr_to_json(data_in)
+    else:
+        print("Please provide either --write or --read flag.")    

--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -75,6 +75,7 @@
     "lucide-react": "^0.276.0",
     "mini-css-extract-plugin": "^2.7.5",
     "ol-ext": "^4.0.11",
+    "pako": "^2.1.0",
     "qrcode-generator": "^1.4.4",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/src/frontend/pnpm-lock.yaml
+++ b/src/frontend/pnpm-lock.yaml
@@ -101,6 +101,9 @@ dependencies:
   ol-ext:
     specifier: ^4.0.11
     version: 4.0.11(ol@8.1.0)
+  pako:
+    specifier: ^2.1.0
+    version: 2.1.0
   qrcode-generator:
     specifier: ^1.4.4
     version: 1.4.4

--- a/src/frontend/src/api/Files.js
+++ b/src/frontend/src/api/Files.js
@@ -1,6 +1,14 @@
 import { useEffect, useState } from 'react';
 import qrcodeGenerator from 'qrcode-generator';
-import { deflate } from 'pako/lib/deflate.js';
+import { deflate } from 'pako/lib/deflate';
+
+// function base64zlibdecode(string) {
+//   return new TextDecoder().decode(inflate(Uint8Array.from(window.atob(string), (c) => c.codePointAt(0))))
+// }
+
+function base64zlibencode(string) {
+  return window.btoa(String.fromCodePoint(...deflate(new TextEncoder().encode(string))));
+}
 
 export const ProjectFilesById = (odkToken, projectName, osmUser, taskId) => {
   const [qrcode, setQrcode] = useState('');
@@ -18,7 +26,7 @@ export const ProjectFilesById = (odkToken, projectName, osmUser, taskId) => {
           basemap_source: 'osm',
           autosend: 'wifi_and_cellular',
           metadata_username: osmUser,
-          metadata_email: taskId,
+          metadata_email: taskId.toString(),
         },
         project: { name: projectName },
         admin: {},
@@ -28,7 +36,7 @@ export const ProjectFilesById = (odkToken, projectName, osmUser, taskId) => {
       const code = qrcodeGenerator(0, 'L');
       // Note: btoa base64 encodes the JSON string
       // Note: pako.deflate zlib encodes to content
-      code.addData(btoa(deflate(odkCollectJson, { to: 'string' })));
+      code.addData(base64zlibencode(odkCollectJson));
       code.make();
 
       // Note: cell size = 3, margin = 5

--- a/src/frontend/src/api/Files.js
+++ b/src/frontend/src/api/Files.js
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import qrcodeGenerator from 'qrcode-generator';
+import { deflate } from 'pako/lib/deflate.js';
 
 export const ProjectFilesById = (odkToken, projectName, osmUser, taskId) => {
   const [qrcode, setQrcode] = useState('');
@@ -26,7 +27,8 @@ export const ProjectFilesById = (odkToken, projectName, osmUser, taskId) => {
       // Note: error correction level = "L"
       const code = qrcodeGenerator(0, 'L');
       // Note: btoa base64 encodes the JSON string
-      code.addData(btoa(odkCollectJson));
+      // Note: pako.deflate zlib encodes to content
+      code.addData(btoa(deflate(odkCollectJson, { to: 'string' })));
       code.make();
 
       // Note: cell size = 3, margin = 5


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Describe this PR

- I updated the QR code generation to the frontend.
- I clearly didn't test well enough, as the QR codes don't work.
- I forgot to zlib encode the QR codes.

Example of how ODK Central frontend does this: https://github.com/getodk/central-frontend/blob/f254a175086b8acd83fd55607fa33b311d8aa6cc/src/components/collect-qr.vue#L43

Central frontend uses pako v1, but pako v2 has since changed it's API.
We are required to pass a `Uint8Array` to the deflate method.

## Screenshots

- After zlib encoding incorrectly the QRCodes are much finer grained and cannot be read on the frontend:

![image](https://github.com/hotosm/fmtm/assets/78538841/e73a41a8-ae07-4986-9fdf-78c0341edb77)

- Example ODK Central frontend QR code:

![image](https://github.com/hotosm/fmtm/assets/78538841/a80246fa-f97a-4763-8bac-b5d152d70560)

- Correctly zlib encoded QR via pako v2:

![image](https://github.com/hotosm/fmtm/assets/78538841/64610e86-9b46-41c5-9bad-d4c9df69f337)

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the FMTM Code of Conduct: <https://github.com/hotosm/fmtm/blob/main/CODE_OF_CONDUCT.md>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
