### PR TITLE
Prevent project generation if api failure

### DIFF
--- a/.github/workflows/pr_test_frontend.yml
+++ b/.github/workflows/pr_test_frontend.yml
@@ -21,6 +21,6 @@ jobs:
   e2e-tests:
     uses: hotosm/gh-workflows/.github/workflows/test_pnpm.yml@main
     with:
-      container_config: '{"image": "mcr.microsoft.com/playwright:v1.44.1"}'
+      container_config: '{"image": "mcr.microsoft.com/playwright:v1.45.1"}'
       working_dir: src/frontend
       run_command: "test:e2e"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -129,7 +129,7 @@ services:
 
   ui-test:
     profiles: ["ui-test"]
-    image: mcr.microsoft.com/playwright:v1.44.1
+    image: mcr.microsoft.com/playwright:v1.45.1
     working_dir: /app
     environment:
       - DISPLAY=:0

--- a/src/frontend/src/components/createnewproject/SplitTasks.tsx
+++ b/src/frontend/src/components/createnewproject/SplitTasks.tsx
@@ -31,7 +31,8 @@ const SplitTasks = ({ flag, geojsonFile, setGeojsonFile, customDataExtractUpload
   const projectDetails = useAppSelector((state) => state.createproject.projectDetails);
   const dataExtractGeojson = useAppSelector((state) => state.createproject.dataExtractGeojson);
 
-  const generateQrSuccess = useAppSelector((state) => state.createproject.generateQrSuccess);
+  const generateProjectSuccess = useAppSelector((state) => state.createproject.generateProjectSuccess);
+  const generateProjectError = useAppSelector((state) => state.createproject.generateProjectError);
   const projectDetailsResponse = useAppSelector((state) => state.createproject.projectDetailsResponse);
   const dividedTaskGeojson = useAppSelector((state) => state.createproject.dividedTaskGeojson);
   const projectDetailsLoading = useAppSelector((state) => state.createproject.projectDetailsLoading);
@@ -191,12 +192,12 @@ const SplitTasks = ({ flag, geojsonFile, setGeojsonFile, customDataExtractUpload
     const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
     const handleQRGeneration = async () => {
-      if (generateQrSuccess) {
+      if (!generateProjectError && generateProjectSuccess) {
         const projectId = projectDetailsResponse?.id;
         dispatch(
           CommonActions.SetSnackBar({
             open: true,
-            message: 'QR Generation Completed. Redirecting...',
+            message: 'Project Generation Completed. Redirecting...',
             variant: 'success',
             duration: 2000,
           }),
@@ -205,7 +206,6 @@ const SplitTasks = ({ flag, geojsonFile, setGeojsonFile, customDataExtractUpload
         // Add 5-second delay to allow backend Entity generation to catch up
         await delay(5000);
         dispatch(CreateProjectActions.CreateProjectLoading(false));
-        dispatch(CreateProjectActions.SetGenerateProjectQRSuccess(null));
         navigate(`/project/${projectId}`);
         dispatch(CreateProjectActions.ClearCreateProjectFormData());
         dispatch(CreateProjectActions.SetCanSwitchCreateProjectSteps(false));
@@ -213,7 +213,7 @@ const SplitTasks = ({ flag, geojsonFile, setGeojsonFile, customDataExtractUpload
     };
 
     handleQRGeneration();
-  }, [generateQrSuccess]);
+  }, [generateProjectSuccess]);
 
   const renderTraceback = (errorText: string) => {
     if (!errorText) {

--- a/src/frontend/src/components/createnewproject/SplitTasks.tsx
+++ b/src/frontend/src/components/createnewproject/SplitTasks.tsx
@@ -213,7 +213,7 @@ const SplitTasks = ({ flag, geojsonFile, setGeojsonFile, customDataExtractUpload
     };
 
     handleQRGeneration();
-  }, [generateProjectSuccess]);
+  }, [generateProjectSuccess, generateProjectError]);
 
   const renderTraceback = (errorText: string) => {
     if (!errorText) {

--- a/src/frontend/src/store/slices/CreateProjectSlice.ts
+++ b/src/frontend/src/store/slices/CreateProjectSlice.ts
@@ -95,6 +95,9 @@ const CreateProject = createSlice({
       state.uploadAreaSelection = '';
       state.dividedTaskGeojson = null;
       state.dividedTaskLoading = false;
+      state.generateProjectSuccess = false;
+      state.generateProjectError = false;
+      state.drawToggle = false;
     },
     UploadAreaLoading(state, action) {
       state.projectAreaLoading = action.payload;

--- a/src/frontend/src/store/slices/CreateProjectSlice.ts
+++ b/src/frontend/src/store/slices/CreateProjectSlice.ts
@@ -28,10 +28,11 @@ export const initialState: CreateProjectStateTypes = {
   projectAreaLoading: false,
   formCategoryList: [],
   formCategoryLoading: false,
-  generateQrLoading: false,
+  generateProjectLoading: false,
+  generateProjectSuccess: false,
+  generateProjectError: false,
   organisationList: [],
   organisationListLoading: false,
-  generateQrSuccess: null,
   createProjectStep: 1,
   dividedTaskLoading: false,
   dividedTaskGeojson: null,
@@ -110,24 +111,20 @@ const CreateProject = createSlice({
     SetIndividualProjectDetailsData(state, action) {
       state.projectDetails = action.payload;
     },
-    GenerateProjectQRLoading(state, action) {
-      state.generateQrLoading = action.payload;
+    GenerateProjectLoading(state, action) {
+      state.generateProjectLoading = action.payload;
+    },
+    GenerateProjectSuccess(state, action) {
+      state.generateProjectSuccess = action.payload;
+    },
+    GenerateProjectError(state, action) {
+      state.generateProjectError = action.payload;
     },
     GetOrganisationList(state, action) {
       state.organisationList = action.payload;
     },
     GetOrganisationListLoading(state, action) {
       state.organisationListLoading = action.payload;
-    },
-    GenerateProjectQRSuccess(state, action) {
-      if (action.payload.status === 'SUCCESS') {
-        state.generateQrSuccess = null;
-      } else {
-        state.generateQrSuccess = action.payload;
-      }
-    },
-    SetGenerateProjectQRSuccess(state, action) {
-      state.generateQrSuccess = action.payload;
     },
     SetCreateProjectFormStep(state, action) {
       state.createProjectStep = action.payload;

--- a/src/frontend/src/store/types/ICreateProject.ts
+++ b/src/frontend/src/store/types/ICreateProject.ts
@@ -11,10 +11,11 @@ export type CreateProjectStateTypes = {
   projectAreaLoading: boolean;
   formCategoryList: FormCategoryListTypes[] | [];
   formCategoryLoading: boolean;
-  generateQrLoading: boolean;
+  generateProjectLoading: boolean;
+  generateProjectSuccess: boolean;
+  generateProjectError: boolean;
   organisationList: OrganisationListTypes[];
   organisationListLoading: boolean;
-  generateQrSuccess: GenerateQrSuccessTypes | null;
   createProjectStep: number;
   dividedTaskLoading: boolean;
   dividedTaskGeojson: null | GeoJSONFeatureTypes;
@@ -127,11 +128,6 @@ export type ProjectAreaTypes = {
 export type FormCategoryListTypes = {
   id: number;
   title: string;
-};
-
-export type GenerateQrSuccessTypes = {
-  Message: string;
-  task_id: string;
 };
 
 export type OrganisationListTypes = {

--- a/src/frontend/src/utilfunctions/commonUtils.ts
+++ b/src/frontend/src/utilfunctions/commonUtils.ts
@@ -9,3 +9,10 @@ export const isInputEmpty = (text: string): boolean => {
 export const camelToFlat = (word: string): string => (
   (word = word.replace(/[A-Z]/g, ' $&')), word[0].toUpperCase() + word.slice(1)
 );
+
+export const isStatusSuccess = (status: number) => {
+  if (status < 300) {
+    return true;
+  }
+  return false;
+};


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Describe this PR

- Currently if there is a failure with of the 4 project creation APIs, the creation will continue, and redirect.
- Instead it should halt creation and display an error to the user.
- I did some refactors here @NSUWAL123 to use a state variables: `generateProjectError` and `generateProjectSuccess`.
- If `generateProjectSuccess` is set to true, then the watcher in `SplitTasks.tsx` will display a success message and do the redirect.
- If `generateProjectError` is set at any stage, then the remaining project creation stages should stop - I didn't get to implement this, could you take a look please?
- It might be a good idea to add the project creation and data extract upload to separate services, for consistency.

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
