### PR TITLE
Fix img proj popup

### DIFF
--- a/src/frontend/src/components/createnewproject/SplitTasks.tsx
+++ b/src/frontend/src/components/createnewproject/SplitTasks.tsx
@@ -288,10 +288,6 @@ const SplitTasks = ({ flag, geojsonFile, setGeojsonFile, customLineUpload, custo
             <div className="fmtm-p-10">
               <ProgressBar totalSteps={totalSteps} currentStep={generateProjectLog?.progress} />
             </div>
-            <p className="fmtm-text-base">
-              Please stay on this page until the process is complete. Your changes might be lost if you cancel the
-              pop-up.
-            </p>
           </div>
         }
         open={toggleStatus}

--- a/src/frontend/src/components/home/ExploreProjectCard.tsx
+++ b/src/frontend/src/components/home/ExploreProjectCard.tsx
@@ -73,7 +73,9 @@ export default function ExploreProjectCard({ data }) {
           <div>
             <div className="fmtm-flex fmtm-justify-between">
               {data.organisation_logo ? (
-                <CoreModules.CardMedia component="img" src={data.organisation_logo} sx={{ width: 50, height: 50 }} />
+                <div className="fmtm-h-[50px]">
+                  <CoreModules.CardMedia component="img" src={data.organisation_logo} sx={{ height: 50 }} />
+                </div>
               ) : (
                 <CustomizedImage status={'card'} style={{ width: 50, height: 50 }} />
               )}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Issue
- Fix #1104

## Describe this PR
This PR solves following issues: 
1. Home Page exploreProjectCard organization image crop. 
2. Remove text below progressBar in createProject popup of splitTasks.

## Screenshots
Tested for different org logos and it seems to work fine: 
![image_480](https://github.com/hotosm/fmtm/assets/81785002/5408d41c-1757-4f16-92f8-c61c95513a33)
![image_480](https://github.com/hotosm/fmtm/assets/81785002/32061d82-6c1a-44dc-b511-b2ba4ad02044)
![image_480](https://github.com/hotosm/fmtm/assets/81785002/df1bbfab-d2d1-45c5-b66f-7bfc86ee64d5)
![image_480](https://github.com/hotosm/fmtm/assets/81785002/b9c08470-bad4-47e6-97fc-7e4613a01524)

- Removed Text
![image_480](https://github.com/hotosm/fmtm/assets/81785002/ba3e70b8-fc66-41cf-9219-f6ff6ba98c11)