### PR TITLE
Generate project location string in model_validator

### DIFF
--- a/src/backend/app/db/postgis_utils.py
+++ b/src/backend/app/db/postgis_utils.py
@@ -537,7 +537,9 @@ def get_address_from_lat_lon(latitude, longitude):
     }
     headers = {"Accept-Language": "en"}  # Set the language to English
 
-    log.debug("Getting Nominatim address from project centroid")
+    log.debug(
+        f"Getting Nominatim address from project lat ({latitude}) lon ({longitude})"
+    )
     response = requests.get(base_url, params=params, headers=headers)
     if (status_code := response.status_code) != 200:
         log.error(f"Getting address string failed: {status_code}")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixes #1388

## Describe this PR

- We were chaining three computed_field:
outline_geojson --> outline --> centroid --> location_str

- Perhaps this was causing an issue, or there is a bug in Pydantic 🤷 
- Moved the location_str validation to a model_validator, so it runs after all the other fields are computed / validated at the end.
- Should hopefully fix missing location strings.

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
