### PR TITLE
Fix loading entity by intent using uuid xformid

### DIFF
--- a/src/backend/app/central/central_crud.py
+++ b/src/backend/app/central/central_crud.py
@@ -584,7 +584,10 @@ async def update_survey_xform(
         ".//xforms:bind[@nodeset='/data/all/form_category']", namespaces
     )
     if form_category_update is not None:
-        form_category_update.set("calculate", f"once('{category}')")
+        if category.endswith("s"):
+            # Plural to singular
+            category = category[:-1]
+        form_category_update.set("calculate", f"once('{category.rstrip('s')}')")
 
     return BytesIO(ElementTree.tostring(root))
 

--- a/src/backend/app/central/central_crud.py
+++ b/src/backend/app/central/central_crud.py
@@ -487,7 +487,7 @@ async def update_entity_registration_xform(
 async def update_survey_xform(
     form_data: BytesIO,
     category: str,
-    task_ids: list[int],
+    existing_id: Optional[str] = None,
 ) -> BytesIO:
     """Update fields in the XForm to work with FMTM.
 
@@ -507,7 +507,11 @@ async def update_survey_xform(
         BytesIO: The XForm data.
     """
     log.debug(f"Updating XML keys in survey XForm: {category}")
-    xform_id = uuid.uuid4()
+
+    if existing_id:
+        xform_id = existing_id
+    else:
+        xform_id = uuid.uuid4()
 
     namespaces = {
         "h": "http://www.w3.org/1999/xhtml",

--- a/src/backend/app/projects/project_crud.py
+++ b/src/backend/app/projects/project_crud.py
@@ -827,7 +827,7 @@ async def generate_odk_central_project_content(
     xlsform: BytesIO,
     form_category: str,
     form_file_ext: str,
-    task_ids: list[int],
+    task_count: int,
     db: Session,
 ) -> str:
     """Populate the project in ODK Central with XForm, Appuser, Permissions."""
@@ -886,7 +886,7 @@ async def generate_odk_central_project_content(
     updated_xform = await central_crud.update_survey_xform(
         xform,
         form_category,
-        task_ids,
+        task_count,
     )
     # Upload survey XForm
     log.info("Uploading survey XForm to ODK Central")
@@ -997,7 +997,7 @@ async def generate_project_files(
             xlsform,
             form_category,
             form_file_ext,
-            list(task_extract_dict.keys()),
+            len(task_extract_dict.keys()),
             db,
         )
         log.debug(

--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -936,6 +936,7 @@ async def download_form(
 
 @router.post("/update-form")
 async def update_project_form(
+    xform_id: str = Form(...),
     category: str = Form(...),
     upload: Optional[UploadFile] = File(None),
     db: Session = Depends(database.get_db),
@@ -978,15 +979,14 @@ async def update_project_form(
 
     # Get ODK Central credentials for project
     odk_creds = await project_deps.get_odk_credentials(db, project.id)
-    # Get task id list
-    task_list = await tasks_crud.get_task_id_list(db, project.id)
     # Update ODK Central form data
     await central_crud.update_project_xform(
-        task_list,
+        xform_id,
         project.odkid,
         new_xform_data,
         file_ext,
         category,
+        len(project.tasks),
         odk_creds,
     )
 

--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -304,7 +304,7 @@ async def set_odk_entities_mapping_status(
     entity_details must be a JSON body with params:
     {
         "entity_id": "string",
-        "label": "task <TASK_ID> feature <FEATURE_ID>",
+        "label": "Task <TASK_ID> Feature <FEATURE_ID>",
         "status": 0
     }
     """

--- a/src/backend/app/projects/project_schemas.py
+++ b/src/backend/app/projects/project_schemas.py
@@ -299,6 +299,7 @@ class ProjectBase(BaseModel):
     """Base project model."""
 
     outline: Any = Field(exclude=True)
+    forms: Any = Field(exclude=True)
 
     id: int
     odkid: int
@@ -331,6 +332,14 @@ class ProjectBase(BaseModel):
             f"{settings.S3_DOWNLOAD_ROOT}/{settings.S3_BUCKET_NAME}"
             f"/{self.organisation_id}/logo.png"
         )
+
+    @computed_field
+    @property
+    def xform_id(self) -> Optional[str]:
+        """Compute the XForm ID from the linked DbXForm."""
+        if not self.forms:
+            return None
+        return self.forms[0].odk_form_id
 
 
 class ProjectWithTasks(ProjectBase):

--- a/src/backend/pdm.lock
+++ b/src/backend/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "debug", "dev", "docs", "test", "monitoring"]
 strategy = ["cross_platform"]
 lock_version = "4.4.1"
-content_hash = "sha256:e578d91db51770738c595f5059208337f66640982428ad77743eadfac9f748d8"
+content_hash = "sha256:cc2c7bfe8ad025999c448bbef3e0f75dffbcb7eef9fe015e022b9436363f310b"
 
 [[package]]
 name = "aiohttp"
@@ -1662,7 +1662,7 @@ files = [
 
 [[package]]
 name = "osm-fieldwork"
-version = "0.10.0"
+version = "0.10.1"
 requires_python = ">=3.10"
 summary = "Processing field data from ODK to OpenStreetMap format."
 dependencies = [
@@ -1687,8 +1687,8 @@ dependencies = [
     "xmltodict>=0.13.0",
 ]
 files = [
-    {file = "osm-fieldwork-0.10.0.tar.gz", hash = "sha256:5aceb5bf4ee7b9e346ad53905da51ea4c4562f94d3e1a1e225cf1b7e5e87eac6"},
-    {file = "osm_fieldwork-0.10.0-py3-none-any.whl", hash = "sha256:d26d6529c0bdb8657f55b822aa2d108a2d589391bfbfacbad5b61fbae359a479"},
+    {file = "osm-fieldwork-0.10.1.tar.gz", hash = "sha256:a437e46e4e8e63f5bd5fedef7830d5648995ee9c896993e70dd63551af30766e"},
+    {file = "osm_fieldwork-0.10.1-py3-none-any.whl", hash = "sha256:1f03c63ac482a558bc2a43f6d05ab66c092b2cfee57d7a838e5e744b00042e53"},
 ]
 
 [[package]]

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "cryptography>=42.0.1",
     "defusedxml>=0.7.1",
     "osm-login-python==1.0.3",
-    "osm-fieldwork==0.10.0",
+    "osm-fieldwork==0.10.1",
     "osm-rawdata==0.3.0",
     "fmtm-splitter==1.2.1",
 ]

--- a/src/frontend/src/api/CreateProjectService.ts
+++ b/src/frontend/src/api/CreateProjectService.ts
@@ -347,13 +347,10 @@ const PostFormUpdate: Function = (url: string, projectData: any) => {
     const postFormUpdate = async (url, projectData) => {
       try {
         const formFormData = new FormData();
-        formFormData.append('project_id', projectData.project_id);
-        if (projectData.category) {
-          formFormData.append('category', projectData.category);
-        }
-        if (projectData.upload) {
-          formFormData.append('upload', projectData.upload);
-        }
+        formFormData.append('xform_id', projectData.xformId);
+        formFormData.append('category', projectData.category);
+        formFormData.append('upload', projectData.upload);
+
         const postFormUpdateResponse = await axios.post(url, formFormData);
         const resp: ProjectDetailsModel = postFormUpdateResponse.data;
         // dispatch(CreateProjectActions.SetIndividualProjectDetails(modifiedResponse));

--- a/src/frontend/src/api/Project.js
+++ b/src/frontend/src/api/Project.js
@@ -40,6 +40,7 @@ export const ProjectById = (existingProjectList, projectId) => {
             tasks_mapped: projectResp.tasks_mapped,
             tasks_validated: projectResp.tasks_validated,
             xform_category: projectResp.xform_category,
+            xform_id: projectResp?.xform_id,
             tasks_bad: projectResp.tasks_bad,
             data_extract_url: projectResp.data_extract_url,
             instructions: projectResp?.project_info?.per_task_instructions,

--- a/src/frontend/src/components/DialogTaskActions.jsx
+++ b/src/frontend/src/components/DialogTaskActions.jsx
@@ -206,13 +206,13 @@ export default function Dialog({ taskId, feature, map, view }) {
             type="submit"
             className="fmtm-font-bold !fmtm-rounded fmtm-text-sm !fmtm-py-2 !fmtm-w-full fmtm-flex fmtm-justify-center"
             onClick={() => {
-              // XForm name is constructed from lower case project title with underscores
-              const projectName = projectInfo.title.toLowerCase().split(' ').join('_');
-              const projectCategory = projectInfo.xform_category;
-              const formName = `${projectName}_${projectCategory}`;
-              document.location.href = `odkcollect://form/${formName}?task_id=${taskId}`;
-              // TODO add this to each feature popup to pre-load a selected entity
-              // document.location.href = `odkcollect://form/${formName}?${geomFieldName}=${entityId}`;
+              const xformId = projectInfo.xform_id;
+
+              try {
+                document.location.href = `odkcollect://form/${xformId}?task_id=${taskId}`;
+              } catch (error) {
+                document.location.href = 'https://play.google.com/store/apps/details?id=org.odk.collect.android';
+              }
             }}
           />
         </div>

--- a/src/frontend/src/components/DialogTaskActions.jsx
+++ b/src/frontend/src/components/DialogTaskActions.jsx
@@ -206,12 +206,21 @@ export default function Dialog({ taskId, feature, map, view }) {
             type="submit"
             className="fmtm-font-bold !fmtm-rounded fmtm-text-sm !fmtm-py-2 !fmtm-w-full fmtm-flex fmtm-justify-center"
             onClick={() => {
-              const xformId = projectInfo.xform_id;
+              const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+                navigator.userAgent,
+              );
 
-              try {
-                document.location.href = `odkcollect://form/${xformId}?task_id=${taskId}`;
-              } catch (error) {
-                document.location.href = 'https://play.google.com/store/apps/details?id=org.odk.collect.android';
+              if (isMobile) {
+                document.location.href = `odkcollect://form/${projectInfo.xform_id}?task_id=${taskId}`;
+              } else {
+                dispatch(
+                  CommonActions.SetSnackBar({
+                    open: true,
+                    message: 'Requires a mobile phone with ODK Collect.',
+                    variant: 'warning',
+                    duration: 3000,
+                  }),
+                );
               }
             }}
           />

--- a/src/frontend/src/components/ManageProject/EditTab/FormUpdateTab.tsx
+++ b/src/frontend/src/components/ManageProject/EditTab/FormUpdateTab.tsx
@@ -26,6 +26,7 @@ const FormUpdateTab = ({ projectId }) => {
   const [selectedCategory, setSelectedCategory] = useState<string | null>(null);
   const [error, setError] = useState({ formError: '', categoryError: '' });
 
+  const xFormId = CoreModules.useAppSelector((state) => state.project.projectInfo.xform_id);
   const formCategoryList = useAppSelector((state) => state.createproject.formCategoryList);
   const sortedFormCategoryList = formCategoryList.slice().sort((a, b) => a.title.localeCompare(b.title));
   const customFileValidity = useAppSelector((state) => state.createproject.customFileValidity);
@@ -64,6 +65,7 @@ const FormUpdateTab = ({ projectId }) => {
     if (validateForm()) {
       dispatch(
         PostFormUpdate(`${import.meta.env.VITE_API_URL}/projects/update-form?project_id=${projectId}`, {
+          xformId: xFormId,
           category: selectedCategory,
           upload: uploadForm && uploadForm?.[0]?.url,
         }),

--- a/src/frontend/src/components/ProjectDetailsV2/FeatureSelectionPopup.tsx
+++ b/src/frontend/src/components/ProjectDetailsV2/FeatureSelectionPopup.tsx
@@ -13,6 +13,7 @@ import ProjectTaskStatus from '@/api/ProjectTaskStatus';
 import MapStyles from '@/hooks/MapStyles';
 
 type TaskFeatureSelectionPopupPropType = {
+  taskId: number;
   featureProperties: TaskFeatureSelectionProperties | null;
   taskId: number;
   taskFeature: Record<string, any>;
@@ -128,17 +129,14 @@ const TaskFeatureSelectionPopup = ({
               }
               isLoading={updateEntityStatusLoading}
               onClick={() => {
-                // XForm name is constructed from lower case project title with underscores
-                const projectName = projectInfo.title.toLowerCase().split(' ').join('_');
-                const projectCategory = projectInfo.xform_category;
-                const formName = `${projectName}_${projectCategory}`;
-
+                const xformId = projectInfo.xform_id;
                 const entity = entityOsmMap.find((x) => x.osm_id === featureProperties?.osm_id);
                 const entityUuid = entity ? entity.id : null;
 
-                if (!formName || !entityUuid) {
+                if (!xformId || !entityUuid) {
                   return;
                 }
+
                 dispatch(
                   UpdateEntityStatus(`${import.meta.env.VITE_API_URL}/projects/${currentProjectId}/entity/status`, {
                     entity_id: entityUuid,
@@ -146,6 +144,7 @@ const TaskFeatureSelectionPopup = ({
                     label: '',
                   }),
                 );
+
                 if (task_status === 'READY') {
                   dispatch(
                     ProjectTaskStatus(
@@ -163,7 +162,11 @@ const TaskFeatureSelectionPopup = ({
                   );
                 }
 
-                document.location.href = `odkcollect://form/${formName}?existing=${entityUuid}`;
+                try {
+                  document.location.href = `odkcollect://form/${xformId}?task_id=${taskId}&existing=${entityUuid}`;
+                } catch (error) {
+                  document.location.href = 'https://play.google.com/store/apps/details?id=org.odk.collect.android';
+                }
               }}
             />
           </div>

--- a/src/frontend/src/components/ProjectDetailsV2/FeatureSelectionPopup.tsx
+++ b/src/frontend/src/components/ProjectDetailsV2/FeatureSelectionPopup.tsx
@@ -141,7 +141,7 @@ const TaskFeatureSelectionPopup = ({
                   UpdateEntityStatus(`${import.meta.env.VITE_API_URL}/projects/${currentProjectId}/entity/status`, {
                     entity_id: entityUuid,
                     status: 1,
-                    label: '',
+                    label: `Task ${taskId} Feature ${entity.osm_id}`,
                   }),
                 );
 

--- a/src/frontend/src/components/ProjectDetailsV2/FeatureSelectionPopup.tsx
+++ b/src/frontend/src/components/ProjectDetailsV2/FeatureSelectionPopup.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useState } from 'react';
 import CoreModules from '@/shared/CoreModules';
 import AssetModules from '@/shared/AssetModules';
+import { CommonActions } from '@/store/slices/CommonSlice';
 import Button from '@/components/common/Button';
 import { ProjectActions } from '@/store/slices/ProjectSlice';
 import environment from '@/environment';
@@ -15,7 +16,6 @@ import MapStyles from '@/hooks/MapStyles';
 type TaskFeatureSelectionPopupPropType = {
   taskId: number;
   featureProperties: TaskFeatureSelectionProperties | null;
-  taskId: number;
   taskFeature: Record<string, any>;
   map: any;
   view: any;
@@ -162,10 +162,22 @@ const TaskFeatureSelectionPopup = ({
                   );
                 }
 
-                try {
+                const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(
+                  navigator.userAgent,
+                );
+
+                if (isMobile) {
+                  // Load entity in ODK Collect by intent
                   document.location.href = `odkcollect://form/${xformId}?task_id=${taskId}&existing=${entityUuid}`;
-                } catch (error) {
-                  document.location.href = 'https://play.google.com/store/apps/details?id=org.odk.collect.android';
+                } else {
+                  dispatch(
+                    CommonActions.SetSnackBar({
+                      open: true,
+                      message: 'Requires a mobile phone with ODK Collect.',
+                      variant: 'warning',
+                      duration: 3000,
+                    }),
+                  );
                 }
               }}
             />

--- a/src/frontend/src/models/project/projectModel.ts
+++ b/src/frontend/src/models/project/projectModel.ts
@@ -59,6 +59,7 @@ export type projectInfoType = {
   description: string;
   short_description: string;
   xform_category: string;
+  xform_id: string;
   data_extract_url: string;
   odk_token: string;
   num_contributors: any;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Related to #1356

## Describe this PR

- There was an issue where the frontend ODK Collect intent URL was using the old `{title}_{category}` XFormID format.
- I updated to pass the XFormID to the frontend for a project, then include in the intent URL.
- I also fixed the form updating via the UI, which also required the XFormID to passed (to know which form to update.
- Finally the script to modify the xform before upload was using the old task ids, and not the task index. Updated too.

## Review Guide

- This can be tested either on the development server, or via tunnel: `just start tunnel`.
- A new project should be made with the tunnel ODK Central URL and loading by intent can be tested.

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
