### PR TITLE
Save current form step state on previous btn click

### DIFF
--- a/src/frontend/src/components/createnewproject/SelectForm.tsx
+++ b/src/frontend/src/components/createnewproject/SelectForm.tsx
@@ -193,7 +193,10 @@ const SelectForm = ({ flag, geojsonFile, customFormFile, setCustomFormFile }) =>
                 btnText="PREVIOUS"
                 btnType="secondary"
                 type="button"
-                onClick={() => toggleStep(2, '/upload-area')}
+                onClick={() => {
+                  dispatch(CreateProjectActions.SetIndividualProjectDetailsData(formValues));
+                  toggleStep(2, '/upload-area');
+                }}
                 className="fmtm-font-bold"
               />
               <Button btnText="NEXT" btnType="primary" type="submit" className="fmtm-font-bold" />

--- a/src/frontend/src/components/createnewproject/SplitTasks.tsx
+++ b/src/frontend/src/components/createnewproject/SplitTasks.tsx
@@ -343,7 +343,10 @@ const SplitTasks = ({ flag, geojsonFile, setGeojsonFile, customDataExtractUpload
                     btnText="PREVIOUS"
                     btnType="secondary"
                     type="button"
-                    onClick={() => toggleStep(3, '/data-extract')}
+                    onClick={() => {
+                      dispatch(CreateProjectActions.SetIndividualProjectDetailsData(formValues));
+                      toggleStep(3, '/data-extract');
+                    }}
                     className="fmtm-font-bold"
                   />
                   <Button

--- a/src/frontend/src/components/createnewproject/UploadArea.tsx
+++ b/src/frontend/src/components/createnewproject/UploadArea.tsx
@@ -316,7 +316,10 @@ const UploadArea = ({ flag, geojsonFile, setGeojsonFile, setCustomDataExtractUpl
                 btnText="PREVIOUS"
                 btnType="secondary"
                 type="button"
-                onClick={() => toggleStep(1, '/create-project')}
+                onClick={() => {
+                  dispatch(CreateProjectActions.SetIndividualProjectDetailsData(formValues));
+                  toggleStep(1, '/create-project');
+                }}
                 className="fmtm-font-bold"
               />
               <Button btnText="NEXT" btnType="primary" type="submit" className="fmtm-font-bold" />


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue
- Related to #1639 

## Describe this PR
Currently in the steps `upload area`, `select category`, and `split tasks`, when the previous button is clicked after filling fields respectively, file states are being saved but the dropdowns, radiobuttons state is not saved leading to displaying misleading error messages. 
This PR contain the works to solve this by saving the state of the current step when the previous button is clicked.

## Screenshots
Before Changes:
[Screencast from 11-7-24 09:48:44 पूर्वाह्न +0545.webm](https://github.com/hotosm/fmtm/assets/81785002/49f61a26-93d7-4da4-a141-b4037ee202b3)

After Changes:
[Screencast from 11-7-24 09:52:22 पूर्वाह्न +0545.webm](https://github.com/hotosm/fmtm/assets/81785002/0b7d5893-e0c0-4e0b-9df8-45f5b6ad05e6)

## Alternative Approaches Considered
Removing the current selected state and files if previous btn was clicked and `next` btn was not clicked was considered as an alternative but in terms of user experience and extra step of entering same fields and files for the users would be hectic.