### PR TITLE
fix createProject: radiobutton replace with checkbox to change formWa…

### DIFF
--- a/src/frontend/src/components/createnewproject/SelectForm.tsx
+++ b/src/frontend/src/components/createnewproject/SelectForm.tsx
@@ -12,11 +12,7 @@ import FileInputComponent from '@/components/common/FileInputComponent';
 import SelectFormValidation from '@/components/createnewproject/validation/SelectFormValidation';
 import { FormCategoryService, ValidateCustomForm } from '@/api/CreateProjectService';
 import NewDefineAreaMap from '@/views/NewDefineAreaMap';
-
-const osmFeatureTypeOptions = [
-  { name: 'form_ways', value: 'existing_form', label: 'Use Existing Form' },
-  { name: 'form_ways', value: 'custom_form', label: 'Upload a Custom Form' },
-];
+import { CustomCheckbox } from '../common/Checkbox';
 
 const SelectForm = ({ flag, geojsonFile, customFormFile, setCustomFormFile }) => {
   const dispatch = useDispatch();
@@ -136,16 +132,18 @@ const SelectForm = ({ flag, geojsonFile, customFormFile, setCustomFormFile }) =>
                   {`if uploading the final submissions to OSM.`}
                 </p>
               </div>
-              <RadioButton
-                topic="You may choose to use existing category or upload your own xlsx form"
-                options={osmFeatureTypeOptions}
-                direction="column"
-                value={formValues.formWays}
-                onChangeData={(value) => {
-                  resetFile();
-                  handleCustomChange('formWays', value);
+              <CustomCheckbox
+                key="fillODKCredentials"
+                label="Upload a custom XLSForm instead"
+                checked={formValues.formWays === 'custom_form'}
+                onCheckedChange={(status) => {
+                  if (status) {
+                    handleCustomChange('formWays', 'custom_form');
+                  } else {
+                    handleCustomChange('formWays', 'existing_form');
+                  }
                 }}
-                errorMsg={errors.formWays}
+                className="fmtm-text-black"
               />
               {formValues.formWays === 'custom_form' ? (
                 <FileInputComponent

--- a/src/frontend/src/components/createnewproject/validation/SelectFormValidation.tsx
+++ b/src/frontend/src/components/createnewproject/validation/SelectFormValidation.tsx
@@ -15,9 +15,6 @@ function SelectFormValidation(values: ProjectValues) {
   if (!values?.formCategorySelection) {
     errors.formCategorySelection = 'Form Category is Required.';
   }
-  if (!values?.formWays) {
-    errors.formWays = 'Form Selection is Required.';
-  }
   if (values?.formWays === 'custom_form' && !values?.customFormUpload) {
     errors.customFormUpload = 'Form needs to be Uploaded.';
   }

--- a/src/frontend/src/store/slices/CreateProjectSlice.ts
+++ b/src/frontend/src/store/slices/CreateProjectSlice.ts
@@ -16,6 +16,7 @@ export const initialState: CreateProjectStateTypes = {
     description: '',
     organisation_id: null,
     per_task_instructions: '',
+    formWays: 'existing_form',
   },
   projectDetailsResponse: null,
   projectDetailsLoading: false,
@@ -80,6 +81,7 @@ const CreateProject = createSlice({
         odk_central_password: '',
         description: '',
         organisation_id: null,
+        form_ways: 'existing_form',
       };
       state.projectArea = null;
       state.totalAreaSelection = null;


### PR DESCRIPTION
…y type

## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue
- Fix #1029

## Describe this PR
This PR updates the Select Form UI of create project by replacing the `radiobutton` with `checkbox`.

## Screenshots
Before: 
![image](https://github.com/hotosm/fmtm/assets/81785002/077e7e9a-6a84-4651-bb0a-9418fe2fd956)

After:
![image](https://github.com/hotosm/fmtm/assets/81785002/221ec225-daad-46f1-b392-b5793e314c25)


Please provide screenshots of the change.

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
