### PR TITLE
fix uploadArea: invalid geojson error handling

### DIFF
--- a/src/frontend/src/components/MapComponent/OpenLayersComponent/Layers/VectorLayer.js
+++ b/src/frontend/src/components/MapComponent/OpenLayersComponent/Layers/VectorLayer.js
@@ -239,6 +239,9 @@ const VectorLayer = ({
       declutter: true,
     });
 
+    const vlFeature = vectorLyr?.getSource().getFeatures();
+    if (!vlFeature || (vlFeature && vlFeature?.length === 0)) return;
+
     map.on('click', (evt) => {
       var pixel = evt.pixel;
       const feature = map.forEachFeatureAtPixel(pixel, function (feature, layer) {

--- a/src/frontend/src/components/createnewproject/UploadArea.tsx
+++ b/src/frontend/src/components/createnewproject/UploadArea.tsx
@@ -126,6 +126,17 @@ const UploadArea = ({ flag, geojsonFile, setGeojsonFile, setCustomDataExtractUpl
   };
 
   useEffect(() => {
+    if (drawnGeojson && !valid(drawnGeojson)) {
+      dispatch(
+        CommonActions.SetSnackBar({
+          open: true,
+          message: 'File not a valid geojson',
+          variant: 'error',
+          duration: 4000,
+        }),
+      );
+      return;
+    }
     if (drawnGeojson) {
       const isWGS84 = () => {
         if (uploadAreaSelection === 'upload_file') {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue
- Related to #1365 

## Describe this PR
This PR solves the page crash problem whenever a geojson with empty features is uploaded.

## Screenshots
![image](https://github.com/hotosm/fmtm/assets/81785002/1ad3c4da-0909-4c4c-acaf-dffb49e060f9)

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
