### PR TITLE
Fix data extract splitting by task area

### DIFF
--- a/src/backend/app/projects/project_crud.py
+++ b/src/backend/app/projects/project_crud.py
@@ -1387,7 +1387,9 @@ async def get_task_geometry(db: Session, project_id: int):
 
 
 async def get_project_features_geojson(
-    db: Session, project: Union[db_models.DbProject, int]
+    db: Session,
+    project: Union[db_models.DbProject, int],
+    task_id: Optional[int] = None,
 ) -> FeatureCollection:
     """Get a geojson of all features for a task."""
     if isinstance(project, int):
@@ -1426,6 +1428,18 @@ async def get_project_features_geojson(
                 f"project ({project_id})"
             ),
         )
+
+    # Split by task areas if task_id provided
+    if task_id:
+        split_extract_dict = await split_geojson_by_task_areas(
+            db, data_extract_geojson, project_id
+        )
+        if not split_extract_dict:
+            raise HTTPException(
+                status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+                detail=(f"Failed to extract geojson for task ({task_id})"),
+            )
+        return split_extract_dict[task_id]
 
     return data_extract_geojson
 

--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -1017,20 +1017,26 @@ async def download_task_boundaries(
 @router.get("/features/download/")
 async def download_features(
     project_id: int,
+    task_id: Optional[int] = None,
     db: Session = Depends(database.get_db),
     current_user: AuthUser = Depends(mapper),
 ):
     """Downloads the features of a project as a GeoJSON file.
 
+    Can generate a geojson for the entire project, or specific task areas.
+
     Args:
         project_id (int): The id of the project.
+        task_id (int): Specify a specific task area to download for.
         db (Session): The database session, provided automatically.
         current_user (AuthUser): Check if user has MAPPER permission.
 
     Returns:
         Response: The HTTP response object containing the downloaded file.
     """
-    feature_collection = await project_crud.get_project_features_geojson(db, project_id)
+    feature_collection = await project_crud.get_project_features_geojson(
+        db, project_id, task_id
+    )
 
     headers = {
         "Content-Disposition": (


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Describe this PR

- The data extract splitting, and hence the ODK Central form media, were generating duplicate geometries.
- Fixed to split the data extract correctly by task boundary.
- Also added the `task_id` param to `/projects/features/download`, so a geojson can be downloaded per project, or per task.

@manjitapandey hopefully the final fix to the project creation workflow 🤞 

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the FMTM Code of Conduct: <https://github.com/hotosm/fmtm/blob/main/CODE_OF_CONDUCT.md>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
