### PR TITLE
Allow empty task id and osm id for new geopoint

### DIFF
--- a/src/backend/app/central/central_crud.py
+++ b/src/backend/app/central/central_crud.py
@@ -795,6 +795,13 @@ async def get_entities_data(
 
         # Rename '__id' to 'id'
         flattened_dict["id"] = flattened_dict.pop("__id")
+
+        # convert empty str task_id and osm_id to None
+        # when new entities are created task_id and osm_id will be empty
+        if "task_id" in flattened_dict and flattened_dict["task_id"] == "":
+            flattened_dict["task_id"] = None
+        if "osm_id" in flattened_dict and flattened_dict["osm_id"] == "":
+            flattened_dict["osm_id"] = None
         all_entities.append(flattened_dict)
 
     return all_entities

--- a/src/backend/app/central/central_crud.py
+++ b/src/backend/app/central/central_crud.py
@@ -796,12 +796,11 @@ async def get_entities_data(
         # Rename '__id' to 'id'
         flattened_dict["id"] = flattened_dict.pop("__id")
 
-        # convert empty str task_id and osm_id to None
-        # when new entities are created task_id and osm_id will be empty
-        if "task_id" in flattened_dict and flattened_dict["task_id"] == "":
-            flattened_dict["task_id"] = None
+        # convert empty str osm_id to None
+        # when new entities are created osm_id will be empty
         if "osm_id" in flattened_dict and flattened_dict["osm_id"] == "":
             flattened_dict["osm_id"] = None
+
         all_entities.append(flattened_dict)
 
     return all_entities

--- a/src/backend/app/central/central_crud.py
+++ b/src/backend/app/central/central_crud.py
@@ -798,7 +798,7 @@ async def get_entities_data(
 
         # convert empty str osm_id to None
         # when new entities are created osm_id will be empty
-        if "osm_id" in flattened_dict and flattened_dict["osm_id"] == "":
+        if flattened_dict.get("osm_id", "") == "":
             flattened_dict["osm_id"] = None
 
         all_entities.append(flattened_dict)

--- a/src/backend/app/central/central_schemas.py
+++ b/src/backend/app/central/central_schemas.py
@@ -102,7 +102,7 @@ class EntityTaskID(BaseModel):
     """Map of Entity UUID to FMTM Task ID."""
 
     id: str
-    task_id: Optional[int] = None
+    task_id: int
 
 
 class EntityMappingStatus(EntityOsmID, EntityTaskID):

--- a/src/backend/app/central/central_schemas.py
+++ b/src/backend/app/central/central_schemas.py
@@ -102,7 +102,7 @@ class EntityTaskID(BaseModel):
     """Map of Entity UUID to FMTM Task ID."""
 
     id: str
-    task_id: int
+    task_id: Optional[int] = None
 
 
 class EntityMappingStatus(EntityOsmID, EntityTaskID):

--- a/src/frontend/src/views/ProjectSubmissions.tsx
+++ b/src/frontend/src/views/ProjectSubmissions.tsx
@@ -20,7 +20,7 @@ const ProjectSubmissions = () => {
   const state = useAppSelector((state) => state.project);
   const projectInfo = useAppSelector((state) => state.project.projectInfo);
   const entityList = useAppSelector((state) => state.project.entityOsmMap);
-  const updatedEntities = entityList?.filter((entity) => entity?.updated_at && entity?.status > 1);
+  const updatedEntities = entityList?.filter((entity) => entity?.status > 1);
 
   //Fetch project for the first time
   useEffect(() => {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue
- Issue #1730 
- Issue #1711 
For newly created entity of geopoint of feature , there won't be `task_id` and `osm_id` in entity properties resulted into validation error.


## Describe this PR

This PR now allows the empty `task_id` and `osm_id` for new entity created when user locate new geopoint for a feature in field. It is dependent to `osm-fieldwork` where xls file is updated to allow to create new entity for the gps point of new feature recorded.

## Screenshots

N/A

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

- Use the xlsx form updated in `osm-fieldwork`
- create submission recording geopoint for new feature
- check the entity status and submission count

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
