### PR TITLE
Test add failure test case for create project endpoint

### DIFF
--- a/src/backend/tests/test_projects_routes.py
+++ b/src/backend/tests/test_projects_routes.py
@@ -51,9 +51,10 @@ async def test_create_project(client, admin_user, organisation):
     }
     odk_creds_models = project_schemas.ODKCentralDecrypted(**odk_credentials)
 
+    project_name = f"Test Project {uuid4()}"
     project_data = {
         "project_info": {
-            "name": f"Test Project {uuid4()}",
+            "name": project_name,
             "short_description": "test",
             "description": "test",
         },
@@ -84,6 +85,19 @@ async def test_create_project(client, admin_user, organisation):
 
     response_data = response.json()
     assert "id" in response_data
+
+    # Duplicate response to test error condition: project name already exists
+    response_duplicate = client.post(
+        f"/projects/create-project?org_id={organisation.id}", json=project_data
+    )
+
+    assert response_duplicate.status_code == 400
+    response_duplicate_data = response_duplicate.json()
+    assert "detail" in response_duplicate_data
+    assert (
+        response_duplicate_data["detail"]
+        == f"Project already exists with the name {project_name}"
+    )
 
 
 async def test_delete_project(client, admin_user, project):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [x] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Related to Issue #1613 

## Describe this PR

This pull request adds a failure test case for the POST /projects/create endpoint. The test verifies that the endpoint correctly handles attempts to create a duplicate project by returning an appropriate error response.

## Screenshots

<img width="1054" alt="Screenshot 2024-07-26 at 14 05 22" src="https://github.com/user-attachments/assets/3366279a-82bc-437b-afde-2ceebd5837ac">


## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Command to run all tests defined in the project using pytest:

`docker compose run --rm api pytest`

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
