### PR TITLE
Project task index as an user facing task_id

### DIFF
--- a/src/backend/app/central/central_crud.py
+++ b/src/backend/app/central/central_crud.py
@@ -20,6 +20,7 @@
 import csv
 import json
 import os
+import uuid
 from io import BytesIO, StringIO
 from typing import Optional, Union
 from xml.etree.ElementTree import Element, SubElement
@@ -211,8 +212,8 @@ def create_odk_xform(
             status_code=500, detail={"message": "Connection failed to odk central"}
         ) from e
 
-    form_name = xform.createForm(odk_id, xform_data, publish=True)
-    if not form_name:
+    xform_id = xform.createForm(odk_id, xform_data, publish=True)
+    if not xform_id:
         namespaces = {
             "h": "http://www.w3.org/1999/xhtml",
             "odk": "http://www.opendatakit.org/xforms",
@@ -229,8 +230,7 @@ def create_odk_xform(
         raise HTTPException(
             status_code=HTTPStatus.UNPROCESSABLE_ENTITY, detail=msg
         ) from None
-
-    return form_name
+    return xform_id
 
 
 def delete_odk_xform(
@@ -542,11 +542,11 @@ async def update_survey_xform(
 
     # Parse the XML
     root = ElementTree.fromstring(form_data.getvalue())
-
+    xform_id = uuid.uuid4()
     # Update id attribute to equal the form name to be generated
     xform_data = root.findall(".//xforms:data[@id]", namespaces)
     for dt in xform_data:
-        dt.set("id", form_name)
+        dt.set("id", str(xform_id))
 
     # Update the form title (displayed in ODK Collect)
     existing_title = root.find(".//h:title", namespaces)

--- a/src/backend/app/db/postgis_utils.py
+++ b/src/backend/app/db/postgis_utils.py
@@ -296,7 +296,7 @@ async def split_geojson_by_task_areas(
             jsonb_set(
                 jsonb_set(
                     feature->'properties',
-                    '{task_id}', to_jsonb(tasks.id), true
+                    '{task_id}', to_jsonb(tasks.project_task_index), true
                 ),
                 '{project_id}', to_jsonb(tasks.project_id), true
             ) AS properties
@@ -309,7 +309,7 @@ async def split_geojson_by_task_areas(
 
         -- Retrieve task outlines based on the provided project_id
         SELECT
-            tasks.id AS task_id,
+            tasks.project_task_index AS task_id,
             jsonb_build_object(
                 'type', 'FeatureCollection',
                 'features', jsonb_agg(feature)
@@ -337,7 +337,7 @@ async def split_geojson_by_task_areas(
         WHERE
             tasks.project_id = :project_id
         GROUP BY
-            tasks.id;
+            tasks.project_task_index;
         """
     )
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [X] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- issue #1326 

## Describe this PR

- uses project task index to use it as a task id starting from 0 for each individual project
- uses uuid as a XFormId(odk_form_id)
- saves odk_form_id in the database table xforms along with category and project_id
there is still an issue uploading entities in the odk central
need some changes in osm fieldwork for proper log, i.e. xform name is taken from xformid, now it has been changed to uuid ,now need clear distinction between xform name and xformid
## Screenshots

N/A

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
