### PR TITLE
fix mapBgColor: map background changed to white

### DIFF
--- a/src/frontend/src/styles/home.scss
+++ b/src/frontend/src/styles/home.scss
@@ -25,7 +25,7 @@
 }
 
 .map {
-  background: #85ccf9;
+  background: #ffffff;
   position: relative;
 }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [x] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Issue

## Describe this PR
This PR changes the background color of the map to white as the current blue color coincides with the water color that confuses the user in distinguishing between a loading tile and a water area.

## Screenshots
![image](https://github.com/hotosm/fmtm/assets/81785002/0484f7e3-07d9-4cf5-8d3f-3cd4083ba181)
![image](https://github.com/hotosm/fmtm/assets/81785002/521802a2-9cb5-4b8d-9e92-d97116be0fe4)
