### PR TITLE
fix josmUpload: send bbox from geojson properties

### DIFF
--- a/src/frontend/src/api/task.ts
+++ b/src/frontend/src/api/task.ts
@@ -178,7 +178,7 @@ export const fetchConvertToOsmDetails: Function = (url: string) => {
   };
 };
 
-export const ConvertXMLToJOSM: Function = (url: string, projectBbox) => {
+export const ConvertXMLToJOSM: Function = (url: string, projectBbox: number[]) => {
   return async (dispatch) => {
     dispatch(CoreModules.TaskActions.SetConvertXMLToJOSMLoading(true));
     const getConvertXMLToJOSM = async (url) => {

--- a/src/frontend/src/components/ProjectSubmissions/SubmissionsTable.tsx
+++ b/src/frontend/src/components/ProjectSubmissions/SubmissionsTable.tsx
@@ -198,7 +198,7 @@ const SubmissionsTable = ({ toggleView }) => {
     dispatch(
       ConvertXMLToJOSM(
         `${import.meta.env.VITE_API_URL}/submission/get_osm_xml/${decodedId}`,
-        projectInfo.outline_geojson.bbox,
+        projectInfo?.outline_geojson?.properties?.bbox,
       ),
     );
   };


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Issue
- Fix #1245 

## Describe this PR
Since the `bbox` is now sent under the `properties` key of `outline_geojson`. The code has been updated accordingly.

## Screenshots
![image](https://github.com/hotosm/fmtm/assets/81785002/91e6a7ee-116c-4b23-84b9-4652d48ebcec)