### PR TITLE
Separate svc accounts for raw-data-api and fmtm

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,8 +42,9 @@ FMTM_DB_USER=${FMTM_DB_USER:-"fmtm"}
 FMTM_DB_PASSWORD=${FMTM_DB_PASSWORD:-"fmtm"}
 FMTM_DB_NAME=${FMTM_DB_NAME:-"fmtm"}
 
-### Underpass (optional override) ###
-UNDERPASS_API_URL=${UNDERPASS_API_URL:-"https://api-prod.raw-data.hotosm.org/v1"}
+### raw-data-api (optional override) ###
+RAW_DATA_API_URL=${RAW_DATA_API_URL:-"https://api-prod.raw-data.hotosm.org/v1"}
+RAW_DATA_API_AUTH_TOKEN=${RAW_DATA_API_AUTH_TOKEN}
 
 # Monitoring (OpenTelemetry). Options: 'openobserve', 'sentry'.
 MONITORING=${MONITORING}

--- a/src/backend/app/config.py
+++ b/src/backend/app/config.py
@@ -262,7 +262,16 @@ class Settings(BaseSettings):
                 return f"http://s3.{fmtm_domain}:{dev_port}"
             return f"https://s3.{fmtm_domain}"
 
-    UNDERPASS_API_URL: HttpUrlStr = "https://api-prod.raw-data.hotosm.org/v1"
+    RAW_DATA_API_URL: HttpUrlStr = "https://api-prod.raw-data.hotosm.org/v1"
+    RAW_DATA_API_AUTH_TOKEN: Optional[str] = None
+
+    @field_validator("RAW_DATA_API_AUTH_TOKEN", mode="before")
+    @classmethod
+    def set_raw_data_api_auth_none(cls, v: Optional[str]) -> Optional[str]:
+        """Set RAW_DATA_API_AUTH_TOKEN to None if set to empty string."""
+        if v == "":
+            return None
+        return v
 
     # Used for temporary auth feature
     OSM_SVC_ACCOUNT_TOKEN: Optional[str] = None

--- a/src/backend/app/helpers/helper_routes.py
+++ b/src/backend/app/helpers/helper_routes.py
@@ -114,7 +114,8 @@ async def convert_xlsform_to_xform(
     allowed_extensions = [".xls", ".xlsx"]
     if file_ext not in allowed_extensions:
         raise HTTPException(
-            status_code=400, detail="Provide a valid .xls or .xlsx file"
+            status_code=HTTPStatus.BAD_REQUEST,
+            detail="Provide a valid .xls or .xlsx file",
         )
 
     contents = await xlsform.read()
@@ -138,7 +139,8 @@ async def convert_geojson_to_odk_csv_wrapper(
     allowed_extensions = [".json", ".geojson"]
     if file_ext not in allowed_extensions:
         raise HTTPException(
-            status_code=400, detail="Provide a valid .json or .geojson file"
+            status_code=HTTPStatus.BAD_REQUEST,
+            detail="Provide a valid .json or .geojson file",
         )
 
     contents = await geojson.read()
@@ -165,7 +167,9 @@ async def create_entities_from_csv(
     file_ext = filename.suffix.lower()
 
     if file_ext != ".csv":
-        raise HTTPException(status_code=400, detail="Provide a valid .csv")
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST, detail="Provide a valid .csv"
+        )
 
     def parse_csv(csv_bytes):
         parsed_data = []
@@ -213,7 +217,9 @@ async def convert_odk_submission_json_to_geojson_wrapper(
 
     allowed_extensions = [".json"]
     if file_ext not in allowed_extensions:
-        raise HTTPException(status_code=400, detail="Provide a valid .json file")
+        raise HTTPException(
+            status_code=HTTPStatus.BAD_REQUEST, detail="Provide a valid .json file"
+        )
 
     contents = await json_file.read()
     submission_geojson = await convert_odk_submission_json_to_geojson(BytesIO(contents))

--- a/src/backend/app/projects/project_crud.py
+++ b/src/backend/app/projects/project_crud.py
@@ -454,8 +454,8 @@ async def generate_data_extract(
     pg = PostgresClient(
         "underpass",
         extract_config,
-        auth_token=settings.OSM_SVC_ACCOUNT_TOKEN
-        if settings.OSM_SVC_ACCOUNT_TOKEN
+        auth_token=settings.RAW_DATA_API_AUTH_TOKEN
+        if settings.RAW_DATA_API_AUTH_TOKEN
         else None,
     )
     fgb_url = pg.execQuery(
@@ -463,7 +463,7 @@ async def generate_data_extract(
         extra_params={
             "fileName": (
                 f"fmtm/{settings.FMTM_DOMAIN}/data_extract"
-                if settings.OSM_SVC_ACCOUNT_TOKEN
+                if settings.RAW_DATA_API_AUTH_TOKEN
                 else "fmtm_extract"
             ),
             "outputType": "fgb",

--- a/src/backend/pdm.lock
+++ b/src/backend/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "debug", "dev", "docs", "test", "monitoring"]
 strategy = ["cross_platform"]
 lock_version = "4.4.1"
-content_hash = "sha256:a1cd565c3d8d2f11a4f3d3738da7eee97399518e3f20de49019dc656c04d7811"
+content_hash = "sha256:8e7a3aa7636a3575425a98fd0d7966c25dece9f6c0a8b25fbbd5a135a136ecfa"
 
 [[package]]
 name = "aiohttp"
@@ -1708,7 +1708,7 @@ files = [
 
 [[package]]
 name = "osm-rawdata"
-version = "0.2.4"
+version = "0.3.0"
 requires_python = ">=3.10"
 summary = "Make data extracts from OSM data."
 dependencies = [
@@ -1724,8 +1724,8 @@ dependencies = [
     "sqlalchemy>=2.0.0",
 ]
 files = [
-    {file = "osm-rawdata-0.2.4.tar.gz", hash = "sha256:5fbf1b91930846a3d6bd1ea3fcedb99b46e2968ef6bad397de8c2f395ba3fbe7"},
-    {file = "osm_rawdata-0.2.4-py3-none-any.whl", hash = "sha256:028968edbe02d53285c721a9c8f6a3e4ed20bcfd1837ad1d8822eed35515a43e"},
+    {file = "osm-rawdata-0.3.0.tar.gz", hash = "sha256:62778c571a1a7d52a91357733deff5bc79466f0c5df5c809d77af7a3259ff7ed"},
+    {file = "osm_rawdata-0.3.0-py3-none-any.whl", hash = "sha256:e803e69ad2980502ebf13586302f51829fa2b1276079bdc3f924f187565076b9"},
 ]
 
 [[package]]

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "defusedxml>=0.7.1",
     "osm-login-python==1.0.3",
     "osm-fieldwork==0.9.2",
-    "osm-rawdata==0.2.4",
+    "osm-rawdata==0.3.0",
     "fmtm-splitter==1.2.1",
 ]
 requires-python = ">=3.10"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Related to #1497

## Describe this PR

- This is a temp solution.
- Separates service account tokens for raw-data-api data extract generation and FMTM temporary auth.
- Two variables: `RAW_DATA_API_AUTH_TOKEN` and `OSM_SVC_ACCOUNT_TOKEN`.
- In future we may remove the temp auth `OSM_SVC_ACCOUNT_TOKEN` and replace with a JWT-based auth.

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
