### PR TITLE
Hotfix use centroids to determine extract tasks split

### DIFF
--- a/src/backend/app/db/postgis_utils.py
+++ b/src/backend/app/db/postgis_utils.py
@@ -257,6 +257,7 @@ async def split_geojson_by_task_areas(
     """Split GeoJSON into tagged task area GeoJSONs.
 
     NOTE inserts feature.properties.osm_id as feature.id for each feature.
+    NOTE ST_Within used on polygon centroids to correctly capture the geoms per task.
 
     Args:
         db (Session): SQLAlchemy db session.
@@ -330,7 +331,7 @@ async def split_geojson_by_task_areas(
                 FROM temp_features
             ) AS temp_features
             WHERE
-                ST_Within(temp_features.geometry, tasks.outline)
+                ST_Within(ST_Centroid(temp_features.geometry), tasks.outline)
         ) AS feature ON true
         WHERE
             tasks.project_id = :project_id


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🎨 Style
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

## Describe this PR

- Data extracts were not correct in ODK Central due to using ST_Within, without first determining the centroid of the polygon.
- If the polygon was not entirely contained within the task area then it was not included.

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the FMTM Code of Conduct: <https://github.com/hotosm/fmtm/blob/main/CODE_OF_CONDUCT.md>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
