### PR TITLE
fix(charts): size state to track responsive container to fix charts m…

### DIFF
--- a/src/frontend/src/components/common/BarChart.tsx
+++ b/src/frontend/src/components/common/BarChart.tsx
@@ -1,12 +1,20 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
 
 const CustomBarChart = ({ data, xLabel, yLabel, dataKey, nameKey }) => {
+  const [size, setSize] = useState({ width: 0, height: 0 });
+
   return (
-    <ResponsiveContainer width="100%" height="100%">
+    <ResponsiveContainer
+      width="100%"
+      height="100%"
+      onResize={(containerWidth, containerHeight) => {
+        setSize({ width: containerWidth, height: containerHeight });
+      }}
+    >
       <BarChart
-        width={500}
-        height={300}
+        width={size.width}
+        height={size.height}
         data={data}
         margin={{
           top: 5,

--- a/src/frontend/src/components/common/LineChart.tsx
+++ b/src/frontend/src/components/common/LineChart.tsx
@@ -1,12 +1,20 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer } from 'recharts';
 
 const CustomLineChart = ({ data, xAxisDataKey, lineOneKey, lineTwoKey, xLabel, yLabel }) => {
+  const [size, setSize] = useState({ width: 0, height: 0 });
+
   return (
-    <ResponsiveContainer width="100%" height="100%">
+    <ResponsiveContainer
+      width="100%"
+      height="100%"
+      onResize={(containerWidth, containerHeight) => {
+        setSize({ width: containerWidth, height: containerHeight });
+      }}
+    >
       <LineChart
-        width={500}
-        height={300}
+        width={size.width}
+        height={size.height}
         data={data}
         margin={{
           right: 30,

--- a/src/frontend/src/components/common/PieChart.tsx
+++ b/src/frontend/src/components/common/PieChart.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from 'recharts';
 
 const COLORS = ['#F19C3C', '#D73F3F', '#FFB74D', '#EC407A'];
@@ -46,9 +46,17 @@ const CustomLegend = ({ payload }) => (
 );
 
 const CustomPieChart = ({ data, dataKey, nameKey }) => {
+  const [size, setSize] = useState({ width: 0, height: 0 });
+
   return (
-    <ResponsiveContainer width="100%" height="105%">
-      <PieChart width={400} height={400}>
+    <ResponsiveContainer
+      width="100%"
+      height="105%"
+      onResize={(containerWidth, containerHeight) => {
+        setSize({ width: containerWidth, height: containerHeight });
+      }}
+    >
+      <PieChart width={size.width} height={size.height}>
         <Pie
           data={data}
           cx="50%"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue
- Related to #1566 

## Describe this PR
This PR contains fixing the recharts chart misalignment due to React 19 upgrade.

Note: In this approach, a state is maintained to track the size of the responsive container using `onResize` function on `ResponsiveContainer`

## Screenshots
![image](https://github.com/hotosm/fmtm/assets/81785002/5213b1ef-cd28-4486-ae68-65bf369b495e)
![image](https://github.com/hotosm/fmtm/assets/81785002/00846cdc-5e57-48b8-825f-876e46db7c85)