### PR TITLE
Use defusedxml for xml parsing, only parse one in proj creation

### DIFF
--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -550,7 +550,7 @@ async def validate_form(form: UploadFile):
         )
 
     contents = await form.read()
-    return await central_crud.test_form_validity(contents, file_ext)
+    return await central_crud.read_and_test_xform(BytesIO(contents), file_ext)
 
 
 @router.post("/{project_id}/generate-project-data")

--- a/src/backend/pdm.lock
+++ b/src/backend/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "debug", "dev", "docs", "test"]
 strategy = ["cross_platform"]
 lock_version = "4.4.1"
-content_hash = "sha256:d693f1ae41c1ad45d442625ba0ad8873d81c5404bc3a3e64de7ddfb3de207d37"
+content_hash = "sha256:06a4dffbc82951158ac785eea6622b443cd2667bc095c0f59cac9e1582e9350e"
 
 [[package]]
 name = "annotated-types"

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -45,6 +45,7 @@ dependencies = [
     "asgiref==3.7.2",
     "sozipfile==0.3.2",
     "cryptography>=42.0.1",
+    "defusedxml>=0.7.1",
     "osm-login-python==1.0.1",
     "osm-fieldwork==0.5.1",
     "osm-rawdata==0.2.3",

--- a/src/frontend/src/api/CreateProjectService.ts
+++ b/src/frontend/src/api/CreateProjectService.ts
@@ -462,11 +462,9 @@ const ValidateCustomForm: Function = (url: string, formUpload: any) => {
         dispatch(
           CommonActions.SetSnackBar({
             open: true,
-            message:
-              JSON.stringify(`${error.response.data.message}, ${error.response.data.possible_reason}`) ||
-              'Something Went Wrong',
+            message: JSON.stringify(error.response.data.detail) || 'Something Went Wrong',
             variant: 'error',
-            duration: 2000,
+            duration: 5000,
           }),
         );
         dispatch(CreateProjectActions.ValidateCustomFormLoading(false));


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Describe this PR

- We were parsing XML directly from the user previously.
- This opens up FMTM to a whole host of exploits and is bad security.
- Using the defusedxml package is a drop in replacement for Python standard lib xml.
- It removes potential security threats.
- I also refactored to make the XForm parsing logic more modular.
- We now only parse the XLSForm once during project creation, then pass through the data to the task creation.
- This should hopefully prevent issues of filesystem conflicts between API replicas etc.

Affects the form validity check during project creation, and the file form parsing in `generate-project-files`.

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the FMTM Code of Conduct: <https://github.com/hotosm/fmtm/blob/main/CODE_OF_CONDUCT.md>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
