### PR TITLE
Add optional auth to raw-data-api calls, plus folder structure for persistence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,7 @@ OSM_URL=${OSM_URL:-"https://www.openstreetmap.org"}
 OSM_SCOPE=${OSM_SCOPE:-"read_prefs"}
 OSM_LOGIN_REDIRECT_URI="http${FMTM_DOMAIN:+s}://${FMTM_DOMAIN:-127.0.0.1:7051}/osmauth/"
 OSM_SECRET_KEY=${OSM_SECRET_KEY}
+OSM_SVC_ACCOUNT_TOKEN=${OSM_SVC_ACCOUNT_TOKEN}
 
 ### S3 File Storage ###
 S3_ENDPOINT=${S3_ENDPOINT:-"http://s3:9000"}

--- a/src/backend/app/config.py
+++ b/src/backend/app/config.py
@@ -154,6 +154,16 @@ class Settings(BaseSettings):
             return f"https://s3.{fmtm_domain}"
 
     UNDERPASS_API_URL: HttpUrlStr = "https://api-prod.raw-data.hotosm.org/v1"
+    # NOTE this var is used by HOT internally and not required
+    OSM_SVC_ACCOUNT_TOKEN: Optional[str] = None
+
+    @field_validator("OSM_SVC_ACCOUNT_TOKEN", mode="before")
+    @classmethod
+    def set_osm_svc_account_none(cls, v: Optional[str]) -> Optional[str]:
+        """Set OSM_SVC_ACCOUNT_TOKEN to None if set to empty string."""
+        if v == "":
+            return None
+
     SENTRY_DSN: Optional[str] = None
 
     model_config = SettingsConfigDict(

--- a/src/backend/app/config.py
+++ b/src/backend/app/config.py
@@ -163,6 +163,7 @@ class Settings(BaseSettings):
         """Set OSM_SVC_ACCOUNT_TOKEN to None if set to empty string."""
         if v == "":
             return None
+        return v
 
     SENTRY_DSN: Optional[str] = None
 

--- a/src/backend/app/projects/project_crud.py
+++ b/src/backend/app/projects/project_crud.py
@@ -754,7 +754,7 @@ async def upload_custom_extract_to_s3(
 
     # Add url and type to database
     s3_fgb_full_url = (
-        f"{settings.S3_DOWNLOAD_ROOT}/{settings.S3_BUCKET_NAME}{s3_fgb_path}"
+        f"{settings.S3_DOWNLOAD_ROOT}/{settings.S3_BUCKET_NAME}/{s3_fgb_path}"
     )
 
     await update_data_extract_url_in_db(db, project, s3_fgb_full_url, data_extract_type)

--- a/src/backend/app/projects/project_crud.py
+++ b/src/backend/app/projects/project_crud.py
@@ -443,12 +443,14 @@ async def generate_data_extract(
     pg = PostgresClient(
         "underpass",
         extract_config,
-        # auth_token=settings.OSM_SVC_ACCOUNT_TOKEN,
+        auth_token=settings.OSM_SVC_ACCOUNT_TOKEN
+        if settings.OSM_SVC_ACCOUNT_TOKEN
+        else None,
     )
     fgb_url = pg.execQuery(
         aoi,
         extra_params={
-            "fileName": "fmtm_extract",
+            "fileName": f"fmtm/{settings.FMTM_DOMAIN}/fmtm_extract",
             "outputType": "fgb",
             "bind_zip": False,
             "useStWithin": False,
@@ -736,9 +738,9 @@ async def upload_custom_extract_to_s3(
         raise HTTPException(status_code=404, detail="Project not found")
 
     fgb_obj = BytesIO(fgb_content)
-    s3_fgb_path = f"/{project.organisation_id}/{project_id}/custom_extract.fgb"
+    s3_fgb_path = f"{project.organisation_id}/{project_id}/custom_extract.fgb"
 
-    log.debug(f"Uploading fgb to S3 path: {s3_fgb_path}")
+    log.debug(f"Uploading fgb to S3 path: /{s3_fgb_path}")
     add_obj_to_bucket(
         settings.S3_BUCKET_NAME,
         fgb_obj,
@@ -924,16 +926,6 @@ async def generate_project_files(
             xlsform_path = f"{xlsforms_path}/{form_category}.xls"
             with open(xlsform_path, "rb") as f:
                 xlsform = BytesIO(f.read())
-
-            # NOTE would filtering be required at any point if this
-            # NOTE is handled upstream?
-            # filter = FilterData(xlsform)
-            # updated_data_extract = {"type": "FeatureCollection", "features": []}
-            # filtered_data_extract = (
-            #     filter.cleanData(data_extract)
-            #     if data_extract
-            #     else updated_data_extract
-            # )
 
         # Extract data extract from flatgeobuf
         log.debug("Getting data extract geojson from flatgeobuf")

--- a/src/backend/app/projects/project_crud.py
+++ b/src/backend/app/projects/project_crud.py
@@ -450,7 +450,11 @@ async def generate_data_extract(
     fgb_url = pg.execQuery(
         aoi,
         extra_params={
-            "fileName": f"fmtm/{settings.FMTM_DOMAIN}/fmtm_extract",
+            "fileName": (
+                f"fmtm/{settings.FMTM_DOMAIN}/data_extract"
+                if settings.OSM_SVC_ACCOUNT_TOKEN
+                else "fmtm_extract"
+            ),
             "outputType": "fgb",
             "bind_zip": False,
             "useStWithin": False,

--- a/src/backend/app/s3.py
+++ b/src/backend/app/s3.py
@@ -71,9 +71,9 @@ def add_obj_to_bucket(
         kwargs (dict[str, Any]): Any other arguments to pass to client.put_object.
 
     """
-    # Ensure s3_path starts with a forward slash
-    if not s3_path.startswith("/"):
-        s3_path = f"/{s3_path}"
+    # Strip "/" from start of s3_path (not required by put_object)
+    if s3_path.startswith("/"):
+        s3_path = s3_path.lstrip("/")
 
     client = s3_client()
     # Set BytesIO object to start, prior to .read()

--- a/src/backend/pdm.lock
+++ b/src/backend/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "debug", "dev", "docs", "test"]
 strategy = ["cross_platform"]
 lock_version = "4.4.1"
-content_hash = "sha256:050398876ce81974dd0dfe06adcd987b2b7515b0f1fb9434c0b420084f7891d3"
+content_hash = "sha256:6941b46327c1822b7d647cad3ec48b07b1c03726edd2bb90bbd791d71666d631"
 
 [[package]]
 name = "aiohttp"

--- a/src/backend/pdm.lock
+++ b/src/backend/pdm.lock
@@ -1521,7 +1521,7 @@ files = [
 
 [[package]]
 name = "osm-rawdata"
-version = "0.2.3"
+version = "0.2.4"
 requires_python = ">=3.10"
 summary = "Make data extracts from OSM data."
 dependencies = [
@@ -1537,8 +1537,8 @@ dependencies = [
     "sqlalchemy>=2.0.0",
 ]
 files = [
-    {file = "osm-rawdata-0.2.3.tar.gz", hash = "sha256:56ebb4147041f86cb5f30564e93621813de4a8bdfc2508fb1d9080db392b9151"},
-    {file = "osm_rawdata-0.2.3-py3-none-any.whl", hash = "sha256:a0d11bab1143386c9fe05aa0b6d878e577a9386698e3a061ee948eaeecbcd87f"},
+    {file = "osm-rawdata-0.2.4.tar.gz", hash = "sha256:5fbf1b91930846a3d6bd1ea3fcedb99b46e2968ef6bad397de8c2f395ba3fbe7"},
+    {file = "osm_rawdata-0.2.4-py3-none-any.whl", hash = "sha256:028968edbe02d53285c721a9c8f6a3e4ed20bcfd1837ad1d8822eed35515a43e"},
 ]
 
 [[package]]

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "defusedxml>=0.7.1",
     "osm-login-python==1.0.3",
     "osm-fieldwork==0.7.0",
-    "osm-rawdata==0.2.3",
+    "osm-rawdata==0.2.4",
     "fmtm-splitter==1.2.1",
 ]
 requires-python = ">=3.10"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixes #1398

## Describe this PR

- Adds environment / config variable `OSM_SVC_ACCOUNT_TOKEN`, which is picked up by `osm-rawdata` and passed as an auth token to `raw-data-api`.
- This authenticates and enables tracking with raw-data-api.
- It also allows for our data extracts to be retained past a 90 day deletion policy.
- The proposed structure is: `fmtm/{domain}/data_extract.fgb`

## Review Guide

- Create a new data extract.
- The returned URL should be with the folder structure mentioned.

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
