### PR TITLE
Ensure `status` Entity field is updated alongside survey form `status` field

### DIFF
--- a/src/backend/app/central/central_crud.py
+++ b/src/backend/app/central/central_crud.py
@@ -29,7 +29,7 @@ import geojson
 from defusedxml import ElementTree
 from fastapi import HTTPException
 from loguru import logger as log
-from osm_fieldwork.CSVDump import CSVDump
+from osm_fieldwork.csvdump import CSVDump
 from osm_fieldwork.OdkCentral import OdkAppUser, OdkForm, OdkProject
 from pyxform.builder import create_survey_element_from_dict
 from pyxform.xls2json import parse_file_to_json
@@ -354,7 +354,7 @@ async def update_project_xform(
     xform_obj.createForm(
         odk_id,
         updated_xform_data,
-        xform_id,
+        form_name=xform_id,
     )
     # The draft form must be published after upload
     xform_obj.publishForm(odk_id, xform_id)
@@ -544,7 +544,7 @@ async def modify_xform_xml(
 
     # Hardcode the form_category value for the start instructions
     form_category_update = root.find(
-        ".//xforms:bind[@nodeset='/data/all/form_category']", namespaces
+        ".//xforms:bind[@nodeset='/data/essential/form_category']", namespaces
     )
     if form_category_update is not None:
         if category.endswith("s"):

--- a/src/backend/pdm.lock
+++ b/src/backend/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "debug", "dev", "docs", "test", "monitoring"]
 strategy = ["cross_platform"]
 lock_version = "4.4.1"
-content_hash = "sha256:3dfb8a9f5d6fb72d99be33d0576d5649f08da14be9108063f0dc1d1352e6bf51"
+content_hash = "sha256:239a2201bc5d6533f19168ff0ff26ba017c652b39b2f80fbe6a0c412cf591d10"
 
 [[package]]
 name = "aiohttp"
@@ -1662,7 +1662,7 @@ files = [
 
 [[package]]
 name = "osm-fieldwork"
-version = "0.11.2"
+version = "0.12.0"
 requires_python = ">=3.10"
 summary = "Processing field data from ODK to OpenStreetMap format."
 dependencies = [
@@ -1687,8 +1687,8 @@ dependencies = [
     "xmltodict>=0.13.0",
 ]
 files = [
-    {file = "osm-fieldwork-0.11.2.tar.gz", hash = "sha256:472edd6873a173d526b636a01abb39cb558609d9df14da19cfe82413945954db"},
-    {file = "osm_fieldwork-0.11.2-py3-none-any.whl", hash = "sha256:be919fc058811253c7ee9276822d9160e2dff170d777bbf3e95d7fc40ec26def"},
+    {file = "osm-fieldwork-0.12.0.tar.gz", hash = "sha256:e0bde9273a966f18b608cf258de21789cd151b234c107d572ca32c630706c567"},
+    {file = "osm_fieldwork-0.12.0-py3-none-any.whl", hash = "sha256:e2a51898c0d66c93112a8cb71fbdadd0c3c5d6657161e538674d6b10a7c9f75f"},
 ]
 
 [[package]]

--- a/src/backend/pdm.lock
+++ b/src/backend/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "debug", "dev", "docs", "test", "monitoring"]
 strategy = ["cross_platform"]
 lock_version = "4.4.1"
-content_hash = "sha256:239a2201bc5d6533f19168ff0ff26ba017c652b39b2f80fbe6a0c412cf591d10"
+content_hash = "sha256:32f723d5850833fdc017e3ae23710d4abe8b26e1a4560500ce7b674a57527b5d"
 
 [[package]]
 name = "aiohttp"
@@ -1662,7 +1662,7 @@ files = [
 
 [[package]]
 name = "osm-fieldwork"
-version = "0.12.0"
+version = "0.12.1"
 requires_python = ">=3.10"
 summary = "Processing field data from ODK to OpenStreetMap format."
 dependencies = [
@@ -1687,8 +1687,8 @@ dependencies = [
     "xmltodict>=0.13.0",
 ]
 files = [
-    {file = "osm-fieldwork-0.12.0.tar.gz", hash = "sha256:e0bde9273a966f18b608cf258de21789cd151b234c107d572ca32c630706c567"},
-    {file = "osm_fieldwork-0.12.0-py3-none-any.whl", hash = "sha256:e2a51898c0d66c93112a8cb71fbdadd0c3c5d6657161e538674d6b10a7c9f75f"},
+    {file = "osm-fieldwork-0.12.1.tar.gz", hash = "sha256:fa67509e2c61ac5cd03bf210cc9884e83487e5f329520fc1a68c50cf8785401c"},
+    {file = "osm_fieldwork-0.12.1-py3-none-any.whl", hash = "sha256:5b70bca56a45508deee4d8b6b0210c3c2d810f9e75eb2a11e10a44a42e629ac6"},
 ]
 
 [[package]]

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "cryptography>=42.0.1",
     "defusedxml>=0.7.1",
     "osm-login-python==1.0.3",
-    "osm-fieldwork==0.12.0",
+    "osm-fieldwork==0.12.1",
     "osm-rawdata==0.3.0",
     "fmtm-splitter==1.2.2",
 ]

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "cryptography>=42.0.1",
     "defusedxml>=0.7.1",
     "osm-login-python==1.0.3",
-    "osm-fieldwork==0.11.2",
+    "osm-fieldwork==0.12.0",
     "osm-rawdata==0.3.0",
     "fmtm-splitter==1.2.2",
 ]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

From osm-fieldwork https://github.com/hotosm/osm-fieldwork/commit/6da506b628efbdb9d485da65f3aa85f919f1ed0b

Fixes #1581
Fixes #1576

## Describe this PR

- An update to osm-fieldwork included some restructured XLSForms (major overhaul for nicer user experience).
- The ODK Central server has also recently been updated.
- The `save_to` column was missing from the survey sheet (perhaps a new requirement in latest ODK Collect).
- This PR adds the column back in, so the status is updated on form submit.

## Additional considerations

- There is no guarantee the `task_id` field will be passed to the submission, as it has a `relevant` trigger, meaning if a building is selected then the `task_id` is omitted.
- The `task_id` field in the XLSForm is only there for filtering the features for selection on the map (and map be moved in future releases when loading ODK Collect by intent is officially available).

## Review Guide

Testing myself now!

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
