### PR TITLE
Append extra hashtag to projects with domain and project id identifier

### DIFF
--- a/src/backend/app/projects/project_crud.py
+++ b/src/backend/app/projects/project_crud.py
@@ -359,6 +359,14 @@ async def create_project_with_project_info(
     db.commit()
     db.refresh(db_project)
 
+    # Append additional hashtag with FMTM domain and project id
+    generated_project_id = db_project.id
+    if db_project.hashtags:
+        db_project.hashtags = db_project.hashtags + [
+            f"{settings.FMTM_DOMAIN}-{generated_project_id}"
+        ]
+    db.commit()
+
     return await convert_to_app_project(db_project)
 
 

--- a/src/backend/app/projects/project_schemas.py
+++ b/src/backend/app/projects/project_schemas.py
@@ -192,9 +192,6 @@ class ProjectIn(BaseModel):
     @classmethod
     def prepend_hash_to_tags(cls, hashtags: List[str]) -> Optional[List[str]]:
         """Add '#' to hashtag if missing. Also added default '#FMTM'."""
-        if not hashtags:
-            return None
-
         hashtags_with_hash = [
             f"#{hashtag}" if hashtag and not hashtag.startswith("#") else hashtag
             for hashtag in hashtags


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Related to discussion https://github.com/hotosm/fmtm/discussions/1268

## Describe this PR

- Fixed a bug where no hashtags were appended. Now it always appends the #FMTM tag.
- Added an extra tag {domain}-{project_id}, for pulling into the final OSM submission for easier identification of the FMTM data in OSM.

## Screenshots

Please provide screenshots of the change.

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
