### PR TITLE
Removing redundant code for removing extra closing </osm> tag

### DIFF
--- a/src/backend/app/submissions/submission_routes.py
+++ b/src/backend/app/submissions/submission_routes.py
@@ -298,21 +298,9 @@ async def get_osm_xml(
     # Remove the extra closing </osm> tag from the end of the file
     with open(osmoutfile, "r") as f:
         osmoutfile_data = f.read()
-        # Find the last index of the closing </osm> tag
-        last_osm_index = osmoutfile_data.rfind("</osm>")
-        # Remove the extra closing </osm> tag from the end
-        processed_xml_string = (
-            osmoutfile_data[:last_osm_index]
-            + osmoutfile_data[last_osm_index + len("</osm>") :]
-        )
-
-    # Write the modified XML data back to the file
-    with open(osmoutfile, "w") as f:
-        f.write(processed_xml_string)
 
     # Create a plain XML response
-    response = Response(content=processed_xml_string, media_type="application/xml")
-    return response
+    return Response(content=osmoutfile_data, media_type="application/xml")
 
 
 @router.get("/submission_page/{project_id}")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [X] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Issue

The submission was not loaded into JOSM due to invalid osm file content.

- Fixes #1245 

## Describe this PR

Previously, the xml file returned from `json2osm` used to lack `</osm>`, because of which it was manually added to the `get_osm_xml` endpoint. Now `json2osm` generates valid OSM files, eliminating the need for manual addition of the tag in the `get_osm_xml` endpoint.

## Screenshots

N/A

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the FMTM Code of Conduct: <https://github.com/hotosm/fmtm/blob/main/CODE_OF_CONDUCT.md>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
