### PR TITLE
fix(map): set default baseLayer to OSM

### DIFF
--- a/src/frontend/src/components/MapComponent/OpenLayersComponent/LayerSwitcher/index.js
+++ b/src/frontend/src/components/MapComponent/OpenLayersComponent/LayerSwitcher/index.js
@@ -178,8 +178,8 @@ const LayerSwitcherControl = ({ map, visible = 'osm', pmTileLayerData = null }) 
       layers: [
         bingMaps(visible),
         osm(visible),
-        mapboxMap(visible),
-        mapboxOutdoors(visible),
+        // mapboxMap(visible),
+        // mapboxOutdoors(visible),
         none(visible),
         // pmTileLayer(pmTileLayerData, visible),
       ],

--- a/src/frontend/src/components/ProjectSubmissions/TaskSubmissionsMap.tsx
+++ b/src/frontend/src/components/ProjectSubmissions/TaskSubmissionsMap.tsx
@@ -254,7 +254,7 @@ const TaskSubmissionsMap = () => {
           width: '100%',
         }}
       >
-        <LayerSwitcherControl />
+        <LayerSwitcherControl visible={'osm'} />
         {taskBoundaries && (
           <VectorLayer
             setStyle={(feature, resolution) =>

--- a/src/frontend/src/components/SubmissionMap/SubmissionInstanceMap.jsx
+++ b/src/frontend/src/components/SubmissionMap/SubmissionInstanceMap.jsx
@@ -30,7 +30,7 @@ const SubmissionInstanceMap = ({ featureGeojson }) => {
           width: '100%',
         }}
       >
-        <LayerSwitcherControl />
+        <LayerSwitcherControl visible={'osm'} />
         {featureGeojson?.type && (
           <VectorLayer
             geojson={featureGeojson}

--- a/src/frontend/src/components/home/ProjectListMap.tsx
+++ b/src/frontend/src/components/home/ProjectListMap.tsx
@@ -89,7 +89,7 @@ const ProjectListMap = () => {
             width: '100%',
           }}
         >
-          <LayerSwitcherControl visible={'outdoors'} />
+          <LayerSwitcherControl visible={'osm'} />
           {projectGeojson && projectGeojson?.features?.length > 0 && (
             <ClusterLayer
               map={map}

--- a/src/frontend/src/views/EditProjectArea.tsx
+++ b/src/frontend/src/views/EditProjectArea.tsx
@@ -23,7 +23,7 @@ const EditProjectArea = ({ geojson }) => {
           width: '100%',
         }}
       >
-        <LayerSwitcherControl />
+        <LayerSwitcherControl visible={'osm'} />
         {geojson && (
           <VectorLayer
             geojson={geojson}

--- a/src/frontend/src/views/NewDefineAreaMap.tsx
+++ b/src/frontend/src/views/NewDefineAreaMap.tsx
@@ -47,7 +47,7 @@ const NewDefineAreaMap = ({
           width: '100%',
         }}
       >
-        <LayerSwitcherControl />
+        <LayerSwitcherControl visible={'osm'} />
         <MapControlComponent map={map} hasEditUndo={hasEditUndo} />
         {splittedGeojson && (
           <VectorLayer

--- a/src/frontend/src/views/ProjectDetailsV2.tsx
+++ b/src/frontend/src/views/ProjectDetailsV2.tsx
@@ -457,7 +457,7 @@ const ProjectDetailsV2 = () => {
                 </div>
               )}
               <LayerSwitcherControl
-                visible={customBasemapData ? 'custom' : 'outdoors'}
+                visible={customBasemapData ? 'custom' : 'osm'}
                 pmTileLayerData={customBasemapData}
               />
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue
- Related to #1599

## Describe this PR
This PR replaces the current default baselayer(Mapbox) to OSM to solve the map not visible issue.

## Screenshots
![image](https://github.com/hotosm/fmtm/assets/81785002/33fb86e2-873b-431e-86ca-66188b21284d)
