### PR TITLE
Separate response for comment and task status history

### DIFF
--- a/src/backend/app/tasks/tasks_routes.py
+++ b/src/backend/app/tasks/tasks_routes.py
@@ -18,7 +18,7 @@
 """Routes for FMTM tasks."""
 
 from datetime import datetime, timedelta
-from typing import List
+from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from loguru import logger as log
@@ -256,9 +256,13 @@ async def task_activity(
     )
 
 
-@router.get("/task_history/", response_model=List[tasks_schemas.TaskHistory])
+@router.get("/task_history/")
 async def task_history(
-    project_id: int, days: int = 10, db: Session = Depends(database.get_db)
+    project_id: int,
+    days: int = 10,
+    comment: bool = False,
+    task_id: Optional[int] = None,
+    db: Session = Depends(database.get_db),
 ):
     """Get the detailed task history for a project.
 
@@ -266,10 +270,16 @@ async def task_history(
         project_id (int): The ID of the project.
         days (int): The number of days to consider for the
             task activity (default: 10).
+        comment (bool): True or False, True to get comments
+            from the project tasks and False by default for
+            entire task status history.
+        task_id (int): The task_id of the project.
         db (Session): The database session.
 
     Returns:
         List[TaskHistory]: A list of task history.
     """
     end_date = datetime.now() - timedelta(days=days)
-    return await tasks_crud.get_project_task_history(project_id, end_date, db)
+    return await tasks_crud.get_project_task_history(
+        project_id, comment, end_date, task_id, db
+    )


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [X] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- Fixes #1390

## Describe this PR

This PR refactors the end point task_history using raw sql returning separate response for comments in task and task status history.
We dont need separate comment `get` endpoint now.

## Response

```
[
  {
    "id": 110,
    "project_id": 236,
    "task_id": 2350,
    "action": "RELEASED_FOR_MAPPING",
    "action_text": "Status changed from READY to LOCKED_FOR_MAPPING by: svcfmtm",
    "action_date": "2024-03-26T04:32:15.998587",
    "status": "LOCKED_FOR_MAPPING"
  },
  {
    "id": 111,
    "project_id": 236,
    "task_id": 2347,
    "action": "RELEASED_FOR_MAPPING",
    "action_text": "Status changed from READY to LOCKED_FOR_MAPPING by: svcfmtm",
    "action_date": "2024-03-26T04:32:20.254619",
    "status": "LOCKED_FOR_MAPPING"
  }
]
```
comments

```
[
  {
    "id": 112,
    "project_id": 236,
    "task_id": 2349,
    "action": "COMMENT",
    "action_text": "<p>this is test comment for task id 2349</p>",
    "action_date": "2024-03-26T04:33:41.524730",
    "status": null
  }
]
```

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
