### PR TITLE
Only load My Organisations once on tab click

### DIFF
--- a/src/frontend/src/views/Organisation.tsx
+++ b/src/frontend/src/views/Organisation.tsx
@@ -20,6 +20,7 @@ const Organisation = () => {
   const [searchKeyword, setSearchKeyword] = useState<string>('');
   const [activeTab, setActiveTab] = useState<0 | 1>(0);
   const [verifiedTab, setVerifiedTab] = useState<boolean>(true);
+  const [myOrgsLoaded, setMyOrgsLoaded] = useState(false);
   const token = CoreModules.useAppSelector((state) => state.login.loginToken);
   const defaultTheme = CoreModules.useAppSelector((state) => state.theme.hotTheme);
 
@@ -48,9 +49,7 @@ const Organisation = () => {
     );
     return filteredCardData;
   };
-  useEffect(() => {
-    dispatch(MyOrganisationDataService(`${import.meta.env.VITE_API_URL}/organisation/my-organisations`));
-  }, []);
+
   useEffect(() => {
     if (verifiedTab) {
       dispatch(OrganisationDataService(`${import.meta.env.VITE_API_URL}/organisation/`));
@@ -58,6 +57,14 @@ const Organisation = () => {
       dispatch(OrganisationDataService(`${import.meta.env.VITE_API_URL}/organisation/unapproved/`));
     }
   }, [verifiedTab]);
+
+  const loadMyOrganisations = () => {
+    if (!myOrgsLoaded) {
+      dispatch(MyOrganisationDataService(`${import.meta.env.VITE_API_URL}/organisation/my-organisations`));
+      setMyOrgsLoaded(true);
+    }
+    setActiveTab(1);
+  };
 
   return (
     <CoreModules.Box
@@ -109,7 +116,7 @@ const Organisation = () => {
                 px: ['12px', '16px', '16px'],
               }}
               className="fmtm-duration-150"
-              onClick={() => setActiveTab(1)}
+              onClick={() => loadMyOrganisations()}
             />
             {token && (
               <CoreModules.Link to={'/create-organization'}>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Issue

Fixes #1251

## Describe this PR

- Previously the My Organisations endpoint was called on page load, even if the user does not click the tab.
- This change means the endpoint is not called unless the user clicks the tab.
- The endpoint is only called once despite changing tabs.

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the FMTM Code of Conduct: <https://github.com/hotosm/fmtm/blob/main/CODE_OF_CONDUCT.md>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
