### PR TITLE
fix(createProject): lineString validation remove

### DIFF
--- a/src/frontend/src/components/createnewproject/DataExtract.tsx
+++ b/src/frontend/src/components/createnewproject/DataExtract.tsx
@@ -191,22 +191,9 @@ const DataExtract = ({ flag, customDataExtractUpload, setCustomDataExtractUpload
       const geojsonFile = new File([extractFeatCol], 'custom_extract.geojson', { type: 'application/json' });
       setDataExtractToState(geojsonFile);
     }
-    const hasGeojsonLineString = checkGeomTypeInGeojson(extractFeatCol, 'LineString');
     if (extractFeatCol && extractFeatCol?.features?.length > 0) {
       handleCustomChange('customDataExtractUpload', event.target.files[0]);
-      handleCustomChange('hasGeojsonLineString', hasGeojsonLineString);
       handleCustomChange('task_split_type', task_split_type['choose_area_as_task'].toString());
-      if (!hasGeojsonLineString) {
-        dispatch(
-          CommonActions.SetSnackBar({
-            open: true,
-            message:
-              'Features must contain line data (roads, rivers) otherwise the task splitting algorithm will not work.',
-            variant: 'warning',
-            duration: 8000,
-          }),
-        );
-      }
       // View on map
       await dispatch(CreateProjectActions.setDataExtractGeojson(extractFeatCol));
       return;

--- a/src/frontend/src/components/createnewproject/SplitTasks.tsx
+++ b/src/frontend/src/components/createnewproject/SplitTasks.tsx
@@ -59,10 +59,7 @@ const SplitTasks = ({ flag, geojsonFile, setGeojsonFile, customDataExtractUpload
       name: 'define_tasks',
       value: task_split_type['task_splitting_algorithm'].toString(),
       label: 'Task Splitting Algorithm',
-      disabled:
-        !projectDetails?.hasGeojsonLineString && projectDetails?.dataExtractWays === 'custom_data_extract'
-          ? true
-          : false,
+      disabled: false,
     },
   ];
 

--- a/src/frontend/src/store/slices/CreateProjectSlice.ts
+++ b/src/frontend/src/store/slices/CreateProjectSlice.ts
@@ -19,7 +19,6 @@ export const initialState: CreateProjectStateTypes = {
     formWays: 'existing_form',
     hasCustomTMS: false,
     custom_tms_url: '',
-    hasGeojsonLineString: true,
   },
   projectDetailsResponse: null,
   projectDetailsLoading: false,

--- a/src/frontend/src/store/types/ICreateProject.ts
+++ b/src/frontend/src/store/types/ICreateProject.ts
@@ -113,7 +113,6 @@ export type ProjectDetailsTypes = {
   per_task_instructions?: string;
   custom_tms_url: string;
   hasCustomTMS: boolean;
-  hasGeojsonLineString: boolean;
 };
 
 export type ProjectAreaTypes = {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue
- Related to #1754

## Describe this PR
This PR removes validation of lineString that checks if lineString is present in the geojson which solves the issue #1754. 
Now, since tasks split is possible without requiring lineString or multiLineString to be present on the geojson.

## Screenshots
![image_720](https://github.com/user-attachments/assets/c2e3c7d5-ae31-4b4b-a6dc-6cc08c65abba)