### PR TITLE
Add Mozilla Dockerflow spec endpoints for devops / healthchecks

### DIFF
--- a/src/backend/Dockerfile
+++ b/src/backend/Dockerfile
@@ -133,7 +133,7 @@ VOLUME /opt/tiles
 USER appuser
 # Add Healthcheck
 HEALTHCHECK --start-period=10s --interval=5s --retries=20 --timeout=5s \
-    CMD curl --fail http://localhost:8000 || exit 1
+    CMD curl --fail http://localhost:8000/__lbheartbeat__ || exit 1
 
 
 # Add certificates to use ODK Central over SSL (HTTPS, required)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [x] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Partially addresses #1443
(still remaining: add version.json to /app/version.json for both backend and frontend, in CI workflow)

## Describe this PR

- Adds endpoints:
  - /__version__ - CI/build details
  - /__heartbeat__ - heartbeat including database connectivity check
  - /__lbheartbeat__ - check for API response only, no services

## Screenshots

Please provide screenshots of the change.

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
