### PR TITLE
Ensure task_id field is always included with submissions

### DIFF
--- a/src/backend/app/central/central_crud.py
+++ b/src/backend/app/central/central_crud.py
@@ -452,7 +452,7 @@ async def modify_xform_xml(
     The 'id' field is set to random UUID (xFormId) unless existing_id is specified
     The 'name' field is set to the category name.
     The upload media must be equal to 'features.csv'.
-    The task_id options are populated as choices in the form.
+    The task_filter options are populated as choices in the form.
     The form_category value is also injected to display in the instructions.
 
     Args:
@@ -504,23 +504,23 @@ async def modify_xform_xml(
     # NOTE add the task ID choices to the XML
     # <instance> must be defined inside <model></model> root element
     model_element = root.find(".//xforms:model", namespaces)
-    # The existing dummy value for task_id must be removed
+    # The existing dummy value for task_filter must be removed
     existing_instance = model_element.find(
-        ".//xforms:instance[@id='task_id']", namespaces
+        ".//xforms:instance[@id='task_filter']", namespaces
     )
     if existing_instance is not None:
         model_element.remove(existing_instance)
     # Create a new instance element
-    instance_task_ids = Element("instance", id="task_id")
-    root_element = SubElement(instance_task_ids, "root")
+    instance_task_filters = Element("instance", id="task_filter")
+    root_element = SubElement(instance_task_filters, "root")
     # Create sub-elements for each task ID, <itextId> <name> pairs
     for task_id in range(1, task_count + 1):
         item = SubElement(root_element, "item")
-        SubElement(item, "itextId").text = f"task_id-{task_id}"
+        SubElement(item, "itextId").text = f"task_filter-{task_id}"
         SubElement(item, "name").text = str(task_id)
-    model_element.append(instance_task_ids)
+    model_element.append(instance_task_filters)
 
-    # Add task_id choice translations (necessary to be visible in form)
+    # Add task_filter choice translations (necessary to be visible in form)
     itext_element = root.find(".//xforms:itext", namespaces)
     if itext_element is not None:
         existing_translations = itext_element.findall(
@@ -529,14 +529,14 @@ async def modify_xform_xml(
         for translation in existing_translations:
             # Remove dummy value from existing translations
             existing_text = translation.find(
-                ".//xforms:text[@id='task_id-0']", namespaces
+                ".//xforms:text[@id='task_filter-0']", namespaces
             )
             if existing_text is not None:
                 translation.remove(existing_text)
 
             # Append new <text> elements for each task_id
             for task_id in range(1, task_count + 1):
-                new_text = Element("text", id=f"task_id-{task_id}")
+                new_text = Element("text", id=f"task_filter-{task_id}")
                 value_element = Element("value")
                 value_element.text = str(task_id)
                 new_text.append(value_element)

--- a/src/backend/app/submissions/submission_crud.py
+++ b/src/backend/app/submissions/submission_crud.py
@@ -91,7 +91,7 @@ from app.tasks import tasks_crud
 #         submissions = [
 #             sub
 #             for sub in submissions
-#             if sub.get("all", {}).get("task_id") == str(task_id)
+#             if sub.get("task_id") == str(task_id)
 #         ]
 
 #     if not submissions:

--- a/src/backend/app/submissions/submission_routes.py
+++ b/src/backend/app/submissions/submission_routes.py
@@ -408,11 +408,7 @@ async def submission_table(
     submissions = data.get("value", [])
 
     if task_id:
-        submissions = [
-            sub
-            for sub in submissions
-            if sub.get("all", {}).get("task_id") == str(task_id)
-        ]
+        submissions = [sub for sub in submissions if sub.get("task_id") == str(task_id)]
 
     pagination = await project_crud.get_pagination(page, count, results_per_page, count)
     response = submission_schemas.PaginatedSubmissions(

--- a/src/backend/pdm.lock
+++ b/src/backend/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "debug", "dev", "docs", "test", "monitoring"]
 strategy = ["cross_platform"]
 lock_version = "4.4.1"
-content_hash = "sha256:587ccb03cc525f2c670bdf4397d16e28bcd0a38d3b0fb1898149becedea97c7b"
+content_hash = "sha256:4ce2944484e6b4e128d661d7ce502ee72e7752344e1d4ab0cbc4d4ba413dc707"
 
 [[package]]
 name = "aiohttp"
@@ -1662,7 +1662,7 @@ files = [
 
 [[package]]
 name = "osm-fieldwork"
-version = "0.12.2"
+version = "0.12.3"
 requires_python = ">=3.10"
 summary = "Processing field data from ODK to OpenStreetMap format."
 dependencies = [
@@ -1687,8 +1687,8 @@ dependencies = [
     "xmltodict>=0.13.0",
 ]
 files = [
-    {file = "osm-fieldwork-0.12.2.tar.gz", hash = "sha256:26da794186e5219a7fe647310151ebe6dfec438049a9405362a6f7193fd43d1a"},
-    {file = "osm_fieldwork-0.12.2-py3-none-any.whl", hash = "sha256:646cbd93b611da8951c5ae1b0808c115dfa8dc35098ebd1c358db6a3f020a7af"},
+    {file = "osm-fieldwork-0.12.3.tar.gz", hash = "sha256:75798d6af2c86b889c6ad9f2ab4333d369d1c6926c8b32f72e0460db86a6b2a3"},
+    {file = "osm_fieldwork-0.12.3-py3-none-any.whl", hash = "sha256:48adc4cc4a56c3ede9f3b3055c22918948dbe061d1a2c00926275ee513d25954"},
 ]
 
 [[package]]

--- a/src/backend/pdm.lock
+++ b/src/backend/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "debug", "dev", "docs", "test", "monitoring"]
 strategy = ["cross_platform"]
 lock_version = "4.4.1"
-content_hash = "sha256:32f723d5850833fdc017e3ae23710d4abe8b26e1a4560500ce7b674a57527b5d"
+content_hash = "sha256:587ccb03cc525f2c670bdf4397d16e28bcd0a38d3b0fb1898149becedea97c7b"
 
 [[package]]
 name = "aiohttp"
@@ -1662,7 +1662,7 @@ files = [
 
 [[package]]
 name = "osm-fieldwork"
-version = "0.12.1"
+version = "0.12.2"
 requires_python = ">=3.10"
 summary = "Processing field data from ODK to OpenStreetMap format."
 dependencies = [
@@ -1687,8 +1687,8 @@ dependencies = [
     "xmltodict>=0.13.0",
 ]
 files = [
-    {file = "osm-fieldwork-0.12.1.tar.gz", hash = "sha256:fa67509e2c61ac5cd03bf210cc9884e83487e5f329520fc1a68c50cf8785401c"},
-    {file = "osm_fieldwork-0.12.1-py3-none-any.whl", hash = "sha256:5b70bca56a45508deee4d8b6b0210c3c2d810f9e75eb2a11e10a44a42e629ac6"},
+    {file = "osm-fieldwork-0.12.2.tar.gz", hash = "sha256:26da794186e5219a7fe647310151ebe6dfec438049a9405362a6f7193fd43d1a"},
+    {file = "osm_fieldwork-0.12.2-py3-none-any.whl", hash = "sha256:646cbd93b611da8951c5ae1b0808c115dfa8dc35098ebd1c358db6a3f020a7af"},
 ]
 
 [[package]]

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "cryptography>=42.0.1",
     "defusedxml>=0.7.1",
     "osm-login-python==1.0.3",
-    "osm-fieldwork==0.12.1",
+    "osm-fieldwork==0.12.2",
     "osm-rawdata==0.3.0",
     "fmtm-splitter==1.2.2",
 ]

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "cryptography>=42.0.1",
     "defusedxml>=0.7.1",
     "osm-login-python==1.0.3",
-    "osm-fieldwork==0.12.2",
+    "osm-fieldwork==0.12.3",
     "osm-rawdata==0.3.0",
     "fmtm-splitter==1.2.2",
 ]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Related to #1581

## Describe this PR

- The `task_id` field was not mandatory on the XLSForms, but was required for the submission table filtering in FMTM.
- I updated osm-fieldwork XLSForms to have a mandatory `task_id` field, that is calculated from the Entity task_id.
- The existing `task_id` field was renamed to `task_filter` and is only used to filter features by the task area in ODK Collect (field ignored if a feature is already selected).

## Review Guide

- Easiest to test on dev / staging, or using cloudflare tunnels: `just --unstable start tunnel`.
- The entire mapping flow can be complete using the tunnel url for odk central.

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
