### PR TITLE
fix uploadArea: geojson with no features leading page crash error solve

### DIFF
--- a/src/frontend/src/components/MapComponent/OpenLayersComponent/Layers/VectorLayer.js
+++ b/src/frontend/src/components/MapComponent/OpenLayersComponent/Layers/VectorLayer.js
@@ -18,8 +18,8 @@ import MultiPoint from 'ol/geom/MultiPoint.js';
 import { buffer } from 'ol/extent';
 import { bbox as OLBbox } from 'ol/loadingstrategy';
 import { geojson as FGBGeoJson } from 'flatgeobuf';
-
 import { isValidUrl } from '@/utilfunctions/urlChecker';
+import { featureCollectionHasFeatures } from '@/utilfunctions/commonUtils';
 
 const selectElement = 'singleselect';
 
@@ -229,6 +229,7 @@ const VectorLayer = ({
     if (!map) return;
     if (!geojson) return;
     if (!valid(geojson)) return;
+    if (!featureCollectionHasFeatures(geojson)) return;
 
     const vectorLyr = new OLVectorLayer({
       source: new VectorSource({
@@ -340,7 +341,7 @@ const VectorLayer = ({
   useEffect(() => {
     if (!map || !vectorLayer || !zoomToLayer) return;
     const source = vectorLayer.getSource();
-    if (source.getFeatures().length === 0) return;
+    if (source.getFeatures()?.length === 0) return;
     const extent = source.getExtent();
     if (!isExtentValid(extent)) return;
     map.getView().fit(extent, viewProperties);
@@ -379,7 +380,7 @@ const VectorLayer = ({
     });
     function pointerMovefn(event) {
       vectorLayer.getFeatures(event.pixel).then((features) => {
-        if (!features.length) {
+        if (!features?.length) {
           selection = {};
           hoverEffect(undefined, vectorLayer);
 

--- a/src/frontend/src/utilfunctions/commonUtils.ts
+++ b/src/frontend/src/utilfunctions/commonUtils.ts
@@ -5,3 +5,15 @@ export const isInputEmpty = (text: string): boolean => {
   const trimmedText = text.trim();
   return trimmedText === '';
 };
+
+export const featureCollectionHasFeatures = (geojson): boolean => {
+  if (
+    geojson?.type === 'FeatureCollection' &&
+    geojson?.features &&
+    Array.isArray(geojson?.features) &&
+    geojson?.features?.length === 0
+  ) {
+    return false;
+  }
+  return true;
+};


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue
- Fix: #1365

## Describe this PR
This PR solves the page crash problem whenever a geojson with empty features is uploaded.

## Screenshots
![image](https://github.com/hotosm/fmtm/assets/81785002/8f870760-17c1-49b2-96f9-488b8822c6b5)

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
