### PR TITLE
Implement download on clicking `download-icon` in `qrpopup` 

### DIFF
--- a/src/frontend/src/components/GenerateBasemap.jsx
+++ b/src/frontend/src/components/GenerateBasemap.jsx
@@ -3,19 +3,23 @@ import CoreModules from '@/shared/CoreModules';
 import AssetModules from '@/shared/AssetModules';
 import environment from '@/environment';
 import { DownloadTile, GenerateProjectTiles, GetTilesList } from '@/api/Project';
+import { ProjectActions } from '@/store/slices/ProjectSlice';
 
-const GenerateBasemap = ({ setToggleGenerateModal, toggleGenerateModal, projectInfo }) => {
+const GenerateBasemap = ({ projectInfo }) => {
   const dispatch = CoreModules.useAppDispatch();
   const params = CoreModules.useParams();
   const encodedId = params.id;
   const decodedId = environment.decode(encodedId);
-  const defaultTheme = CoreModules.useAppSelector((state) => state.theme.hotTheme);
-  const generateProjectTilesLoading = CoreModules.useAppSelector((state) => state.project.generateProjectTilesLoading);
-  const tilesList = CoreModules.useAppSelector((state) => state.project.tilesList);
+
   const [selectedTileSource, setSelectedTileSource] = useState(null);
   const [selectedOutputFormat, setSelectedOutputFormat] = useState(null);
   const [tmsUrl, setTmsUrl] = useState('');
   const [error, setError] = useState([]);
+
+  const toggleGenerateMbTilesModal = CoreModules.useAppSelector((state) => state.project.toggleGenerateMbTilesModal);
+  const defaultTheme = CoreModules.useAppSelector((state) => state.theme.hotTheme);
+  const generateProjectTilesLoading = CoreModules.useAppSelector((state) => state.project.generateProjectTilesLoading);
+  const tilesList = CoreModules.useAppSelector((state) => state.project.tilesList);
 
   const modalStyle = (theme) => ({
     width: '90vw', // Responsive modal width using vw
@@ -35,10 +39,10 @@ const GenerateBasemap = ({ setToggleGenerateModal, toggleGenerateModal, projectI
 
   useEffect(() => {
     // Only fetch tiles list when the modal is open
-    if (toggleGenerateModal) {
+    if (toggleGenerateMbTilesModal) {
       getTilesList();
     }
-  }, [toggleGenerateModal]);
+  }, [toggleGenerateMbTilesModal]);
 
   const handleTileSourceChange = (e) => {
     setSelectedTileSource(e.target.value);
@@ -83,16 +87,20 @@ const GenerateBasemap = ({ setToggleGenerateModal, toggleGenerateModal, projectI
 
   return (
     <CoreModules.CustomizedModal
-      isOpen={!!toggleGenerateModal}
+      isOpen={!!toggleGenerateMbTilesModal}
       style={modalStyle}
-      toggleOpen={() => setToggleGenerateModal(!toggleGenerateModal)}
+      toggleOpen={() => {
+        dispatch(ProjectActions.ToggleGenerateMbTilesModalStatus(!toggleGenerateMbTilesModal));
+      }}
     >
       <CoreModules.Grid container spacing={2}>
         {/* Close Button */}
         <CoreModules.Grid item xs={12}>
           <CoreModules.IconButton
             aria-label="close"
-            onClick={() => setToggleGenerateModal(!toggleGenerateModal)}
+            onClick={() => {
+              dispatch(ProjectActions.ToggleGenerateMbTilesModalStatus(!toggleGenerateMbTilesModal));
+            }}
             sx={{ width: '50px', float: 'right', display: 'block' }}
           >
             <AssetModules.CloseIcon />

--- a/src/frontend/src/components/ProjectDetailsV2/ProjectOptions.tsx
+++ b/src/frontend/src/components/ProjectDetailsV2/ProjectOptions.tsx
@@ -8,7 +8,7 @@ import Button from '@/components/common/Button';
 import { useNavigate } from 'react-router-dom';
 import { downloadProjectFormLoadingType } from '@/models/project/projectModel';
 
-const ProjectOptions = ({ setToggleGenerateModal }) => {
+const ProjectOptions = () => {
   const dispatch = CoreModules.useAppDispatch();
   const params = CoreModules.useParams();
   const navigate = useNavigate();
@@ -96,7 +96,7 @@ const ProjectOptions = ({ setToggleGenerateModal }) => {
           <div className="fmtm-flex fmtm-flex-col sm:fmtm-flex-row sm:fmtm-justify-center lg:fmtm-justify-end fmtm-w-full sm:fmtm-ml-4 fmtm-gap-6">
             <CoreModules.Button
               onClick={() => {
-                setToggleGenerateModal(true);
+                dispatch(ProjectActions.ToggleGenerateMbTilesModalStatus(true));
                 dispatch(ProjectActions.SetMobileFooterSelection('explore'));
               }}
               variant="contained"

--- a/src/frontend/src/components/ProjectDetailsV2/TaskSectionPopup.tsx
+++ b/src/frontend/src/components/ProjectDetailsV2/TaskSectionPopup.tsx
@@ -60,14 +60,27 @@ const TaskSectionPopup = ({ taskId, body, feature }: TaskSectionPopupPropType) =
         fmtm-rounded-t-3xl fmtm-border-opacity-50`}
     >
       <div
-        onClick={() => dispatch(ProjectActions.ToggleTaskModalStatus(false))}
         className={`fmtm-absolute fmtm-top-[17px] fmtm-right-[20px] ${
           taskModalStatus ? '' : 'fmtm-hidden'
         }  fmtm-cursor-pointer fmtm-flex fmtm-items-center fmtm-gap-3`}
       >
-        <AssetModules.FileDownloadOutlinedIcon style={{ width: '20px' }} className="hover:fmtm-text-primaryRed " />
-        <AssetModules.DescriptionOutlinedIcon style={{ width: '20px' }} className="hover:fmtm-text-primaryRed " />
-        <AssetModules.CloseIcon style={{ width: '20px' }} className="hover:fmtm-text-primaryRed " />
+        <AssetModules.FileDownloadOutlinedIcon
+          style={{ width: '20px' }}
+          className="hover:fmtm-text-primaryRed"
+          onClick={() => {
+            dispatch(ProjectActions.ToggleGenerateMbTilesModalStatus(true));
+          }}
+        />
+        <AssetModules.DescriptionOutlinedIcon
+          style={{ width: '20px' }}
+          className="hover:fmtm-text-primaryRed"
+          onClick={() => {}}
+        />
+        <AssetModules.CloseIcon
+          style={{ width: '20px' }}
+          className="hover:fmtm-text-primaryRed"
+          onClick={() => dispatch(ProjectActions.ToggleTaskModalStatus(false))}
+        />
       </div>
       <div className="fmtm-bg-[#fbfbfb] fmtm-rounded-t-2xl fmtm-shadow-[-20px_0px_60px_25px_rgba(0,0,0,0.2)]  md:fmtm-rounded-tr-none md:fmtm-rounded-l-2xl">
         <div className="fmtm-flex fmtm-flex-col fmtm-gap-2 fmtm-p-5">

--- a/src/frontend/src/store/slices/ProjectSlice.ts
+++ b/src/frontend/src/store/slices/ProjectSlice.ts
@@ -17,6 +17,7 @@ const initialState: ProjectStateTypes = {
   downloadTilesLoading: false,
   downloadDataExtractLoading: false,
   taskModalStatus: false,
+  toggleGenerateMbTilesModal: false,
   mobileFooterSelection: 'explore',
   geolocationStatus: false,
   projectDetailsLoading: true,
@@ -79,6 +80,9 @@ const ProjectSlice = createSlice({
     },
     ToggleTaskModalStatus(state, action) {
       state.taskModalStatus = action.payload;
+    },
+    ToggleGenerateMbTilesModalStatus(state, action) {
+      state.toggleGenerateMbTilesModal = action.payload;
     },
     SetMobileFooterSelection(state, action) {
       state.mobileFooterSelection = action.payload;

--- a/src/frontend/src/store/types/IProject.ts
+++ b/src/frontend/src/store/types/IProject.ts
@@ -20,6 +20,7 @@ export type ProjectStateTypes = {
   downloadTilesLoading: boolean;
   downloadDataExtractLoading: boolean;
   taskModalStatus: boolean;
+  toggleGenerateMbTilesModal: boolean;
   mobileFooterSelection: string;
   geolocationStatus: boolean;
   projectDetailsLoading: boolean;

--- a/src/frontend/src/views/ProjectDetailsV2.tsx
+++ b/src/frontend/src/views/ProjectDetailsV2.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import '../../node_modules/ol/ol.css';
 import '../styles/home.scss';
 import WindowDimension from '@/hooks/WindowDimension';
-import MapDescriptionComponents from '@/components/MapDescriptionComponents';
+// import MapDescriptionComponents from '@/components/MapDescriptionComponents';
 import ActivitiesPanel from '@/components/ProjectDetailsV2/ActivitiesPanel';
 import environment from '@/environment';
 import { ProjectById, GetProjectDashboard } from '@/api/Project';
@@ -27,7 +27,7 @@ import LayerSwitcherControl from '@/components/MapComponent/OpenLayersComponent/
 import MapControlComponent from '@/components/ProjectDetailsV2/MapControlComponent';
 import { VectorLayer } from '@/components/MapComponent/OpenLayersComponent/Layers';
 import { geojsonObjectModel } from '@/constants/geojsonObjectModal';
-import { basicGeojsonTemplate } from '@/utilities/mapUtils';
+// import { basicGeojsonTemplate } from '@/utilities/mapUtils';
 import getTaskStatusStyle from '@/utilfunctions/getTaskStatusStyle';
 import { defaultStyles } from '@/components/MapComponent/OpenLayersComponent/helpers/styleUtils';
 import MapLegends from '@/components/MapLegends';
@@ -54,7 +54,6 @@ const Home = () => {
 
   const [mainView, setView] = useState<any>();
   const [featuresLayer, setFeaturesLayer] = useState();
-  const [toggleGenerateModal, setToggleGenerateModal] = useState<boolean>(false);
   const [dataExtractUrl, setDataExtractUrl] = useState(null);
   const [dataExtractExtent, setDataExtractExtent] = useState(null);
   const [taskBoundariesLayer, setTaskBoundariesLayer] = useState<null | Record<string, any>>(null);
@@ -195,7 +194,7 @@ const Home = () => {
 
   useEffect(() => {
     if (mobileFooterSelection !== 'explore') {
-      setToggleGenerateModal(false);
+      dispatch(ProjectActions.ToggleGenerateMbTilesModalStatus(false));
     }
   }, [mobileFooterSelection]);
 
@@ -278,11 +277,7 @@ const Home = () => {
     <div className="fmtm-bg-[#F5F5F5] fmtm-h-[100vh] sm:fmtm-h-[90vh]">
       {/* Customized Modal For Generate Tiles */}
       <div>
-        <GenerateBasemap
-          toggleGenerateModal={toggleGenerateModal}
-          setToggleGenerateModal={setToggleGenerateModal}
-          projectInfo={state.projectInfo}
-        />
+        <GenerateBasemap projectInfo={state.projectInfo} />
 
         {/* Home snackbar */}
         <CustomizedSnackbar
@@ -383,7 +378,7 @@ const Home = () => {
                   toggle ? 'fmtm-left-0 fmtm-top-0' : '-fmtm-left-[60rem] fmtm-top-0'
                 }`}
               >
-                <ProjectOptions setToggleGenerateModal={false} />
+                <ProjectOptions />
               </div>
             </div>
           </div>
@@ -465,7 +460,9 @@ const Home = () => {
                 <Button
                   btnText="GENERATE MBTILES"
                   icon={<AssetModules.BoltIcon />}
-                  onClick={() => setToggleGenerateModal(true)}
+                  onClick={() => {
+                    dispatch(ProjectActions.ToggleGenerateMbTilesModalStatus(true));
+                  }}
                   btnType="primary"
                   className="!fmtm-text-base !fmtm-pr-2"
                 />
@@ -509,7 +506,7 @@ const Home = () => {
               <BottomSheet
                 body={
                   <div className="fmtm-mb-[10vh]">
-                    <ProjectOptions setToggleGenerateModal={setToggleGenerateModal} />
+                    <ProjectOptions />
                   </div>
                 }
                 onClose={() => dispatch(ProjectActions.SetMobileFooterSelection('explore'))}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Issue

- fixes #1243

## Describe this PR

This PR adds a global state to open and close the generate mb tiles modal. And then the functionality is implemented in download icon of `TaskSectionPopup`.

## Screenshots

![image](https://github.com/hotosm/fmtm/assets/123072058/d1981574-c7f3-4f4b-99cf-ae40aa02ac55)

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the FMTM Code of Conduct: <https://github.com/hotosm/fmtm/blob/main/CODE_OF_CONDUCT.md>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
