### PR TITLE
fix(manageProject): hide user tab until its api integration

### DIFF
--- a/src/frontend/src/views/ManageProject.tsx
+++ b/src/frontend/src/views/ManageProject.tsx
@@ -9,7 +9,7 @@ import { useNavigate } from 'react-router-dom';
 import { useAppSelector } from '@/types/reduxTypes';
 
 const tabList = [
-  { id: 'users', name: 'USERS', icon: <AssetModules.PersonIcon style={{ fontSize: '20px' }} /> },
+  // { id: 'users', name: 'USERS', icon: <AssetModules.PersonIcon style={{ fontSize: '20px' }} /> },
   { id: 'edit', name: 'EDIT', icon: <AssetModules.EditIcon style={{ fontSize: '20px' }} /> },
   { id: 'delete', name: 'DELETE', icon: <AssetModules.DeleteIcon style={{ fontSize: '20px' }} /> },
 ];
@@ -18,7 +18,7 @@ const ManageProject = () => {
   const params = CoreModules.useParams();
   const navigate = useNavigate();
   const projectId = params.id;
-  const [tabView, setTabView] = useState<'users' | 'edit' | string>('users');
+  const [tabView, setTabView] = useState<'users' | 'edit' | string>('edit');
   const editProjectDetails = useAppSelector((state) => state.createproject.editProjectDetails);
 
   useEffect(() => {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [x] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue
The `USERS` tab containing `assign user` and `invite user` on `manage project` page is currently static leading to confusion among users.

## Describe this PR
This PR hides the USERS tab until API integration is done.

## Screenshots
![image](https://github.com/user-attachments/assets/8a889181-ec5f-4022-b068-cab57ca61e85)