### PR TITLE
Remove id from the conflated geojson

### DIFF
--- a/src/backend/app/db/postgis_utils.py
+++ b/src/backend/app/db/postgis_utils.py
@@ -904,7 +904,6 @@ def conflate_features(
 
         updated_input_feature = {
             "type": input_feature["type"],
-            "id": input_feature["properties"]["xid"],
             "geometry": input_feature["geometry"],
             "properties": {
                 **input_feature["properties"],
@@ -916,7 +915,6 @@ def conflate_features(
         if overlap_percent < 90:
             corresponding_feature = {
                 "type": "Feature",
-                "id": osm_feature["properties"].pop("osm_id"),
                 "geometry": mapping(osm_geometry),
                 "properties": osm_feature["properties"],
             }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

There was an issue loading multiple conflict geometries having same `id` field in geojson.

## Describe this PR

This PR updates the conflation removing `id` from the geojson of conflated features.

## Screenshots

Please provide screenshots of the change.

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
