### PR TITLE
Limit the no.of threads according to CPU core

### DIFF
--- a/src/backend/app/projects/project_crud.py
+++ b/src/backend/app/projects/project_crud.py
@@ -32,6 +32,7 @@ import requests
 import shapely.wkb as wkblib
 import sozipfile.sozipfile as zipfile
 from asgiref.sync import async_to_sync
+from cpuinfo import get_cpu_info
 from fastapi import File, HTTPException, Response, UploadFile
 from fastapi.concurrency import run_in_threadpool
 from fmtm_splitter.splitter import split_by_sql, split_by_square
@@ -1283,8 +1284,13 @@ def generate_appuser_files(
             except Exception as e:
                 log.exception(str(e))
 
-        # Use a ThreadPoolExecutor to run the synchronous code in threads
-        with ThreadPoolExecutor() as executor:
+        # The number of threads is based on the CPU cores
+        info = get_cpu_info()
+        cores = info["count"] * 2
+
+        # Use a ThreadPoolExecutor to run the synchronous code in threads.
+        # Used no.of threads = number of cores - 2
+        with ThreadPoolExecutor(max_workers=cores - 2) as executor:
             # Submit tasks to the thread pool
             futures = [
                 executor.submit(wrap_generate_task_files, task) for task in task_list


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [x] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Describe this PR
I have limited the number of threads running when generating QR Codes, by looking into the cpu cores. Sometimes, fmtm backend freezes when creating a project. This might be a potential solution. What do you think @spwoodcock .
I have kept 2 cpu cores free.

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the FMTM Code of Conduct: <https://github.com/hotosm/fmtm/blob/main/CODE_OF_CONDUCT.md>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
