### PR TITLE
Typo error in project name prefix in submission-download-geojson

### DIFF
--- a/src/backend/app/submissions/submission_routes.py
+++ b/src/backend/app/submissions/submission_routes.py
@@ -586,7 +586,7 @@ async def download_submission_geojson(
 
     featcol = geojson.FeatureCollection(features=all_features)
     submission_geojson = BytesIO(json.dumps(featcol).encode("utf-8"))
-    filename = project.project_prefix_name
+    filename = project.project_name_prefix
 
     headers = {"Content-Disposition": f"attachment; filename={filename}.geojson"}
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

There was an issue while downloading submissions in geojson due to typo error while assigning filename as project name prefix

## Describe this PR

This PR addresses the issue by correctly using prefix name as a filename.

## Screenshots

Please provide screenshots of the change.

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
