### PR TITLE
fix:(create-project): reset data extract when geojson is redrawn

### DIFF
--- a/src/frontend/src/components/createnewproject/UploadArea.tsx
+++ b/src/frontend/src/components/createnewproject/UploadArea.tsx
@@ -312,7 +312,6 @@ const UploadArea = ({ flag, geojsonFile, setGeojsonFile, setCustomLineUpload, se
                 drawnGeojson || uploadAreaSelection === 'upload_file'
                   ? null
                   : (geojson, area) => {
-                      console.log('drawn');
                       handleCustomChange('drawnGeojson', geojson);
                       dispatch(CreateProjectActions.SetDrawnGeojson(JSON.parse(geojson)));
                       dispatch(CreateProjectActions.SetTotalAreaSelection(area));

--- a/src/frontend/src/components/createnewproject/UploadArea.tsx
+++ b/src/frontend/src/components/createnewproject/UploadArea.tsx
@@ -156,6 +156,7 @@ const UploadArea = ({ flag, geojsonFile, setGeojsonFile, setCustomLineUpload, se
     handleCustomChange('drawnGeojson', null);
     dispatch(CreateProjectActions.SetDrawnGeojson(null));
     dispatch(CreateProjectActions.SetTotalAreaSelection(null));
+    dispatch(CreateProjectActions.ClearProjectStepState(formValues));
   };
 
   useEffect(() => {
@@ -311,6 +312,7 @@ const UploadArea = ({ flag, geojsonFile, setGeojsonFile, setCustomLineUpload, se
                 drawnGeojson || uploadAreaSelection === 'upload_file'
                   ? null
                   : (geojson, area) => {
+                      console.log('drawn');
                       handleCustomChange('drawnGeojson', geojson);
                       dispatch(CreateProjectActions.SetDrawnGeojson(JSON.parse(geojson)));
                       dispatch(CreateProjectActions.SetTotalAreaSelection(area));


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Issue

Fixes #1276 

## Describe this PR

This PR ensures that the form state is cleared including the data extract when the Geojson is redrawn enabling user to extract data each time the AOI is changed.

## Screenshots

-  Able to generate extract for the second time.
![image](https://github.com/hotosm/fmtm/assets/123072058/8f211a8e-1618-4a35-b7fd-7c9dfcf55c68)

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the FMTM Code of Conduct: <https://github.com/hotosm/fmtm/blob/main/CODE_OF_CONDUCT.md>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
