### PR TITLE
Updated default values in the database

### DIFF
--- a/src/backend/migrations/004-update-default-values.sql
+++ b/src/backend/migrations/004-update-default-values.sql
@@ -1,0 +1,65 @@
+-- ## Migration to:
+-- * Set default values to respective fields in the table.
+
+-- Start a transaction
+BEGIN;
+
+-- Update mapping_issue_categories table
+ALTER TABLE public.mapping_issue_categories
+ALTER COLUMN archived SET DEFAULT false;
+
+-- Update mbtiles_path table
+ALTER TABLE public.mbtiles_path
+ALTER COLUMN created_at SET DEFAULT now();
+
+-- Update project_chat table
+ALTER TABLE public.project_chat
+ALTER COLUMN time_stamp SET DEFAULT now();
+
+-- Update projects table
+ALTER TABLE public.projects
+ALTER COLUMN created SET DEFAULT now(),
+ALTER COLUMN last_updated SET DEFAULT now(),
+ALTER COLUMN status SET DEFAULT 'DRAFT',
+ALTER COLUMN mapper_level SET DEFAULT 'INTERMEDIATE',
+ALTER COLUMN priority SET DEFAULT 'MEDIUM',
+ALTER COLUMN featured SET DEFAULT false,
+ALTER COLUMN mapping_permission SET DEFAULT 'ANY',
+ALTER COLUMN validation_permission SET DEFAULT 'LEVEL';
+
+-- Update task_history table
+ALTER TABLE public.task_history
+ALTER COLUMN action_date SET DEFAULT now();
+
+-- Update task_invalidation_history table
+ALTER TABLE public.task_invalidation_history
+ALTER COLUMN is_closed SET DEFAULT false,
+ALTER COLUMN updated_date SET DEFAULT now();
+
+-- Update tasks table
+ALTER TABLE public.tasks
+ALTER COLUMN task_status SET DEFAULT 'READY';
+
+-- Update teams table
+ALTER TABLE public.teams
+ALTER COLUMN invite_only SET DEFAULT false,
+ALTER COLUMN visibility SET DEFAULT 'PUBLIC';
+
+-- Update user_roles table
+ALTER TABLE public.user_roles
+ALTER COLUMN role SET DEFAULT 'MAPPER';
+
+-- Update users table
+ALTER TABLE public.users
+ALTER COLUMN role SET DEFAULT 'MAPPER',
+ALTER COLUMN is_email_verified SET DEFAULT false,
+ALTER COLUMN is_expert SET DEFAULT false,
+ALTER COLUMN mapping_level SET DEFAULT 'BEGINNER',
+ALTER COLUMN tasks_mapped SET DEFAULT 0,
+ALTER COLUMN tasks_validated SET DEFAULT 0,
+ALTER COLUMN tasks_invalidated SET DEFAULT 0,
+ALTER COLUMN date_registered SET DEFAULT now(),
+ALTER COLUMN last_validation_date SET DEFAULT now();
+
+-- Commit the transaction
+COMMIT;

--- a/src/backend/migrations/init/fmtm_base_schema.sql
+++ b/src/backend/migrations/init/fmtm_base_schema.sql
@@ -216,7 +216,7 @@ CREATE TABLE public.mapping_issue_categories (
     id integer NOT NULL,
     name character varying NOT NULL,
     description character varying,
-    archived boolean NOT NULL
+    archived boolean NOT NULL DEFAULT false
 );
 ALTER TABLE public.mapping_issue_categories OWNER TO fmtm;
 CREATE SEQUENCE public.mapping_issue_categories_id_seq
@@ -238,7 +238,7 @@ CREATE TABLE public.mbtiles_path (
     path character varying,
     tile_source character varying,
     background_task_id character varying,
-    created_at timestamp without time zone
+    created_at timestamp without time zone DEFAULT now()
 );
 ALTER TABLE public.mbtiles_path OWNER TO fmtm;
 CREATE SEQUENCE public.mbtiles_path_id_seq
@@ -297,7 +297,7 @@ CREATE TABLE public.project_chat (
     id bigint NOT NULL,
     project_id integer NOT NULL,
     user_id integer NOT NULL,
-    time_stamp timestamp without time zone NOT NULL,
+    time_stamp timestamp without time zone NOT NULL DEFAULT now(),
     message character varying NOT NULL
 );
 ALTER TABLE public.project_chat OWNER TO fmtm;
@@ -336,21 +336,21 @@ CREATE TABLE public.projects (
     organisation_id integer,
     odkid integer,
     author_id bigint NOT NULL,
-    created timestamp without time zone NOT NULL,
+    created timestamp without time zone NOT NULL DEFAULT now(),
     project_name_prefix character varying,
     task_type_prefix character varying,
     location_str character varying,
     outline public.GEOMETRY (POLYGON, 4326),
-    last_updated timestamp without time zone,
-    status public.projectstatus NOT NULL,
+    last_updated timestamp without time zone DEFAULT now(),
+    status public.projectstatus NOT NULL DEFAULT 'DRAFT',
     total_tasks integer,
     xform_category character varying,
     visibility public.projectvisibility NOT NULL DEFAULT 'PUBLIC',
-    mapper_level public.mappinglevel NOT NULL,
-    priority public.projectpriority,
-    featured boolean,
-    mapping_permission public.mappingpermission,
-    validation_permission public.validationpermission,
+    mapper_level public.mappinglevel NOT NULL DEFAULT 'INTERMEDIATE',
+    priority public.projectpriority DEFAULT 'MEDIUM',
+    featured boolean DEFAULT false,
+    mapping_permission public.mappingpermission DEFAULT 'ANY',
+    validation_permission public.validationpermission DEFAULT 'LEVEL',
     due_date timestamp without time zone,
     changeset_comment character varying,
     osmcha_filter_id character varying,
@@ -393,7 +393,7 @@ CREATE TABLE public.task_history (
     task_id integer NOT NULL,
     action public.taskaction NOT NULL,
     action_text character varying,
-    action_date timestamp without time zone NOT NULL,
+    action_date timestamp without time zone NOT NULL DEFAULT now(),
     user_id bigint NOT NULL
 );
 ALTER TABLE public.task_history OWNER TO fmtm;
@@ -412,7 +412,7 @@ CREATE TABLE public.task_invalidation_history (
     id integer NOT NULL,
     project_id integer NOT NULL,
     task_id integer NOT NULL,
-    is_closed boolean,
+    is_closed boolean DEFAULT false,
     mapper_id bigint,
     mapped_date timestamp without time zone,
     invalidator_id bigint,
@@ -420,7 +420,7 @@ CREATE TABLE public.task_invalidation_history (
     invalidation_history_id integer,
     validator_id bigint,
     validated_date timestamp without time zone,
-    updated_date timestamp without time zone
+    updated_date timestamp without time zone DEFAULT now()
 );
 ALTER TABLE public.task_invalidation_history OWNER TO fmtm;
 CREATE SEQUENCE public.task_invalidation_history_id_seq
@@ -463,7 +463,7 @@ CREATE TABLE public.tasks (
     outline public.GEOMETRY (POLYGON, 4326),
     geometry_geojson character varying,
     feature_count integer,
-    task_status public.taskstatus,
+    task_status public.taskstatus DEFAULT 'READY',
     locked_by bigint,
     mapped_by bigint,
     validated_by bigint
@@ -486,8 +486,8 @@ CREATE TABLE public.teams (
     name character varying(512) NOT NULL,
     logo character varying,
     description character varying,
-    invite_only boolean NOT NULL,
-    visibility public.teamvisibility NOT NULL
+    invite_only boolean NOT NULL DEFAULT false,
+    visibility public.teamvisibility NOT NULL DEFAULT 'PUBLIC'
 );
 ALTER TABLE public.teams OWNER TO fmtm;
 CREATE SEQUENCE public.teams_id_seq
@@ -511,7 +511,7 @@ ALTER TABLE public.user_licenses OWNER TO fmtm;
 CREATE TABLE public.user_roles (
     user_id bigint NOT NULL,
     project_id integer NOT NULL,
-    role public.projectrole NOT NULL
+    role public.projectrole NOT NULL DEFAULT 'MAPPER'
 );
 ALTER TABLE public.user_roles OWNER TO fmtm;
 
@@ -519,21 +519,21 @@ ALTER TABLE public.user_roles OWNER TO fmtm;
 CREATE TABLE public.users (
     id bigint NOT NULL,
     username character varying,
-    role public.userrole NOT NULL,
+    role public.userrole NOT NULL DEFAULT 'MAPPER',
     name character varying,
     city character varying,
     country character varying,
     profile_img character varying,
     email_address character varying,
-    is_email_verified boolean,
-    is_expert boolean,
-    mapping_level public.mappinglevel NOT NULL,
-    tasks_mapped integer NOT NULL,
-    tasks_validated integer NOT NULL,
-    tasks_invalidated integer NOT NULL,
+    is_email_verified boolean DEFAULT false,
+    is_expert boolean DEFAULT false,
+    mapping_level public.mappinglevel NOT NULL DEFAULT 'BEGINNER',
+    tasks_mapped integer NOT NULL DEFAULT 0,
+    tasks_validated integer NOT NULL DEFAULT 0,
+    tasks_invalidated integer NOT NULL DEFAULT 0,
     projects_mapped integer [],
-    date_registered timestamp without time zone,
-    last_validation_date timestamp without time zone
+    date_registered timestamp without time zone DEFAULT now(),
+    last_validation_date timestamp without time zone DEFAULT now()
 );
 ALTER TABLE public.users OWNER TO fmtm;
 

--- a/src/backend/migrations/revert/004-update-default-values.sql
+++ b/src/backend/migrations/revert/004-update-default-values.sql
@@ -1,0 +1,65 @@
+-- ## Migration to:
+-- * Remove default values from respective fields in the table.
+
+-- Start a transaction
+BEGIN;
+
+-- Revert changes in mapping_issue_categories table
+ALTER TABLE public.mapping_issue_categories
+ALTER COLUMN archived DROP DEFAULT;
+
+-- Revert changes in mbtiles_path table
+ALTER TABLE public.mbtiles_path
+ALTER COLUMN created_at DROP DEFAULT;
+
+-- Revert changes in project_chat table
+ALTER TABLE public.project_chat
+ALTER COLUMN time_stamp DROP DEFAULT;
+
+-- Revert changes in projects table
+ALTER TABLE public.projects
+ALTER COLUMN created DROP DEFAULT,
+ALTER COLUMN last_updated DROP DEFAULT,
+ALTER COLUMN status DROP DEFAULT,
+ALTER COLUMN mapper_level DROP DEFAULT,
+ALTER COLUMN priority DROP DEFAULT,
+ALTER COLUMN featured DROP DEFAULT,
+ALTER COLUMN mapping_permission DROP DEFAULT,
+ALTER COLUMN validation_permission DROP DEFAULT;
+
+-- Revert changes in task_history table
+ALTER TABLE public.task_history
+ALTER COLUMN action_date DROP DEFAULT;
+
+-- Revert changes in task_invalidation_history table
+ALTER TABLE public.task_invalidation_history
+ALTER COLUMN is_closed DROP DEFAULT,
+ALTER COLUMN updated_date DROP DEFAULT;
+
+-- Revert changes in task_invalidation_history_id_seq table
+ALTER TABLE public.task_invalidation_history_id_seq
+ALTER COLUMN task_status DROP DEFAULT;
+
+-- Revert changes in teams table
+ALTER TABLE public.teams
+ALTER COLUMN invite_only DROP DEFAULT,
+ALTER COLUMN visibility DROP DEFAULT;
+
+-- Revert changes in user_roles table
+ALTER TABLE public.user_roles
+ALTER COLUMN role DROP DEFAULT;
+
+-- Revert changes in users table
+ALTER TABLE public.users
+ALTER COLUMN role DROP DEFAULT,
+ALTER COLUMN is_email_verified DROP DEFAULT,
+ALTER COLUMN is_expert DROP DEFAULT,
+ALTER COLUMN mapping_level DROP DEFAULT,
+ALTER COLUMN tasks_mapped DROP DEFAULT,
+ALTER COLUMN tasks_validated DROP DEFAULT,
+ALTER COLUMN tasks_invalidated DROP DEFAULT,
+ALTER COLUMN date_registered DROP DEFAULT,
+ALTER COLUMN last_validation_date DROP DEFAULT;
+
+-- Commit the transaction
+COMMIT;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [X] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- Issue No.  #1337 

## Describe this PR

This PR updates the fmtm base database schema by adding default values wherever necessary at the database level instead of defining them using sqlalchemy.

## Screenshots

SQL query to insert data in the user table without mentioning other fields where default values are set.
![image](https://github.com/hotosm/fmtm/assets/109404840/0e136d71-dedf-4631-ba20-aa37bd200e51)

Result
![image](https://github.com/hotosm/fmtm/assets/109404840/aaf33b3b-b598-4ac2-ae6c-8f5ef077aa16)
Here, `role`, `is_email_verified`, `is_expert` , `mapping_level` , `tasks_mapped`, `tasks_validated` are auto-populated with default values.
## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
