### PR TITLE
Use XLSForm injection during project creation

### DIFF
--- a/src/backend/app/central/central_crud.py
+++ b/src/backend/app/central/central_crud.py
@@ -379,7 +379,7 @@ async def update_project_xform(
     category: str,
     task_count: int,
     odk_credentials: project_schemas.ODKCentralDecrypted,
-) -> BytesIO:
+) -> None:
     """Update and publish the XForm for a project.
 
     Args:
@@ -390,23 +390,9 @@ async def update_project_xform(
         task_count (int): The number of tasks in a project.
         odk_credentials (project_schemas.ODKCentralDecrypted): ODK Central creds.
 
-    Returns:
-        BytesIO: updated XLSForm for the project.
-            NOTE this is the XLSForm, not the XForm XML.
+    Returns: None
     """
-    xform_bytesio = await validate_and_update_user_xlsform(
-        xlsform=xlsform,
-        form_category=category,
-        task_count=task_count,
-        existing_id=xform_id,
-    )
-
-    xlsform_updated = await append_fields_to_user_xlsform(
-        xlsform=xlsform,
-        form_category=category,
-        task_count=task_count,
-        existing_id=xform_id,
-    )
+    xform_bytesio = await read_and_test_xform(xlsform)
 
     xform_obj = get_odk_form(odk_credentials)
 
@@ -417,9 +403,9 @@ async def update_project_xform(
         form_name=xform_id,
     )
     # The draft form must be published after upload
+    # NOTE we can't directly publish existing forms
+    # in createForm and need 2 steps
     xform_obj.publishForm(odk_id, xform_id)
-
-    return xlsform_updated
 
 
 async def convert_geojson_to_odk_csv(

--- a/src/backend/app/central/central_crud.py
+++ b/src/backend/app/central/central_crud.py
@@ -19,17 +19,15 @@
 
 import csv
 import json
-import os
-import uuid
 from io import BytesIO, StringIO
 from typing import Optional, Union
-from xml.etree.ElementTree import Element, SubElement
 
 import geojson
 from defusedxml import ElementTree
 from fastapi import HTTPException
 from loguru import logger as log
 from osm_fieldwork.OdkCentral import OdkAppUser, OdkForm, OdkProject
+from osm_fieldwork.update_xlsform import append_mandatory_fields
 from pyxform.xls2xform import convert as xform_convert
 from sqlalchemy import text
 from sqlalchemy.orm import Session
@@ -314,35 +312,99 @@ async def get_form_list(db: Session) -> list:
         ) from e
 
 
+async def read_and_test_xform(input_data: BytesIO) -> None:
+    """Read and validate an XForm.
+
+    Args:
+        input_data (BytesIO): form to be tested.
+
+    Returns:
+        BytesIO: the converted XML representation of the XForm.
+    """
+    try:
+        log.debug("Parsing XLSForm --> XML data")
+        # NOTE pyxform.xls2xform.convert returns a ConvertResult object
+        return BytesIO(xform_convert(input_data).xform.encode("utf-8"))
+    except Exception as e:
+        log.error(e)
+        msg = f"XLSForm is invalid: {str(e)}"
+        raise HTTPException(
+            status_code=HTTPStatus.UNPROCESSABLE_ENTITY, detail=msg
+        ) from e
+
+
+async def append_fields_to_user_xlsform(
+    xlsform: BytesIO,
+    form_category: str = "buildings",
+    additional_entities: list[str] = None,
+    task_count: int = None,
+    existing_id: str = None,
+) -> BytesIO:
+    """Helper to return the intermediate XLSForm prior to convert."""
+    log.debug("Appending mandatory FMTM fields to XLSForm")
+    return await append_mandatory_fields(
+        xlsform,
+        form_category=form_category,
+        additional_entities=additional_entities,
+        task_count=task_count,
+        existing_id=existing_id,
+    )
+
+
+async def validate_and_update_user_xlsform(
+    xlsform: BytesIO,
+    form_category: str = "buildings",
+    additional_entities: list[str] = None,
+    task_count: int = None,
+    existing_id: str = None,
+) -> BytesIO:
+    """Wrapper to append mandatory fields and validate user uploaded XLSForm."""
+    updated_file_bytes = await append_fields_to_user_xlsform(
+        xlsform,
+        form_category=form_category,
+        additional_entities=additional_entities,
+        task_count=task_count,
+        existing_id=existing_id,
+    )
+
+    # Validate and return the form
+    log.debug("Validating uploaded XLS form")
+    return await read_and_test_xform(updated_file_bytes)
+
+
 async def update_project_xform(
     xform_id: str,
     odk_id: int,
-    xform_data: BytesIO,
-    form_file_ext: str,
+    xlsform: BytesIO,
     category: str,
     task_count: int,
     odk_credentials: project_schemas.ODKCentralDecrypted,
-) -> None:
+) -> BytesIO:
     """Update and publish the XForm for a project.
 
     Args:
         xform_id (str): The UUID of the existing XForm in ODK Central.
         odk_id (int): ODK Central form ID.
-        xform_data (BytesIO): XForm data.
-        form_file_ext (str): Extension of the form file.
+        xlsform (UploadFile): XForm data.
         category (str): Category of the XForm.
         task_count (int): The number of tasks in a project.
         odk_credentials (project_schemas.ODKCentralDecrypted): ODK Central creds.
+
+    Returns:
+        BytesIO: updated XLSForm for the project.
+            NOTE this is the XLSForm, not the XForm XML.
     """
-    xform_data = await read_and_test_xform(
-        xform_data,
-        form_file_ext,
-        return_form_data=True,
+    xform_bytesio = await validate_and_update_user_xlsform(
+        xlsform=xlsform,
+        form_category=category,
+        task_count=task_count,
+        existing_id=xform_id,
     )
-    updated_xform_data = await modify_xform_xml(
-        xform_data,
-        category,
-        task_count,
+
+    xlsform_updated = await append_fields_to_user_xlsform(
+        xlsform=xlsform,
+        form_category=category,
+        task_count=task_count,
         existing_id=xform_id,
     )
 
@@ -351,195 +413,13 @@ async def update_project_xform(
     # NOTE calling createForm for an existing form will update it
     xform_obj.createForm(
         odk_id,
-        updated_xform_data,
+        xform_bytesio,
         form_name=xform_id,
     )
     # The draft form must be published after upload
     xform_obj.publishForm(odk_id, xform_id)
 
-
-async def read_and_test_xform(
-    input_data: BytesIO,
-    form_file_ext: str,
-    return_form_data: bool = False,
-) -> BytesIO | dict:
-    """Read and validate an XForm.
-
-    Args:
-        input_data (BytesIO): form to be tested.
-        form_file_ext (str): type of form (.xls, .xlsx, or .xml).
-        return_form_data (bool): return the XForm data.
-    """
-    # Read from BytesIO object
-    file_ext = form_file_ext.lower()
-
-    if file_ext == ".xml":
-        xform_bytesio = input_data
-        # Parse / validate XForm
-        try:
-            ElementTree.fromstring(xform_bytesio.getvalue())
-        except ElementTree.ParseError as e:
-            log.error(e)
-            msg = f"Error parsing XForm XML: Possible reason: {str(e)}"
-            raise HTTPException(
-                status_code=HTTPStatus.UNPROCESSABLE_ENTITY, detail=msg
-            ) from e
-    else:
-        try:
-            log.debug("Parsing XLSForm --> XML data")
-            xform_bytesio = BytesIO(xform_convert(input_data).xform.encode("utf-8"))
-        except Exception as e:
-            log.error(e)
-            msg = f"XLSForm is invalid: {str(e)}"
-            raise HTTPException(
-                status_code=HTTPStatus.UNPROCESSABLE_ENTITY, detail=msg
-            ) from e
-
-    # Return immediately
-    if return_form_data:
-        return xform_bytesio
-
-    # Load XML
-    xform_xml = ElementTree.fromstring(xform_bytesio.getvalue())
-
-    # Extract csv filenames
-    try:
-        namespaces = {"xforms": "http://www.w3.org/2002/xforms"}
-        csv_list = [
-            os.path.splitext(inst.attrib["src"].split("/")[-1])[0]
-            for inst in xform_xml.findall(".//xforms:instance[@src]", namespaces)
-            if inst.attrib.get("src", "").endswith(".csv")
-        ]
-
-        # No select_one_from_file defined
-        if not csv_list:
-            msg = (
-                "The form has no select_one_from_file or "
-                "select_multiple_from_file field defined for a CSV."
-            )
-            raise ValueError(msg) from None
-
-        return {"required_media": csv_list, "message": "Your form is valid"}
-
-    except Exception as e:
-        log.error(e)
-        raise HTTPException(
-            status_code=HTTPStatus.UNPROCESSABLE_ENTITY, detail=str(e)
-        ) from e
-
-
-async def modify_xform_xml(
-    form_data: BytesIO,
-    category: str,
-    task_count: int,
-    existing_id: Optional[str] = None,
-) -> BytesIO:
-    """Update fields in the XForm to work with FMTM.
-
-    The 'id' field is set to random UUID (xFormId) unless existing_id is specified
-    The 'name' field is set to the category name.
-    The upload media must be equal to 'features.csv'.
-    The task_filter options are populated as choices in the form.
-    The form_category value is also injected to display in the instructions.
-
-    Args:
-        form_data (str): The input form data.
-        category (str): The form category, used to name the dataset (entity list)
-            and the .csv file containing the geometries.
-        task_count (int): The number of tasks in a project.
-        existing_id (str): An existing XForm ID in ODK Central, for updating.
-
-    Returns:
-        BytesIO: The XForm data.
-    """
-    log.debug(f"Updating XML keys in survey XForm: {category}")
-
-    if existing_id:
-        xform_id = existing_id
-    else:
-        xform_id = uuid.uuid4()
-
-    namespaces = {
-        "h": "http://www.w3.org/1999/xhtml",
-        "odk": "http://www.opendatakit.org/xforms",
-        "xforms": "http://www.w3.org/2002/xforms",
-        "entities": "http://www.opendatakit.org/xforms/entities",
-    }
-
-    # Parse the XML from BytesIO obj
-    root = ElementTree.fromstring(form_data.getvalue())
-
-    xform_data = root.findall(".//xforms:data[@id]", namespaces)
-    for dt in xform_data:
-        # This sets the xFormId in ODK Central (the form reference via API)
-        dt.set("id", str(xform_id))
-
-    # Update the form title (displayed in ODK Collect)
-    existing_title = root.find(".//h:title", namespaces)
-    if existing_title is not None:
-        existing_title.text = category
-
-    # Update the attachment name to {category}.csv, to link to the entity list
-    xform_instance_src = root.findall(".//xforms:instance[@src]", namespaces)
-    for inst in xform_instance_src:
-        src_value = inst.get("src", "")
-        if src_value.endswith(".geojson") or src_value.endswith(".csv"):
-            # NOTE geojson files require jr://file/features.geojson
-            # NOTE csv files require jr://file-csv/features.csv
-            inst.set("src", "jr://file-csv/features.csv")
-
-    # NOTE add the task ID choices to the XML
-    # <instance> must be defined inside <model></model> root element
-    model_element = root.find(".//xforms:model", namespaces)
-    # The existing dummy value for task_filter must be removed
-    existing_instance = model_element.find(
-        ".//xforms:instance[@id='task_filter']", namespaces
-    )
-    if existing_instance is not None:
-        model_element.remove(existing_instance)
-    # Create a new instance element
-    instance_task_filters = Element("instance", id="task_filter")
-    root_element = SubElement(instance_task_filters, "root")
-    # Create sub-elements for each task ID, <itextId> <name> pairs
-    for task_id in range(1, task_count + 1):
-        item = SubElement(root_element, "item")
-        SubElement(item, "itextId").text = f"task_filter-{task_id}"
-        SubElement(item, "name").text = str(task_id)
-    model_element.append(instance_task_filters)
-
-    # Add task_filter choice translations (necessary to be visible in form)
-    itext_element = root.find(".//xforms:itext", namespaces)
-    if itext_element is not None:
-        existing_translations = itext_element.findall(
-            ".//xforms:translation", namespaces
-        )
-        for translation in existing_translations:
-            # Remove dummy value from existing translations
-            existing_text = translation.find(
-                ".//xforms:text[@id='task_filter-0']", namespaces
-            )
-            if existing_text is not None:
-                translation.remove(existing_text)
-
-            # Append new <text> elements for each task_id
-            for task_id in range(1, task_count + 1):
-                new_text = Element("text", id=f"task_filter-{task_id}")
-                value_element = Element("value")
-                value_element.text = str(task_id)
-                new_text.append(value_element)
-                translation.append(new_text)
-
-    # Hardcode the form_category value for the start instructions
-    form_category_update = root.find(
-        ".//xforms:bind[@nodeset='/data/form_category']", namespaces
-    )
-    if form_category_update is not None:
-        if category.endswith("s"):
-            # Plural to singular
-            category = category[:-1]
-        form_category_update.set("calculate", f"once('{category.rstrip('s')}')")
-
-    return BytesIO(ElementTree.tostring(root))
+    return xlsform_updated
 
 
 async def convert_geojson_to_odk_csv(

--- a/src/backend/app/helpers/helper_routes.py
+++ b/src/backend/app/helpers/helper_routes.py
@@ -42,7 +42,6 @@ from app.central import central_deps
 from app.central.central_crud import (
     convert_geojson_to_odk_csv,
     convert_odk_submission_json_to_geojson,
-    read_and_test_xform,
 )
 from app.config import settings
 from app.db.postgis_utils import (
@@ -112,31 +111,6 @@ async def append_required_geojson_properties(
         status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
         detail="Your geojson file is invalid.",
     )
-
-
-@router.post("/convert-xlsform-to-xform")
-async def convert_xlsform_to_xform(
-    xlsform: UploadFile,
-    current_user: AuthUser = Depends(login_required),
-):
-    """Convert XLSForm to XForm XML."""
-    filename = Path(xlsform.filename)
-    file_ext = filename.suffix.lower()
-
-    allowed_extensions = [".xls", ".xlsx"]
-    if file_ext not in allowed_extensions:
-        raise HTTPException(
-            status_code=HTTPStatus.BAD_REQUEST,
-            detail="Provide a valid .xls or .xlsx file",
-        )
-
-    contents = await xlsform.read()
-    xform_data = await read_and_test_xform(
-        BytesIO(contents), file_ext, return_form_data=True
-    )
-
-    headers = {"Content-Disposition": f"attachment; filename={filename.stem}.xml"}
-    return Response(xform_data.getvalue(), headers=headers)
 
 
 @router.post("/convert-geojson-to-odk-csv")

--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -950,7 +950,7 @@ async def download_form(
 async def update_project_form(
     xform_id: str = Form(...),
     category: XLSFormType = Form(...),
-    upload: BytesIO = Depends(central_deps.read_xlsform),
+    xlsform: BytesIO = Depends(central_deps.read_xlsform),
     db: Session = Depends(database.get_db),
     project_user_dict: ProjectUserDict = Depends(project_manager),
 ) -> project_schemas.ProjectBase:
@@ -958,7 +958,6 @@ async def update_project_form(
 
     Also updates the category and custom XLSForm data in the database.
     """
-    # TODO migrate most logic to project_crud
     project = project_user_dict["project"]
 
     # TODO we currently do nothing with the provided category
@@ -974,17 +973,17 @@ async def update_project_form(
     # Get ODK Central credentials for project
     odk_creds = await project_deps.get_odk_credentials(db, project.id)
     # Update ODK Central form data
-    updated_xlsform = await central_crud.update_project_xform(
+    await central_crud.update_project_xform(
         xform_id,
         project.odkid,
-        upload,
+        xlsform,
         category,
         len(project.tasks),
         odk_creds,
     )
 
     # Commit changes to db
-    project.form_xls = updated_xlsform.getvalue()
+    project.form_xls = xlsform.getvalue()
     db.commit()
 
     return project

--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -40,7 +40,6 @@ from geojson_pydantic import Feature, FeatureCollection
 from loguru import logger as log
 from osm_fieldwork.data_models import data_models_path
 from osm_fieldwork.make_data_extract import getChoices
-from osm_fieldwork.update_form import update_xls_form
 from osm_fieldwork.xlsforms import xlsforms_path
 from sqlalchemy.orm import Session
 from sqlalchemy.sql import text
@@ -48,7 +47,7 @@ from sqlalchemy.sql import text
 from app.auth.auth_schemas import AuthUser, OrgUserDict, ProjectUserDict
 from app.auth.osm import login_required
 from app.auth.roles import mapper, org_admin, project_manager
-from app.central import central_crud, central_schemas
+from app.central import central_crud, central_deps, central_schemas
 from app.db import database, db_models
 from app.db.postgis_utils import (
     check_crs,
@@ -661,41 +660,38 @@ async def task_split(
 
 
 @router.post("/validate-form")
-async def validate_form(form: UploadFile):
-    """Tests the validity of the xls form uploaded.
+async def validate_form(
+    xlsform: BytesIO = Depends(central_deps.read_xlsform),
+    debug: bool = False,
+):
+    """Basic validity check for uploaded XLSForm.
 
-    Parameters:
-        - form: The xls form to validate
+    Does not append all addition values to make this a valid FMTM form for mapping.
     """
-    file = Path(form.filename)
-    file_ext = file.suffix.lower()
-
-    allowed_extensions = [".xls", ".xlsx", ".xml"]
-    if file_ext not in allowed_extensions:
-        raise HTTPException(
-            status_code=400, detail="Provide a valid .xls,.xlsx,.xml file"
+    if debug:
+        updated_form = await central_crud.append_fields_to_user_xlsform(
+            xlsform,
+            task_count=1,  # NOTE this must be included to append task_filter choices
         )
-
-    contents = await form.read()
-    updated_file_bytes = update_xls_form(BytesIO(contents))
-
-    # open bytes again to avoid I/O error on closed bytes
-    form_data = BytesIO(updated_file_bytes.getvalue())
-
-    await central_crud.read_and_test_xform(updated_file_bytes, file_ext)
-
-    # Return the updated form as a StreamingResponse
-    return StreamingResponse(
-        form_data,
-        media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-        headers={"Content-Disposition": f"attachment; filename={form.filename}"},
-    )
+        return StreamingResponse(
+            updated_form,
+            media_type=(
+                "application/vnd.openxmlformats-" "officedocument.spreadsheetml.sheet"
+            ),
+            headers={"Content-Disposition": "attachment; filename=updated_form.xlsx"},
+        )
+    else:
+        await central_crud.validate_and_update_user_xlsform(
+            xlsform,
+            task_count=1,  # NOTE this must be included to append task_filter choices
+        )
+        return Response(status_code=HTTPStatus.OK)
 
 
 @router.post("/{project_id}/generate-project-data")
 async def generate_files(
     background_tasks: BackgroundTasks,
-    xls_form_upload: Optional[UploadFile] = File(None),
+    xlsform_upload: Optional[BytesIO] = Depends(central_deps.read_optional_xlsform),
     db: Session = Depends(database.get_db),
     project_user_dict: ProjectUserDict = Depends(project_manager),
 ):
@@ -718,7 +714,7 @@ async def generate_files(
 
     Args:
         background_tasks (BackgroundTasks): FastAPI bg tasks, provided automatically.
-        xls_form_upload (UploadFile, optional): A custom XLSForm to use in the project.
+        xlsform_upload (UploadFile, optional): A custom XLSForm to use in the project.
             A file should be provided if user wants to upload a custom xls form.
         db (Session): Database session, provided automatically.
         project_user_dict (ProjectUserDict): Project admin role.
@@ -728,28 +724,41 @@ async def generate_files(
     """
     project = project_user_dict.get("project")
     project_id = project.id
+    form_category = project.xform_category
+    task_count = len(project.tasks)
 
-    log.debug(f"Generating media files tasks for project: {project.id}")
+    log.debug(f"Generating additional files for project: {project.id}")
 
-    custom_xls_form = None
-    file_ext = ".xls"
-    if xls_form_upload:
-        log.debug("Validating uploaded XLS form")
+    if xlsform_upload:
+        log.debug("User provided custom XLSForm")
 
-        file_path = Path(xls_form_upload.filename)
-        file_ext = file_path.suffix.lower()
-        allowed_extensions = {".xls", ".xlsx", ".xml"}
-        if file_ext not in allowed_extensions:
-            raise HTTPException(
-                status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
-                detail=f"Invalid file extension, must be {allowed_extensions}",
-            )
+        # Validate uploaded form
+        await central_crud.validate_and_update_user_xlsform(
+            xlsform=xlsform_upload,
+            form_category=form_category,
+            task_count=task_count,
+        )
 
-        custom_xls_form = await xls_form_upload.read()
+        # xlsform_upload.seek(0)
 
-        # Write XLS form content to db
-        project.form_xls = custom_xls_form
-        db.commit()
+        xlsform = xlsform_upload
+
+    else:
+        log.debug(f"Using default XLSForm for category: '{form_category}'")
+
+        form_filename = XLSFormType(form_category).name
+        xlsform_path = f"{xlsforms_path}/{form_filename}.xls"
+        with open(xlsform_path, "rb") as f:
+            xlsform = BytesIO(f.read())
+
+    project_xlsform = await central_crud.append_fields_to_user_xlsform(
+        xlsform=xlsform,
+        form_category=form_category,
+        task_count=task_count,
+    )
+    # Write XLS form content to db
+    project.form_xls = project_xlsform.getvalue()
+    db.commit()
 
     # Create task in db and return uuid
     log.debug(f"Creating export background task for project ID: {project_id}")
@@ -762,8 +771,6 @@ async def generate_files(
         project_crud.generate_project_files,
         db,
         project_id,
-        BytesIO(custom_xls_form) if custom_xls_form else None,
-        file_ext,
         background_task_id,
     )
 
@@ -934,13 +941,6 @@ async def download_form(
         "Content-Disposition": "attachment; filename=submission_data.xls",
         "Content-Type": "application/media",
     }
-    if not project.form_xls:
-        form_filename = XLSFormType(project.xform_category).name
-        xlsform_path = f"{xlsforms_path}/{form_filename}.xls"
-        if os.path.exists(xlsform_path):
-            return FileResponse(xlsform_path, filename="form.xls")
-        else:
-            raise HTTPException(status_code=404, detail="Form not found")
     return Response(content=project.form_xls, headers=headers)
 
 
@@ -948,7 +948,7 @@ async def download_form(
 async def update_project_form(
     xform_id: str = Form(...),
     category: XLSFormType = Form(...),
-    upload: UploadFile = File(...),
+    upload: BytesIO = Depends(central_deps.read_xlsform),
     db: Session = Depends(database.get_db),
     project_user_dict: ProjectUserDict = Depends(project_manager),
 ) -> project_schemas.ProjectBase:
@@ -969,37 +969,21 @@ async def update_project_form(
     # with open(xlsform_path, "rb") as f:
     #     new_xform_data = BytesIO(f.read())
 
-    file_ext = Path(upload.filename or "x.xls").suffix.lower()
-    allowed_extensions = [".xls", ".xlsx", ".xml"]
-    if file_ext not in allowed_extensions:
-        raise HTTPException(
-            status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
-            detail="Provide a valid .xls, .xlsx, .xml file.",
-        )
-    new_xform_data = await upload.read()
-    # Update the XLSForm blob in the database
-    project.form_xls = new_xform_data
-    new_xform_data = BytesIO(new_xform_data)
-
-    # TODO related to above info about category updating
-    # # Update form category in database
-    # project.xform_category = category
-
-    # Commit changes to db
-    db.commit()
-
     # Get ODK Central credentials for project
     odk_creds = await project_deps.get_odk_credentials(db, project.id)
     # Update ODK Central form data
-    await central_crud.update_project_xform(
+    updated_xlsform = await central_crud.update_project_xform(
         xform_id,
         project.odkid,
-        new_xform_data,
-        file_ext,
+        upload,
         category,
         len(project.tasks),
         odk_creds,
     )
+
+    # Commit changes to db
+    project.form_xls = updated_xlsform.getvalue()
+    db.commit()
 
     return project
 

--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -692,6 +692,7 @@ async def validate_form(
 async def generate_files(
     background_tasks: BackgroundTasks,
     xlsform_upload: Optional[BytesIO] = Depends(central_deps.read_optional_xlsform),
+    additional_entities: list[str] = None,
     db: Session = Depends(database.get_db),
     project_user_dict: ProjectUserDict = Depends(project_manager),
 ):
@@ -716,6 +717,8 @@ async def generate_files(
         background_tasks (BackgroundTasks): FastAPI bg tasks, provided automatically.
         xlsform_upload (UploadFile, optional): A custom XLSForm to use in the project.
             A file should be provided if user wants to upload a custom xls form.
+        additional_entities (list[str]): If additional Entity lists need to be
+            created (i.e. the project form references multiple geometries).
         db (Session): Database session, provided automatically.
         project_user_dict (ProjectUserDict): Project admin role.
 
@@ -737,10 +740,8 @@ async def generate_files(
             xlsform=xlsform_upload,
             form_category=form_category,
             task_count=task_count,
+            additional_entities=additional_entities,
         )
-
-        # xlsform_upload.seek(0)
-
         xlsform = xlsform_upload
 
     else:
@@ -755,6 +756,7 @@ async def generate_files(
         xlsform=xlsform,
         form_category=form_category,
         task_count=task_count,
+        additional_entities=additional_entities,
     )
     # Write XLS form content to db
     project.form_xls = project_xlsform.getvalue()

--- a/src/backend/pdm.lock
+++ b/src/backend/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "debug", "dev", "docs", "test", "monitoring"]
 strategy = ["cross_platform"]
 lock_version = "4.4.1"
-content_hash = "sha256:dece6ce0db5c1445154361c5c4529b58d558fe30d21e450df8a375de26648ba0"
+content_hash = "sha256:815753d9e8a59493e0b7c51f1a791431dd8c561c7e0df8c112935d81a9bd59ab"
 
 [[package]]
 name = "aiohttp"
@@ -1579,7 +1579,7 @@ files = [
 
 [[package]]
 name = "osm-fieldwork"
-version = "0.16.1"
+version = "0.16.2"
 requires_python = ">=3.10"
 summary = "Processing field data from ODK to OpenStreetMap format."
 dependencies = [
@@ -1605,8 +1605,8 @@ dependencies = [
     "xmltodict>=0.13.0",
 ]
 files = [
-    {file = "osm-fieldwork-0.16.1.tar.gz", hash = "sha256:c724c6a8650c1eb62a059317bad46d2f08f612feb4d0ce76dfc2faae90410f13"},
-    {file = "osm_fieldwork-0.16.1-py3-none-any.whl", hash = "sha256:c9dbdec0c29747797c63874208fa014a37071b3e663ea63dfd0d3f8ebbe00f69"},
+    {file = "osm-fieldwork-0.16.2.tar.gz", hash = "sha256:ba6b2a488225613f6d3d6d4d1946ff9300281d3658862f39ecb7c79d865e57b1"},
+    {file = "osm_fieldwork-0.16.2-py3-none-any.whl", hash = "sha256:5a1424c07bf06eacc8aff652851d857fb66644b120c09218830a6c1848fdccd1"},
 ]
 
 [[package]]

--- a/src/backend/pdm.lock
+++ b/src/backend/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "debug", "dev", "docs", "test", "monitoring"]
 strategy = ["cross_platform"]
 lock_version = "4.4.1"
-content_hash = "sha256:815753d9e8a59493e0b7c51f1a791431dd8c561c7e0df8c112935d81a9bd59ab"
+content_hash = "sha256:a02ce45e28be043d654f512ec57a6db6adf4cba528cb2c937191e3d025ca5490"
 
 [[package]]
 name = "aiohttp"
@@ -1579,7 +1579,7 @@ files = [
 
 [[package]]
 name = "osm-fieldwork"
-version = "0.16.2"
+version = "0.16.4"
 requires_python = ">=3.10"
 summary = "Processing field data from ODK to OpenStreetMap format."
 dependencies = [
@@ -1605,8 +1605,8 @@ dependencies = [
     "xmltodict>=0.13.0",
 ]
 files = [
-    {file = "osm-fieldwork-0.16.2.tar.gz", hash = "sha256:ba6b2a488225613f6d3d6d4d1946ff9300281d3658862f39ecb7c79d865e57b1"},
-    {file = "osm_fieldwork-0.16.2-py3-none-any.whl", hash = "sha256:5a1424c07bf06eacc8aff652851d857fb66644b120c09218830a6c1848fdccd1"},
+    {file = "osm-fieldwork-0.16.4.tar.gz", hash = "sha256:0285313d3e4bd99df0cccd91b8706b6d3f66ae427bab259250df19b07c51d31b"},
+    {file = "osm_fieldwork-0.16.4-py3-none-any.whl", hash = "sha256:595afcf05a0a3fda035e5c2c342b5a5c1bcfa2e21002098f6c670c7e502baf93"},
 ]
 
 [[package]]

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -45,8 +45,8 @@ dependencies = [
     "defusedxml>=0.7.1",
     "pyjwt>=2.8.0",
     "async-lru>=2.0.4",
+    "osm-fieldwork>=0.16.4",
     "osm-login-python==2.0.0",
-    "osm-fieldwork==0.16.2",
     "osm-rawdata==0.3.2",
     "fmtm-splitter==1.3.0",
 ]

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -46,7 +46,7 @@ dependencies = [
     "pyjwt>=2.8.0",
     "async-lru>=2.0.4",
     "osm-login-python==2.0.0",
-    "osm-fieldwork==0.16.1",
+    "osm-fieldwork==0.16.2",
     "osm-rawdata==0.3.2",
     "fmtm-splitter==1.3.0",
 ]

--- a/src/frontend/src/api/CreateProjectService.ts
+++ b/src/frontend/src/api/CreateProjectService.ts
@@ -460,7 +460,7 @@ const ValidateCustomForm = (url: string, formUpload: any) => {
     const validateCustomForm = async (url: any, formUpload: any) => {
       try {
         const formUploadFormData = new FormData();
-        formUploadFormData.append('form', formUpload);
+        formUploadFormData.append('xlsform', formUpload);
 
         // response is in file format so we need to convert it to blob
         const getTaskSplittingResponse = await axios.post(url, formUploadFormData, {

--- a/src/frontend/src/api/CreateProjectService.ts
+++ b/src/frontend/src/api/CreateProjectService.ts
@@ -385,7 +385,7 @@ const PostFormUpdate = (url: string, projectData: Record<string, any>) => {
         const formFormData = new FormData();
         formFormData.append('xform_id', projectData.xformId);
         formFormData.append('category', projectData.category);
-        formFormData.append('upload', projectData.upload);
+        formFormData.append('xlsform', projectData.upload);
 
         const postFormUpdateResponse = await axios.post(url, formFormData);
         const resp: ProjectDetailsModel = postFormUpdateResponse.data;

--- a/src/frontend/src/components/ManageProject/EditTab/FormUpdateTab.tsx
+++ b/src/frontend/src/components/ManageProject/EditTab/FormUpdateTab.tsx
@@ -4,11 +4,10 @@ import UploadArea from '../../common/UploadArea';
 import Button from '../../common/Button';
 import { CustomSelect } from '@/components/common/Select';
 import CoreModules from '@/shared/CoreModules';
-import { FormCategoryService, ValidateCustomForm } from '@/api/CreateProjectService';
+import { FormCategoryService } from '@/api/CreateProjectService';
+import { DownloadProjectForm } from '@/api/Project';
 import { PostFormUpdate } from '@/api/CreateProjectService';
 import { CreateProjectActions } from '@/store/slices/CreateProjectSlice';
-import { CommonActions } from '@/store/slices/CommonSlice';
-import { Loader2 } from 'lucide-react';
 import useDocumentTitle from '@/utilfunctions/useDocumentTitle';
 
 type FileType = {
@@ -28,8 +27,6 @@ const FormUpdateTab = ({ projectId }) => {
   const xFormId = CoreModules.useAppSelector((state) => state.project.projectInfo.xform_id);
   const formCategoryList = useAppSelector((state) => state.createproject.formCategoryList);
   const sortedFormCategoryList = formCategoryList.slice().sort((a, b) => a.title.localeCompare(b.title));
-  const customFileValidity = useAppSelector((state) => state.createproject.customFileValidity);
-  const validateCustomFormLoading = useAppSelector((state) => state.createproject.validateCustomFormLoading);
   const selectedCategory = useAppSelector((state) => state.createproject.editProjectDetails.xform_category);
   const formUpdateLoading = useAppSelector((state) => state.createproject.formUpdateLoading);
 
@@ -37,44 +34,15 @@ const FormUpdateTab = ({ projectId }) => {
     dispatch(FormCategoryService(`${import.meta.env.VITE_API_URL}/central/list-forms`));
   }, []);
 
-  const validateForm = () => {
-    setError({ formError: '', categoryError: '' });
-    let isValid = true;
-    if (!uploadForm || (uploadForm && uploadForm?.length === 0)) {
-      setError((prev) => ({ ...prev, formError: 'Form is required.' }));
-      isValid = false;
-    }
-    if (!customFileValidity && uploadForm && uploadForm.length > 0) {
-      dispatch(
-        CommonActions.SetSnackBar({
-          open: true,
-          message: 'Your file is invalid',
-          variant: 'error',
-          duration: 2000,
-        }),
-      );
-      isValid = false;
-    }
-    return isValid;
-  };
-
   const onSave = () => {
-    if (validateForm()) {
-      dispatch(
-        PostFormUpdate(`${import.meta.env.VITE_API_URL}/projects/update-form?project_id=${projectId}`, {
-          xformId: xFormId,
-          category: selectedCategory,
-          upload: uploadForm && uploadForm?.[0]?.url,
-        }),
-      );
-    }
+    dispatch(
+      PostFormUpdate(`${import.meta.env.VITE_API_URL}/projects/update-form?project_id=${projectId}`, {
+        xformId: xFormId,
+        category: selectedCategory,
+        upload: uploadForm && uploadForm?.[0]?.url,
+      }),
+    );
   };
-
-  useEffect(() => {
-    if (uploadForm && uploadForm?.length > 0 && !customFileValidity) {
-      dispatch(ValidateCustomForm(`${import.meta.env.VITE_API_URL}/projects/validate-form`, uploadForm?.[0]?.url));
-    }
-  }, [uploadForm]);
 
   return (
     <div className="fmtm-flex fmtm-flex-col fmtm-gap-10">
@@ -103,6 +71,24 @@ const FormUpdateTab = ({ projectId }) => {
           {`if uploading the final submissions to OSM.`}
         </p>
       </div>
+      <p className="fmtm-text-base fmtm-mt-2">
+        Please{' '}
+        <a
+          className="fmtm-text-blue-600 hover:fmtm-text-blue-700 fmtm-cursor-pointer fmtm-underline"
+          onClick={() =>
+            dispatch(
+              DownloadProjectForm(
+                `${import.meta.env.VITE_API_URL}/projects/download-form/${projectId}/`,
+                'form',
+                projectId,
+              ),
+            )
+          }
+        >
+          download
+        </a>{' '}
+        {`your form, modify it, before re-uploading below:`}
+      </p>
       <div>
         <UploadArea
           title="Upload Form"
@@ -111,23 +97,15 @@ const FormUpdateTab = ({ projectId }) => {
           data={uploadForm || []}
           filterKey="url"
           onUploadFile={(updatedFiles: FileType[]) => {
-            dispatch(CreateProjectActions.SetCustomFileValidity(false));
             setUploadForm(updatedFiles);
           }}
           acceptedInput=".xls, .xlsx, .xml"
         />
-        {validateCustomFormLoading && (
-          <div className="fmtm-flex fmtm-items-center fmtm-gap-2 fmtm-mt-2">
-            <Loader2 className="fmtm-h-4 fmtm-w-4 fmtm-animate-spin fmtm-text-primaryRed" />
-            <p className="fmtm-text-base">Validating form...</p>
-          </div>
-        )}
         {error.formError && <p className="fmtm-text-primaryRed fmtm-text-base">{error.formError}</p>}
       </div>
       <div className="fmtm-flex fmtm-justify-center">
         <Button
           isLoading={formUpdateLoading}
-          disabled={validateCustomFormLoading}
           loadingText="UPDATE"
           onClick={onSave}
           btnText="UPDATE"

--- a/src/frontend/src/components/ProjectDetailsV2/FeatureSelectionPopup.tsx
+++ b/src/frontend/src/components/ProjectDetailsV2/FeatureSelectionPopup.tsx
@@ -153,7 +153,7 @@ const TaskFeatureSelectionPopup = ({ featureProperties, taskId, taskFeature }: T
 
                 if (isMobile) {
                   // Load entity in ODK Collect by intent
-                  document.location.href = `odkcollect://form/${xformId}?existing=${entityUuid}`;
+                  document.location.href = `odkcollect://form/${xformId}?feature=${entityUuid}`;
                 } else {
                   dispatch(
                     CommonActions.SetSnackBar({


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixes https://github.com/hotosm/fmtm/issues/1722

## Describe this PR

- PR https://github.com/hotosm/fmtm/pull/1763 added the osm-fieldwork update_xlsform work to the `validate-form` endpoint.
- This PR also adds the functionality during the project creation.
- Users can upload a custom form full of question and have the required FMTM fields injected automatically.
- Removes the custom XML manipulation that was difficult to understand / maintain, replaced with much easier Pandas-based XLSForm concatenation.

## Review Guide

- Rebuild the docker image
- Run the API
- Create a new project using a custom form
- Also test using the default / bundled forms

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
