### PR TITLE
Allow multipolygons to choose as task area

### DIFF
--- a/src/backend/app/db/postgis_utils.py
+++ b/src/backend/app/db/postgis_utils.py
@@ -722,11 +722,15 @@ def multipolygon_to_polygon(features: Union[Feature, FeatCol, MultiPolygon, Poly
     return geojson.FeatureCollection(geojson_feature)
 
 
-def merge_multipolygon(features: Union[Feature, FeatCol, MultiPolygon, Polygon]):
+def merge_multipolygon(
+    features: Union[Feature, FeatCol, MultiPolygon, Polygon],
+    dissolve_polygon: bool = True,
+):
     """Merge multiple Polygons or MultiPolygons into a single Polygon.
 
     Args:
         features: geojson features to merge.
+        dissolve_polygon: True to dissolve polygons to single polygon.
 
     Returns:
         A GeoJSON FeatureCollection containing the merged Polygon.
@@ -749,15 +753,16 @@ def merge_multipolygon(features: Union[Feature, FeatCol, MultiPolygon, Polygon])
             multi_polygons.append(polygon)
 
         merged_polygon = unary_union(multi_polygons)
-        if isinstance(merged_polygon, MultiPolygon):
-            merged_polygon = merged_polygon.convex_hull
-
         merged_geojson = mapping(merged_polygon)
         if merged_geojson["type"] == "MultiPolygon":
-            log.error(
-                "Resulted GeoJSON contains disjoint Polygons. "
-                "Adjacent polygons are preferred."
-            )
+            if dissolve_polygon:
+                merged_polygon = merged_polygon.convex_hull
+                merged_geojson = mapping(merged_polygon)
+                log.error(
+                    "Resulted GeoJSON contains disjoint Polygons. "
+                    "Adjacent polygons are preferred."
+                )
+            merged_geojson = merged_geojson
         return geojson.FeatureCollection([geojson.Feature(geometry=merged_geojson)])
     except Exception as e:
         raise HTTPException(

--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -660,7 +660,7 @@ async def task_split(
     """
     # read project boundary
     boundary = geojson.loads(await project_geojson.read())
-    parsed_boundary = merge_multipolygon(boundary)
+    parsed_boundary = merge_multipolygon(boundary, False)
     # Validatiing Coordinate Reference Systems
     await check_crs(parsed_boundary)
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- Issue #1640

## Describe this PR

This PR addresses issue of not supporting multipolygons to upload as a project aoi.
**Updates:**
- when multipolygons are uploaded as an aoi, those polygons gets dissolved to create a single aoi
- if we want to split task without dissolving those polygons we can pass dissolve_polygon = False since task-splitter can splits those separate polygons
- we can ask for a param (`dissolve_polygons = True/False`)from user if they want to dissolve those polygons while splitting it (not implemented yet)

## Screenshots

Provided in the mentioned issue.

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
