### PR TITLE
Fix generating project files passing project id to background task

### DIFF
--- a/src/backend/app/projects/project_crud.py
+++ b/src/backend/app/projects/project_crud.py
@@ -889,7 +889,7 @@ async def generate_odk_central_project_content(
 
 async def generate_project_files(
     db: Session,
-    project: db_models.DbProject,
+    project_id: int,
     custom_form: Optional[BytesIO],
     form_file_ext: str,
     background_task_id: Optional[uuid.UUID] = None,
@@ -906,7 +906,7 @@ async def generate_project_files(
         background_task_id (uuid): the task_id of the background task.
     """
     try:
-        project_id = project.id
+        project = await get_project_by_id(db, project_id)
         form_category = project.xform_category
         log.info(f"Starting generate_project_files for project {project_id}")
         odk_credentials = await project_deps.get_odk_credentials(db, project_id)

--- a/src/backend/app/projects/project_crud.py
+++ b/src/backend/app/projects/project_crud.py
@@ -900,7 +900,7 @@ async def generate_project_files(
 
     Args:
         db (Session): the database session.
-        project (DbProject): FMTM database project.
+        project_id(int): id of the FMTM project.
         custom_form (BytesIO): the xls file to upload if we have a custom form
         form_file_ext (str): weather the form is xls, xlsx or xml
         background_task_id (uuid): the task_id of the background task.

--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -714,6 +714,7 @@ async def generate_files(
         json (JSONResponse): A success message containing the project ID.
     """
     project = project_user_dict.get("project")
+    project_id = project.id
 
     log.debug(f"Generating media files tasks for project: {project.id}")
 
@@ -738,16 +739,16 @@ async def generate_files(
         db.commit()
 
     # Create task in db and return uuid
-    log.debug(f"Creating export background task for project ID: {project.id}")
+    log.debug(f"Creating export background task for project ID: {project_id}")
     background_task_id = await project_crud.insert_background_task_into_database(
-        db, project_id=str(project.id)
+        db, project_id=project_id
     )
 
     log.debug(f"Submitting {background_task_id} to background tasks stack")
     background_tasks.add_task(
         project_crud.generate_project_files,
         db,
-        project,
+        project_id,
         BytesIO(custom_xls_form) if custom_xls_form else None,
         file_ext,
         background_task_id,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- Issue #1705 

## Describe this PR

There was an issue due to latest upgrade in dependency resulted in db session expiry something related to sqlalchemy/async.
This PR updates `generate_project_data`  passing `project_id` instead of passing `DbProject` object to background task which fixed the issue.

## Screenshots

Please provide screenshots of the change.

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
