### PR TITLE
Updated generate_project_files to bulk upload entities

### DIFF
--- a/src/backend/app/central/central_crud.py
+++ b/src/backend/app/central/central_crud.py
@@ -731,7 +731,7 @@ async def get_entities_geojson(
     Returns:
         dict: Entity data in OData JSON format.
     """
-    async with central_deps.get_odk_entity(odk_creds) as odk_central:
+    async with central_deps.get_odk_dataset(odk_creds) as odk_central:
         entities = await odk_central.getEntityData(
             odk_id,
             dataset_name,
@@ -781,7 +781,7 @@ async def get_entities_data(
         list: JSON list containing Entity info. If updated_at is included,
             the format is string 2022-01-31T23:59:59.999Z.
     """
-    async with central_deps.get_odk_entity(odk_creds) as odk_central:
+    async with central_deps.get_odk_dataset(odk_creds) as odk_central:
         entities = await odk_central.getEntityData(
             odk_id,
             dataset_name,
@@ -847,7 +847,7 @@ async def get_entity_mapping_status(
         dict: JSON containing Entity: id, status, updated_at.
             updated_at is in string format 2022-01-31T23:59:59.999Z.
     """
-    async with central_deps.get_odk_entity(odk_creds) as odk_central:
+    async with central_deps.get_odk_dataset(odk_creds) as odk_central:
         entity = await odk_central.getEntity(
             odk_id,
             dataset_name,
@@ -879,7 +879,7 @@ async def update_entity_mapping_status(
     Returns:
         dict: All Entity data in OData JSON format.
     """
-    async with central_deps.get_odk_entity(odk_creds) as odk_central:
+    async with central_deps.get_odk_dataset(odk_creds) as odk_central:
         entity = await odk_central.updateEntity(
             odk_id,
             dataset_name,

--- a/src/backend/app/central/central_deps.py
+++ b/src/backend/app/central/central_deps.py
@@ -21,17 +21,17 @@
 from contextlib import asynccontextmanager
 
 from fastapi.exceptions import HTTPException
-from osm_fieldwork.OdkCentralAsync import OdkEntity
+from osm_fieldwork.OdkCentralAsync import OdkDataset
 
 from app.models.enums import HTTPStatus
 from app.projects.project_schemas import ODKCentralDecrypted
 
 
 @asynccontextmanager
-async def get_odk_entity(odk_creds: ODKCentralDecrypted):
-    """Wrap getting an OdkEntity object with ConnectionError handling."""
+async def get_odk_dataset(odk_creds: ODKCentralDecrypted):
+    """Wrap getting an OdkDataset object with ConnectionError handling."""
     try:
-        async with OdkEntity(
+        async with OdkDataset(
             url=odk_creds.odk_central_url,
             user=odk_creds.odk_central_user,
             passwd=odk_creds.odk_central_password,

--- a/src/backend/app/db/postgis_utils.py
+++ b/src/backend/app/db/postgis_utils.py
@@ -696,6 +696,11 @@ async def feature_geojson_to_entity_dict(
     feature_id = feature.get("id")
 
     geometry = feature.get("geometry", {})
+    if not geometry:
+        msg = "'geometry' data field is mandatory"
+        log.debug(msg)
+        raise ValueError(msg)
+    
     javarosa_geom = await geojson_to_javarosa_geom(geometry)
 
     # NOTE all properties MUST be string values for Entities, convert
@@ -708,7 +713,7 @@ async def feature_geojson_to_entity_dict(
     task_id = properties.get("task_id")
     entity_label = f"Task {task_id} Feature {feature_id}"
 
-    return {entity_label: {"geometry": javarosa_geom, **properties}}
+    return {"label": entity_label, "data":{"geometry": javarosa_geom, **properties}}
 
 
 async def task_geojson_dict_to_entity_values(task_geojson_dict):
@@ -720,9 +725,7 @@ async def task_geojson_dict_to_entity_values(task_geojson_dict):
             [feature_geojson_to_entity_dict(feature) for feature in features if feature]
         )
 
-    entity_values = await gather(*asyncio_tasks)
-    # Merge all dicts into a single dict
-    return {k: v for result in entity_values for k, v in result.items()}
+    return await gather(*asyncio_tasks)
 
 
 def multipolygon_to_polygon(

--- a/src/backend/app/helpers/helper_routes.py
+++ b/src/backend/app/helpers/helper_routes.py
@@ -192,7 +192,7 @@ async def create_entities_from_csv(
     parsed_data = parse_csv(await csv_file.read())
     entities_data_dict = {str(uuid4()): data for data in parsed_data}
 
-    async with central_deps.get_odk_entity(odk_creds) as odk_central:
+    async with central_deps.get_odk_dataset(odk_creds) as odk_central:
         entities = await odk_central.createEntities(
             odk_project_id,
             entity_name,

--- a/src/backend/app/projects/project_crud.py
+++ b/src/backend/app/projects/project_crud.py
@@ -867,7 +867,7 @@ async def generate_odk_central_project_content(
             "features",
             entities_list,
         )
-        if entities["success"]==True:
+        if entities["success"]:
             log.debug(f"Wrote {len(entities_list)} entities for project ({project.id})")
         else:
             log.debug(f"No entities uploaded for project ({project.id})")

--- a/src/backend/app/projects/project_crud.py
+++ b/src/backend/app/projects/project_crud.py
@@ -855,7 +855,7 @@ async def generate_odk_central_project_content(
     entities_list = await task_geojson_dict_to_entity_values(task_extract_dict)
     fields_dict_list = project_schemas.fields_to_dict()
 
-    async with central_deps.get_odk_entity(odk_credentials) as odk_central:
+    async with central_deps.get_odk_dataset(odk_credentials) as odk_central:
         await odk_central.createDataset(project_odk_id, project.project_name_prefix)
         await odk_central.createProperties(project_odk_id, "features", fields_dict_list)
         entities = await odk_central.createEntities(

--- a/src/backend/app/projects/project_schemas.py
+++ b/src/backend/app/projects/project_schemas.py
@@ -20,7 +20,7 @@
 import uuid
 from dataclasses import dataclass
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, List, Optional, Union
 
 from dateutil import parser
 from geojson_pydantic import Feature, FeatureCollection, MultiPolygon, Polygon
@@ -455,11 +455,11 @@ class Field:
     type: str
 
 
-def fields_to_dict() -> List[Dict[str, str]]:
-    """Converts a list of Field objects to a list of dictionaries.
+def entity_fields_to_list() -> List[str]:
+    """Converts a list of Field objects to a list of field names.
 
     Returns:
-        List[Dict[str, str]]: A list of dictionaries representing the fields.
+        List[str]: A list of fields.
     """
     fields: List[Field] = [
         Field(name="geometry", type="geopoint"),
@@ -470,5 +470,6 @@ def fields_to_dict() -> List[Dict[str, str]]:
         Field(name="version", type="string"),
         Field(name="changeset", type="string"),
         Field(name="timestamp", type="datetime"),
+        Field(name="status", type="string"),
     ]
-    return [field.__dict__ for field in fields]
+    return [field.name for field in fields]

--- a/src/backend/app/projects/project_schemas.py
+++ b/src/backend/app/projects/project_schemas.py
@@ -19,7 +19,8 @@
 
 import uuid
 from datetime import datetime
-from typing import Any, List, Optional, Union
+from dataclasses import dataclass
+from typing import Any, List, Optional, Union, Dict
 
 from dateutil import parser
 from geojson_pydantic import Feature, FeatureCollection, MultiPolygon, Polygon
@@ -436,3 +437,37 @@ class ProjectDashboard(BaseModel):
             return f'{days_difference} day{"s" if days_difference > 1 else ""} ago'
         else:
             return last_active.strftime("%d %b %Y")
+
+@dataclass
+class Field:
+    """
+    A data class representing a field with a name and type.
+
+    Args:
+        name (str): The name of the field.
+        type (str): The type of the field.
+
+    Returns:
+        None
+    """
+    name: str
+    type: str
+
+def fields_to_dict() -> List[Dict[str, str]]:
+    """
+    Converts a list of Field objects to a list of dictionaries.
+
+    Returns:
+        List[Dict[str, str]]: A list of dictionaries representing the fields.
+    """
+    fields: List[Field] = [
+    Field(name="geometry", type="geopoint"),
+    Field(name="project_id", type="string"),
+    Field(name="task_id", type="string"),
+    Field(name="osm_id", type="string"),
+    Field(name="tags", type="string"),
+    Field(name="version", type="string"),
+    Field(name="changeset", type="string"),
+    Field(name="timestamp", type="datetime"),
+]
+    return [field.__dict__ for field in fields]

--- a/src/backend/pdm.lock
+++ b/src/backend/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "debug", "dev", "docs", "test", "monitoring"]
 strategy = ["cross_platform"]
 lock_version = "4.4.1"
-content_hash = "sha256:eb7decd06266cdc5d8441f9e947f54d0e7f9b99affccb18234ffaf6c500de681"
+content_hash = "sha256:318c50c56d3a2c1d9a7dfe3f527c2efd7c8c98d599fb674bb803349f6b4e9ef2"
 
 [[package]]
 name = "aiohttp"
@@ -1579,7 +1579,7 @@ files = [
 
 [[package]]
 name = "osm-fieldwork"
-version = "0.13.0"
+version = "0.14.0"
 requires_python = ">=3.10"
 summary = "Processing field data from ODK to OpenStreetMap format."
 dependencies = [
@@ -1603,8 +1603,8 @@ dependencies = [
     "xmltodict>=0.13.0",
 ]
 files = [
-    {file = "osm-fieldwork-0.13.0.tar.gz", hash = "sha256:69b07a47619394171277dba5b39f6044954310b07ea84f0a83a067242d2e5bbd"},
-    {file = "osm_fieldwork-0.13.0-py3-none-any.whl", hash = "sha256:1217f940e2647410a544c5d032efed0598cb47006d8864305b21a5e00818fe90"},
+    {file = "osm-fieldwork-0.14.0.tar.gz", hash = "sha256:503172335f11d3e8aaf31ef3dd95b702a91d7e367ea90b57012d46791c7a390e"},
+    {file = "osm_fieldwork-0.14.0-py3-none-any.whl", hash = "sha256:98bf2001a651b3744a70f6c84326947df4b2c143d9311bd5bd7a69360d59315b"},
 ]
 
 [[package]]

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "pyjwt>=2.8.0",
     "async-lru>=2.0.4",
     "osm-login-python==1.0.3",
-    "osm-fieldwork==0.13.0",
+    "osm-fieldwork==0.14.0",
     "osm-rawdata==0.3.0",
     "fmtm-splitter==1.3.0",
 ]

--- a/src/backend/tests/test_projects_routes.py
+++ b/src/backend/tests/test_projects_routes.py
@@ -51,9 +51,10 @@ async def test_create_project(client, admin_user, organisation):
     }
     odk_creds_models = project_schemas.ODKCentralDecrypted(**odk_credentials)
 
+    project_name = f"Test Project {uuid4()}"
     project_data = {
         "project_info": {
-            "name": f"Test Project {uuid4()}",
+            "name": project_name,
             "short_description": "test",
             "description": "test",
         },
@@ -84,6 +85,19 @@ async def test_create_project(client, admin_user, organisation):
 
     response_data = response.json()
     assert "id" in response_data
+
+    # Duplicate response to test error condition: project name already exists
+    response_duplicate = client.post(
+        f"/projects/create-project?org_id={organisation.id}", json=project_data
+    )
+
+    assert response_duplicate.status_code == 400
+    response_duplicate_data = response_duplicate.json()
+    assert "detail" in response_duplicate_data
+    assert (
+        response_duplicate_data["detail"]
+        == f"Project already exists with the name {project_name}"
+    )
 
 
 async def test_delete_project(client, admin_user, project):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [X] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- Issue #1588 

## Describe this PR

This PR now allows to create entities via single api call without needing entity form creation.
- refactored `generate_project_files` shifting odk_contents to `generate_odk_central_project_content`
- created Data Class for the Fields in `project_schemas` required for entities
- removed `entity_creation_form`
- created functions to create dataset , its properties(fields), bulk create entities via api calls in osm-fieldwork
- dependent to release of o`sm-fieldwork`

## Screenshots

N/A

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
