### PR TITLE
Replace unecessary outline_centroid calculation on backend, replace with ol function

### DIFF
--- a/src/backend/app/tasks/tasks_schemas.py
+++ b/src/backend/app/tasks/tasks_schemas.py
@@ -25,7 +25,7 @@ from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, computed_fiel
 from pydantic.functional_serializers import field_serializer
 from pydantic.functional_validators import field_validator
 
-from app.db.postgis_utils import geometry_to_geojson, get_centroid
+from app.db.postgis_utils import geometry_to_geojson
 from app.models.enums import TaskStatus
 
 
@@ -70,7 +70,6 @@ class Task(BaseModel):
     project_task_index: int
     project_task_name: Optional[str]
     outline_geojson: Optional[GeojsonFeature] = None
-    outline_centroid: Optional[GeojsonFeature] = None
     feature_count: Optional[int] = None
     task_status: TaskStatus
     locked_by_uid: Optional[int] = None
@@ -88,21 +87,6 @@ class Task(BaseModel):
                 "name": info.data.get("project_task_name"),
             }
             return geometry_to_geojson(outline, properties, info.data.get("id"))
-        return None
-
-    @field_validator("outline_centroid", mode="before")
-    @classmethod
-    def get_centroid_from_outline(
-        cls, value: Any, info: ValidationInfo
-    ) -> Optional[str]:
-        """Get outline_centroid from Shapely geom."""
-        if outline := info.data.get("outline"):
-            properties = {
-                "fid": info.data.get("project_task_index"),
-                "uid": info.data.get("id"),
-                "name": info.data.get("project_task_name"),
-            }
-            return get_centroid(outline, properties, info.data.get("id"))
         return None
 
     @field_serializer("locked_by_uid")

--- a/src/frontend/src/api/Project.js
+++ b/src/frontend/src/api/Project.js
@@ -16,7 +16,6 @@ export const ProjectById = (existingProjectList, projectId) => {
           return {
             id: data.id,
             outline_geojson: data.outline_geojson,
-            outline_centroid: data.outline_centroid,
             task_status: task_priority_str[data.task_status],
             locked_by_uid: data.locked_by_uid,
             locked_by_username: data.locked_by_username,

--- a/src/frontend/src/api/ProjectTaskStatus.js
+++ b/src/frontend/src/api/ProjectTaskStatus.js
@@ -53,9 +53,6 @@ const UpdateTaskStatus = (url, style, existingData, currentProjectId, feature, m
       }
     };
     await updateTask(url, existingData, body, feature, params);
-    const centroid = await existingData[index].taskBoundries.filter((task) => {
-      return task.id == taskId;
-    })[0].outline_centroid.geometry.coordinates;
   };
 };
 

--- a/src/frontend/src/components/Activities.jsx
+++ b/src/frontend/src/components/Activities.jsx
@@ -24,34 +24,6 @@ const Activities = ({ history, defaultTheme, mapDivPostion, map, view, state, pa
         <CoreModules.Typography variant="h2" style={{ wordWrap: 'break-word' }}>
           {history.action_text}
         </CoreModules.Typography>
-        {/* <CoreModules.Stack direction={'row-reverse'}>
-          <IconButtonCard
-            element={
-              <CoreModules.IconButton
-                onClick={async () => {
-                  const main = document.getElementsByClassName('mainview')[0];
-                  await main.scrollTo({
-                    top: mapDivPostion,
-                  });
-
-                  const centroid = state.projectTaskBoundries[index].taskBoundries.filter((task) => {
-                    return task.id == history.taskId;
-                  })[0].outline_centroid.geometry.coordinates;
-
-                  map.getView().setCenter(centroid);
-
-                  setTimeout(() => {
-                    view.animate({ zoom: 19, easing: easeOut, duration: 2000 });
-                  }, 100);
-                }}
-                color="info"
-                aria-label="share qrcode"
-              >
-                <AssetModules.LinkIcon color="info" sx={{ fontSize: defaultTheme.typography.fontSize }} />
-              </CoreModules.IconButton>
-            }
-          />
-        </CoreModules.Stack> */}
       </CoreModules.Stack>
 
       <CoreModules.Divider color="lightgray" />

--- a/src/frontend/src/hooks/MapStyles.js
+++ b/src/frontend/src/hooks/MapStyles.js
@@ -6,7 +6,6 @@ import CoreModules from '@/shared/CoreModules';
 import AssetModules from '@/shared/AssetModules';
 import { getCenter } from 'ol/extent';
 import Point from 'ol/geom/Point.js';
-import { transform } from 'ol/proj';
 
 function createPolygonStyle(fillColor, strokeColor) {
   return new Style({
@@ -29,11 +28,8 @@ function createIconStyle(iconSrc) {
       src: iconSrc,
     }),
     geometry: function (feature) {
-      // return the coordinates of the centroid of the polygon
-      // const coordinates = feature.getGeometry().getExtent();
-      // const center = getCenter(coordinates);
-      const convertedCenter = transform(feature.values_.centroid, 'EPSG:4326', 'EPSG:3857');
-      return new Point(convertedCenter);
+      const polygonCentroid = getCenter(feature.getGeometry().getExtent());
+      return new Point(polygonCentroid);
     },
   });
 }

--- a/src/frontend/src/models/createproject/createProjectModel.ts
+++ b/src/frontend/src/models/createproject/createProjectModel.ts
@@ -37,16 +37,6 @@ export interface ProjectDetailsModel {
       id: string;
       bbox: [string, string, string, string];
     };
-    outline_centroid: {
-      type: string;
-      geometry: {
-        coordinates: [string, string];
-        type: string;
-      };
-      properties: Record<string, any>;
-      id: string;
-      bbox: [string, string, string, string];
-    };
     task_status: number;
     locked_by_uid: number;
     locked_by_username: string;

--- a/src/frontend/src/models/project/projectModel.ts
+++ b/src/frontend/src/models/project/projectModel.ts
@@ -103,16 +103,6 @@ export type taskBoundriesTypes = {
     id: string;
     bbox: [string, string, string, string];
   };
-  outline_centroid: {
-    type: string;
-    geometry: {
-      coordinates: [string, string];
-      type: string;
-    };
-    properties: Record<string, any>;
-    id: string;
-    bbox: [string, string, string, string];
-  };
   task_history: taskHistoryTypes[];
   task_status: string;
 };

--- a/src/frontend/src/store/types/ICreateProject.ts
+++ b/src/frontend/src/store/types/ICreateProject.ts
@@ -61,7 +61,6 @@ export type ProjectTaskTypes = {
   project_id: number;
   project_task_index: number;
   outline_geojson: GeoJSONFeatureTypes;
-  outline_centroid: GeoJSONFeatureTypes;
   task_status: number;
   locked_by_uid: number | null;
   locked_by_username: string | null;

--- a/src/frontend/src/utilfunctions/getTaskStatusStyle.js
+++ b/src/frontend/src/utilfunctions/getTaskStatusStyle.js
@@ -1,5 +1,5 @@
 import { Fill, Icon, Stroke, Style } from 'ol/style';
-import { transform } from 'ol/proj';
+import { getCenter } from 'ol/extent';
 import { Point } from 'ol/geom';
 import AssetModules from '@/shared/AssetModules';
 import { task_priority_str } from '@/types/enums';
@@ -25,8 +25,8 @@ function createIconStyle(iconSrc) {
       src: iconSrc,
     }),
     geometry: function (feature) {
-      const convertedCenter = transform(feature.values_.centroid, 'EPSG:4326', 'EPSG:3857');
-      return new Point(convertedCenter);
+      const polygonCentroid = getCenter(feature.getGeometry().getExtent());
+      return new Point(polygonCentroid);
     },
   });
 }

--- a/src/frontend/src/views/ProjectDetailsV2.tsx
+++ b/src/frontend/src/views/ProjectDetailsV2.tsx
@@ -143,8 +143,6 @@ const Home = () => {
       geometry: { ...taskObj.outline_geojson.geometry },
       properties: {
         ...taskObj.outline_geojson.properties,
-        centroid: taskObj.outline_centroid.geometry.coordinates,
-        // TODO add bbox field here too?
       },
       id: `${taskObj.id}_${taskObj.task_status}`,
     }));


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [x] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Describe this PR

- I don't think we need to calculate the task outline centroid in the backend and pass to the frontend.
- We can simply use OpenLayers Extent.getCenter `ol.extent.getCenter` function.

## Screenshots

Seems to work fine for displaying the lock icon in the center of the task area:

![image](https://github.com/hotosm/fmtm/assets/78538841/e66bd0c2-05ba-4d99-a837-5d021ef9b214)

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
