### PR TITLE
fix uploadArea: apply limit condition for only Km.sq.

### DIFF
--- a/src/frontend/src/components/createnewproject/UploadArea.tsx
+++ b/src/frontend/src/components/createnewproject/UploadArea.tsx
@@ -46,7 +46,8 @@ const UploadArea = ({ flag, geojsonFile, setGeojsonFile, setCustomLineUpload, se
   const submission = () => {
     if (totalAreaSelection) {
       const totalArea = parseFloat(totalAreaSelection?.split(' ')[0]);
-      if (totalArea > 1000) {
+      const areaUnit = totalAreaSelection?.split(' ')[1];
+      if (totalArea > 1000 && areaUnit === 'km²') {
         dispatch(
           CommonActions.SetSnackBar({
             open: true,
@@ -162,7 +163,8 @@ const UploadArea = ({ flag, geojsonFile, setGeojsonFile, setCustomLineUpload, se
   useEffect(() => {
     if (totalAreaSelection) {
       const totalArea = parseFloat(totalAreaSelection?.split(' ')[0]);
-      if (totalArea > 100) {
+      const areaUnit = totalAreaSelection?.split(' ')[1];
+      if (totalArea > 100 && areaUnit === 'km²') {
         dispatch(
           CommonActions.SetSnackBar({
             open: true,
@@ -172,7 +174,7 @@ const UploadArea = ({ flag, geojsonFile, setGeojsonFile, setCustomLineUpload, se
           }),
         );
       }
-      if (totalArea > 1000) {
+      if (totalArea > 1000 && areaUnit === 'km²') {
         dispatch(
           CommonActions.SetSnackBar({
             open: true,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Related Issue
- Fix #1303 

## Describe this PR
This PR solves area limit exceed warning & error shown for even small area as `> 1000` was checked despite checking `1000m2` or `1000km2`. Now `> 1000` is only checked for `Km2`.

## Screenshots
![image_720](https://github.com/hotosm/fmtm/assets/81785002/3d2b5b06-932e-4eef-8d99-8b771b90cbbb)