### PR TITLE
Update task_history.action correctly on db

### DIFF
--- a/src/backend/app/models/enums.py
+++ b/src/backend/app/models/enums.py
@@ -225,22 +225,22 @@ def is_status_change_action(task_action):
 
 def get_action_for_status_change(task_status: TaskStatus):
     """Update task action inferred from previous state."""
-    return TaskAction.RELEASED_FOR_MAPPING
-    # match task_status:
-    #     case TaskStatus.READY:
-    #         return TaskAction.RELEASED_FOR_MAPPING
-    #     case TaskStatus.LOCKED_FOR_MAPPING:
-    #         return TaskAction.LOCKED_FOR_MAPPING
-    #     case TaskStatus.MAPPED:
-    #         return TaskAction.MARKED_MAPPED
-    #     case TaskStatus.LOCKED_FOR_VALIDATION:
-    #         return TaskAction.LOCKED_FOR_VALIDATION
-    #     case TaskStatus.VALIDATED:
-    #         return TaskAction.VALIDATED
-    #     case TaskStatus.BAD:
-    #         return TaskAction.MARKED_BAD
-    #     case TaskStatus.SPLIT:
-    #         return TaskAction.SPLIT_NEEDED
+    # return TaskAction.RELEASED_FOR_MAPPING
+    match task_status:
+        case TaskStatus.READY:
+            return TaskAction.RELEASED_FOR_MAPPING
+        case TaskStatus.LOCKED_FOR_MAPPING:
+            return TaskAction.LOCKED_FOR_MAPPING
+        case TaskStatus.MAPPED:
+            return TaskAction.MARKED_MAPPED
+        case TaskStatus.LOCKED_FOR_VALIDATION:
+            return TaskAction.LOCKED_FOR_VALIDATION
+        case TaskStatus.VALIDATED:
+            return TaskAction.VALIDATED
+        case TaskStatus.BAD:
+            return TaskAction.MARKED_BAD
+        case TaskStatus.SPLIT:
+            return TaskAction.SPLIT_NEEDED
 
 
 class TaskType(IntEnum, Enum):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue
- Related to #1605

## Describe this PR
This PR contains works to fix the `task_history.action` column not being updated in the DB. 
It seems `get_action_for_status_change` was only returning `RELEASED_FOR_MAPPING`.

## Screenshots
![image](https://github.com/hotosm/fmtm/assets/81785002/6c7c4db6-a273-4a78-9558-4c0c82f47cd2)


