### PR TITLE
Fix login methods after temp cookie auth

### DIFF
--- a/docs/dev/Setup.md
+++ b/docs/dev/Setup.md
@@ -374,7 +374,7 @@ authenticate.
    Three endpoints are responsible for oauth
    <img width="698" alt="image" src="../images/endpoints_responsible_for_auth_screenshot-2023-03-26-092756.png">
 
-2. Select the `/auth/osm_login/` endpoint, click `Try it out` and then
+2. Select the `/auth/osm-login/` endpoint, click `Try it out` and then
    `Execute`.  
     This would give you the Login URL where you can supply your osm username
    and password.

--- a/src/backend/app/auth/auth_routes.py
+++ b/src/backend/app/auth/auth_routes.py
@@ -29,7 +29,7 @@ from sqlalchemy.orm import Session
 from app.auth.osm import AuthUser, init_osm_auth, login_required
 from app.config import settings
 from app.db import database
-from app.models.enums import UserRole
+from app.models.enums import HTTPStatus, UserRole
 
 router = APIRouter(
     prefix="/auth",
@@ -38,7 +38,7 @@ router = APIRouter(
 )
 
 
-@router.get("/osm_login/")
+@router.get("/osm-login/")
 async def login_url(request: Request, osm_auth=Depends(init_osm_auth)):
     """Get Login URL for OSM Oauth Application.
 
@@ -81,13 +81,13 @@ async def callback(request: Request, osm_auth=Depends(init_osm_auth)):
     # Get access token
     access_token = osm_auth.callback(callback_url).get("access_token")
     log.debug(f"Access token returned of length {len(access_token)}")
-    response = JSONResponse(content={"access_token": access_token}, status_code=200)
+    response = Response(status_code=HTTPStatus.OK)
 
     # Set cookie
     cookie_name = settings.FMTM_DOMAIN.replace(".", "_")
     log.debug(
         f"Setting cookie in response named '{cookie_name}' with params: "
-        f"max_age=259200 | expires=259200 | path='/' | "
+        f"max_age=31536000 | expires=31536000 | path='/' | "
         f"domain={settings.FMTM_DOMAIN} | httponly=True | samesite='lax' | "
         f"secure={False if settings.DEBUG else True}"
     )
@@ -233,11 +233,8 @@ async def check_login(
     return user_data
 
 
-@router.get("/login/")
-async def temp_login(
-    request: Request,
-    email: Optional[str] = None,
-):
+@router.get("/temp-login")
+async def temp_login(email: Optional[str] = None):
     """Handles the authentication check endpoint.
 
     By creating a temporary access token and
@@ -251,8 +248,23 @@ async def temp_login(
         Response: The response object containing the access token as a cookie.
     """
     access_token = settings.OSM_SVC_ACCOUNT_TOKEN
-    response = JSONResponse(content={"access_token": access_token}, status_code=200)
+
+    if not access_token:
+        raise HTTPException(
+            status_code=HTTPStatus.FORBIDDEN,
+            detail=(
+                "OSM_SVC_ACCOUNT_TOKEN variable is not set. Temp login not possible."
+            ),
+        )
+
+    response = Response(status_code=HTTPStatus.OK)
     cookie_name = settings.FMTM_DOMAIN.replace(".", "_")
+    log.debug(
+        f"Setting TEMP cookie in response named '{cookie_name}' with params: "
+        f"max_age=604800 | expires=604800 | path='/' | "
+        f"domain={settings.FMTM_DOMAIN} | httponly=True | samesite='lax' | "
+        f"secure={False if settings.DEBUG else True}"
+    )
     response.set_cookie(
         key=cookie_name,
         value=access_token,

--- a/src/frontend/src/App.tsx
+++ b/src/frontend/src/App.tsx
@@ -72,6 +72,8 @@ const GlobalInit = () => {
         return resp.json();
       })
       .then((apiUser) => {
+        if (!apiUser) return;
+
         if (apiUser.username !== storeUser?.loginToken?.username) {
           // Mismatch between store user and logged in user via api
           dispatch(LoginActions.signOut(null));

--- a/src/frontend/src/api/Login.ts
+++ b/src/frontend/src/api/Login.ts
@@ -1,29 +1,24 @@
 import axios from 'axios';
+import { getUserDetailsFromApi } from '@/utilfunctions/login';
+import { CommonActions } from '@/store/slices/CommonSlice';
 
 export const TemporaryLoginService: Function = (url: string) => {
   return async (dispatch) => {
     const getTemporaryLogin = async (url) => {
-      const login = await axios.get(url);
-      const token = login.data.access_token;
+      // Sets a cookie in the browser that is used for auth
+      await axios.get(url);
 
-      fetch(`${import.meta.env.VITE_API_URL}/auth/me/`, {
-        headers: { 'access-token': token },
-      })
-        .then((resp) => resp.json())
-        .then((userRes) => {
-          const params = new URLSearchParams({
-            username: userRes.username,
-            osm_oauth_token: token,
-            id: userRes.id,
-            picture: userRes.profile_img,
-            redirect_to: '/',
-            role: userRes.role,
-          }).toString();
-          const redirectUrl = `/osmauth?${params}`;
-          window.location.href = redirectUrl;
-        });
-      try {
-      } catch (error) {}
+      const loginSuccess = await getUserDetailsFromApi();
+      if (!loginSuccess) {
+        dispatch(
+          CommonActions.SetSnackBar({
+            open: true,
+            message: 'Temp login failed. Try OSM.',
+            variant: 'error',
+            duration: 2000,
+          }),
+        );
+      }
     };
 
     await getTemporaryLogin(url);

--- a/src/frontend/src/components/LoginPopup.tsx
+++ b/src/frontend/src/components/LoginPopup.tsx
@@ -1,9 +1,8 @@
-import React, { useState } from 'react';
+import React from 'react';
 import CoreModules from '@/shared/CoreModules';
 import { Modal } from '@/components/common/Modal';
 import { useDispatch } from 'react-redux';
 import { LoginActions } from '@/store/slices/LoginSlice';
-import Button from './common/Button';
 import { createLoginWindow } from '@/utilfunctions/login';
 import { TemporaryLoginService } from '@/api/Login';
 import AssetModules from '@/shared/AssetModules';
@@ -22,7 +21,7 @@ const loginOptions: loginOptionsType[] = [
     id: 'osm_account',
     name: 'Personal OSM Account',
     image: OSMImg,
-    description: 'If you want to Log in using your individual OSM account.',
+    description: 'Edits made in FMTM will be credited to your OSM account.',
   },
   {
     id: 'temp_account',
@@ -35,61 +34,38 @@ const loginOptions: loginOptionsType[] = [
 const LoginPopup = () => {
   const dispatch = useDispatch();
 
-  const [activeLogin, setActiveLogin] = useState('');
   const loginModalOpen = CoreModules.useAppSelector((state) => state.login.loginModalOpen);
 
-  const updateStatus = (currentOption: string) => {
-    if (currentOption === activeLogin) {
-      setActiveLogin('');
-    } else {
-      setActiveLogin(currentOption);
-    }
-  };
-
-  const handleSignIn = () => {
-    if (activeLogin === 'osm_account') {
+  const handleSignIn = (selectedOption: string) => {
+    if (selectedOption === 'osm_account') {
       createLoginWindow('/');
     } else {
-      dispatch(TemporaryLoginService(`${import.meta.env.VITE_API_URL}/auth/login/`));
+      dispatch(TemporaryLoginService(`${import.meta.env.VITE_API_URL}/auth/temp-login`));
     }
   };
 
   const LoginDescription = () => {
     return (
       <div className="fmtm-flex fmtm-items-start fmtm-flex-col">
-        <h2 className="fmtm-text-2xl fmtm-font-bold fmtm-mb-1">Sign In</h2>
-        <p className="fmtm-text-base fmtm-mb-5 fmtm-text-gray-700">Sign In with any of the accounts</p>
+        <div className="fmtm-text-2xl fmtm-font-bold fmtm-mb-1">Sign In</div>
+        <div className="fmtm-text-base fmtm-mb-5 fmtm-text-gray-700">Select an account type to sign in</div>
         <div className="fmtm-w-full fmtm-flex fmtm-flex-col fmtm-gap-4 fmtm-justify-items-center">
           {loginOptions?.map((option) => (
             <div
               key={option.id}
-              onClick={() => updateStatus(option.id)}
-              className={`${
-                activeLogin === option.id
-                  ? 'fmtm-bg-red-50 fmtm-text-primaryRed fmtm-border-primaryRed'
-                  : 'fmtm-bg-[#F5F5F5] fmtm-border-gray-300 fmtm-text-gray-700'
-              } fmtm-w-full fmtm-py-3 fmtm-px-4 fmtm-rounded-md fmtm-duration-300 hover:fmtm-border-primaryRed hover:fmtm-text-primaryRed fmtm-border-[1px] fmtm-cursor-pointer fmtm-text-sm fmtm-flex fmtm-items-start fmtm-gap-3 fmtm-group`}
+              onClick={() => handleSignIn(option.id)}
+              className="fmtm-bg-[#F5F5F5] fmtm-border-gray-300 fmtm-text-gray-700 fmtm-w-full fmtm-py-3 fmtm-px-4 fmtm-rounded-md fmtm-duration-300 hover:fmtm-border-primaryRed hover:fmtm-text-primaryRed fmtm-border-[1px] fmtm-cursor-pointer fmtm-text-sm fmtm-flex fmtm-items-start fmtm-gap-3 fmtm-group"
             >
               <div className="fmtm-w-10 fmtm-max-w-10 fmtm-min-w-10">
                 {option?.image ? <img src={option?.image} className="fmtm-w-full" /> : option?.icon}
               </div>
               <div className="fmtm-flex fmtm-flex-col">
-                <p className="fmtm-text-lg">{option.name}</p>
-                <p className="">{option.description}</p>
+                <div className="fmtm-text-lg">{option.name}</div>
+                <div className="">{option.description}</div>
               </div>
             </div>
           ))}
         </div>
-        {activeLogin && (
-          <div className="fmtm-w-full fmtm-flex fmtm-justify-center fmtm-mt-6">
-            <Button
-              btnText="Sign In"
-              btnType="primary"
-              onClick={handleSignIn}
-              className="!fmtm-py-1 !fmtm-px-6 !fmtm-rounded-md"
-            />
-          </div>
-        )}
       </div>
     );
   };

--- a/src/frontend/src/utilfunctions/login.ts
+++ b/src/frontend/src/utilfunctions/login.ts
@@ -1,63 +1,80 @@
 import { createPopup } from '@/utilfunctions/createPopup';
 
-export const createLoginWindow = (redirectTo) => {
+export const getUserDetailsFromApi = async (redirectTo: string = '/') => {
+  const resp = await fetch(`${import.meta.env.VITE_API_URL}/auth/me/`, {
+    credentials: 'include',
+  });
+
+  if (resp.status !== 200) {
+    return false;
+  }
+
+  const apiUser = await resp.json();
+
+  if (!apiUser) return false;
+
+  const params = new URLSearchParams({
+    username: apiUser.username,
+    id: apiUser.id,
+    picture: apiUser.profile_img,
+    redirect_to: redirectTo,
+    role: apiUser.role,
+  }).toString();
+
+  const redirectUrl = `/osmauth?${params}`;
+  window.location.href = redirectUrl;
+
+  return true;
+};
+
+export const createLoginWindow = async (redirectTo: string) => {
   // Create popup outside of request (required for Safari security)
   const popup = createPopup('OSM Auth', '');
 
-  fetch(`${import.meta.env.VITE_API_URL}/auth/osm_login/`)
-    .then((resp) => resp.json())
-    .then((resp) => {
-      if (!popup) {
-        console.warn('Popup blocked or unavailable.');
-        return;
+  try {
+    const resp = await fetch(`${import.meta.env.VITE_API_URL}/auth/osm-login/`);
+    const data = await resp.json();
+
+    if (!popup) {
+      console.warn('Popup blocked or unavailable.');
+      return;
+    }
+
+    // Set URL for popup from response
+    popup.location = data.login_url;
+
+    // Get OAuth2 authorization url, extract state
+    const authUrl = new URL(data.login_url);
+    const authParams = new URLSearchParams(authUrl.search);
+    const responseState = authParams.get('state');
+
+    const handleLoginPopup = (event) => {
+      // OAuth2 state param validation
+      if (event.data.authCode && event.data.state === responseState) {
+        // Clean up the postMessage event listener
+        window.removeEventListener('message', handleLoginPopup);
+
+        const authCode = event.data.authCode;
+        const state = event.data.state;
+        const callbackUrl = `${import.meta.env.VITE_API_URL}/auth/callback/?code=${authCode}&state=${state}`;
+
+        const completeLogin = async () => {
+          // NOTE this encapsulates async methods to call sequentially
+          // Sets a cookie in the browser that is used for auth
+          await fetch(callbackUrl, { credentials: 'include' });
+          await getUserDetailsFromApi(redirectTo);
+        };
+        completeLogin();
+      } else {
+        console.log('Login states do not match');
       }
+    };
 
-      // Set URL for popup from response
-      popup.location = resp.login_url;
-
-      // Get OAuth2 authorization url, extract state
-      const authUrl = new URL(resp.login_url);
-      const authParams = new URLSearchParams(authUrl.search);
-      const responseState = authParams.get('state');
-
-      const handleLoginPopup = (event) => {
-        // OAuth2 state param validation
-        if (event.data.authCode && event.data.state === responseState) {
-          // Clean up the postMessage event listener
-          window.removeEventListener('message', handleLoginPopup);
-
-          const authCode = event.data.authCode;
-          const state = event.data.state;
-          const callback_url = `${import.meta.env.VITE_API_URL}/auth/callback/?code=${authCode}&state=${state}`;
-
-          fetch(callback_url, { credentials: 'include' })
-            .then((resp) => resp.json())
-            .then((res) => {
-              fetch(`${import.meta.env.VITE_API_URL}/auth/me/`, {
-                credentials: 'include',
-              })
-                .then((resp) => resp.json())
-                .then((userRes) => {
-                  const params = new URLSearchParams({
-                    username: userRes.username,
-                    osm_oauth_token: res.access_token,
-                    id: userRes.id,
-                    picture: userRes.profile_img,
-                    redirect_to: redirectTo,
-                    role: userRes.role,
-                  }).toString();
-                  const redirectUrl = `/osmauth?${params}`;
-                  window.location.href = redirectUrl;
-                });
-            });
-        } else {
-          console.log('States do not match');
-        }
-      };
-
-      // Add the postMessage event listener
-      window.addEventListener('message', handleLoginPopup);
-    });
+    // Add the postMessage event listener
+    window.addEventListener('message', handleLoginPopup);
+  } catch (error) {
+    console.error('Error fetching data:', error);
+  }
 };
 
 export const revokeCookie = async () => {

--- a/src/frontend/src/views/Authorized.tsx
+++ b/src/frontend/src/views/Authorized.tsx
@@ -27,11 +27,10 @@ function Authorized() {
     const id = params.get('id');
     const username = params.get('username');
     const sessionToken = params.get('session_token');
-    const osm_oauth_token = params.get('osm_oauth_token');
     const picture = params.get('picture');
     const role = params.get('role');
-    dispatch(LoginActions.setAuthDetails(username, sessionToken, osm_oauth_token));
-    dispatch(LoginActions.SetLoginToken({ username, id, sessionToken, osm_oauth_token, picture, role }));
+    dispatch(LoginActions.setAuthDetails(username, sessionToken));
+    dispatch(LoginActions.SetLoginToken({ username, id, sessionToken, picture, role }));
 
     const redirectUrl = params.get('redirect_to') || '/';
     setIsReadyToRedirect(true);


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Describe this PR

- Improves the logic for frontend login (full async/await).
- Removes all handling of access_token in API JSON and frontend (cookie httpOnly).
- Reuse the same `/auth/me` call logic for temp and OSM auth.
- Simplify LoginPopup slightly to reduce number of clicks required.
- Both login methods work well.

The OSM login tokens should not change, but we have encountered strange behaviour.
If they change again, we should consider other options - using our own JWT auth would be fine.

## Review Guide

Try both login methods - they should work.

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
