### PR TITLE
Allow reset polygon on draw selection even if geojson file upload

### DIFF
--- a/src/frontend/src/components/createnewproject/UploadArea.tsx
+++ b/src/frontend/src/components/createnewproject/UploadArea.tsx
@@ -255,7 +255,7 @@ const UploadArea = ({ flag, geojsonFile, setGeojsonFile, setCustomDataExtractUpl
                     type="button"
                     onClick={() => resetFile()}
                     className=""
-                    disabled={drawnGeojson && !geojsonFile ? false : true}
+                    disabled={drawnGeojson ? false : true}
                   />
                   <p className="fmtm-text-gray-700 fmtm-mt-5">
                     Total Area: <span className="fmtm-font-bold">{totalAreaSelection}</span>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue
- Related to #1707

## Describe this PR
This PR allows the user to reset the polygon (geojson file) on the draw selection without switching back to `upload file` and resetting the file over there.

## Screenshots
[Screencast from 29-7-24 03:48:07 अपराह्न +0545.webm](https://github.com/user-attachments/assets/3537b636-4993-4cda-97db-d03417b2720a)