### PR TITLE
[HOTFIX] fix pyxform usage only allowing xls file extension

### DIFF
--- a/src/backend/app/central/central_crud.py
+++ b/src/backend/app/central/central_crud.py
@@ -389,7 +389,7 @@ async def read_and_test_xform(
         try:
             log.debug("Converting xlsform -> xform")
             json_data = parse_file_to_json(
-                path="/dummy/path/with/file/ext.xls",
+                path=f"/dummy/path/with/file{file_ext}",
                 file_object=input_data,
             )
             generated_xform = create_survey_element_from_dict(json_data)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixes https://github.com/hotosm/fmtm/issues/1667

## Describe this PR

- The file extension type was not passed through to `pyxform` and `.xls` was hardcoded.
- Fixed to support `.xlsx` too.

## Review Guide

Test uploading an xlsx file.

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
