### PR TITLE
Remove xforms table from database, refactor project creation

### DIFF
--- a/src/backend/app/auth/auth_routes.py
+++ b/src/backend/app/auth/auth_routes.py
@@ -250,6 +250,14 @@ async def refresh_token(
     request: Request, user_data: AuthUser = Depends(login_required)
 ):
     """Uses the refresh token to generate a new access token."""
+    if settings.DEBUG:
+        return JSONResponse(
+            status_code=HTTPStatus.OK,
+            content={
+                "token": "debugtoken",
+                **user_data.model_dump(),
+            },
+        )
     try:
         refresh_token = extract_refresh_token_from_cookie(request)
         if not refresh_token:

--- a/src/backend/app/central/central_routes.py
+++ b/src/backend/app/central/central_routes.py
@@ -79,9 +79,8 @@ async def refresh_appuser_token(
     try:
         odk_credentials = await project_deps.get_odk_credentials(db, project_id)
         project_odk_id = project.odkid
-        db_xform = await project_deps.get_project_xform(db, project_id)
         odk_token = await central_crud.get_appuser_token(
-            db_xform.odk_form_id, project_odk_id, odk_credentials, db
+            project.odk_form_id, project_odk_id, odk_credentials, db
         )
         project.odk_token = odk_token
         db.commit()

--- a/src/backend/app/db/db_models.py
+++ b/src/backend/app/db/db_models.py
@@ -210,23 +210,6 @@ class DbXLSForm(Base):
     xls = cast(bytes, Column(LargeBinary))
 
 
-class DbXForm(Base):
-    """XForms linked per project.
-
-    TODO eventually we will support multiple forms per project.
-    TODO So the category field a stub until then.
-    TODO currently it's maintained under projects.xform_category.
-    """
-
-    __tablename__ = "xforms"
-    id = cast(int, Column(Integer, primary_key=True, autoincrement=True))
-    project_id = cast(
-        int, Column(Integer, ForeignKey("projects.id"), name="project_id", index=True)
-    )
-    odk_form_id = cast(str, Column(String))
-    category = cast(str, Column(String))
-
-
 class DbTaskHistory(Base):
     """Describes the history associated with a task."""
 
@@ -453,10 +436,8 @@ class DbProject(Base):
 
     # XForm category specified
     xform_category = cast(str, Column(String))
-    # Linked XForms
-    forms = relationship(
-        DbXForm, backref="project_xform_link", cascade="all, delete, delete-orphan"
-    )
+    odk_form_id = cast(str, Column(String))
+    xlsform_content = cast(bytes, Column(LargeBinary))
 
     __table_args__ = (
         Index("idx_geometry", outline, postgresql_using="gist"),
@@ -485,13 +466,6 @@ class DbProject(Base):
     odk_central_user = cast(str, Column(String))
     odk_central_password = cast(str, Column(String))
     odk_token = cast(str, Column(String, nullable=True))
-
-    form_xls = cast(
-        bytes, Column(LargeBinary)
-    )  # XLSForm file if custom xls is uploaded
-    form_config_file = cast(
-        bytes, Column(LargeBinary)
-    )  # Yaml config file if custom xls is uploaded
 
     data_extract_type = cast(
         str, Column(String)
@@ -559,7 +533,11 @@ class DbSubmissionPhotos(Base):
     __tablename__ = "submission_photos"
 
     id = cast(int, Column(Integer, primary_key=True))
-    project_id = cast(int, Column(Integer))
-    task_id = cast(int, Column(Integer))
+    project_id = cast(
+        int, Column(Integer, ForeignKey("projects.id"), name="project_id", index=True)
+    )
+    task_id = cast(
+        int, Column(Integer, ForeignKey("tasks.id"), name="task_id", index=True)
+    )
     submission_id = cast(str, Column(String))
     s3_path = cast(str, Column(String))

--- a/src/backend/app/projects/project_deps.py
+++ b/src/backend/app/projects/project_deps.py
@@ -98,28 +98,3 @@ async def get_odk_credentials(db: Session, project_id: int):
         odk_central_user=user,
         odk_central_password=password,
     )
-
-
-async def get_project_xform(db, project_id):
-    """Retrieve the transformation associated with a specific project.
-
-    Args:
-        db: Database connection object.
-        project_id: The ID of the project to retrieve the transformation for.
-
-    Returns:
-        The transformation record associated with the specified project.
-
-    Raises:
-        None
-    """
-    sql = text(
-        """
-        SELECT * FROM xforms
-        WHERE project_id = :project_id;
-    """
-    )
-
-    result = db.execute(sql, {"project_id": project_id})
-    db_xform = result.first()
-    return db_xform

--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -666,7 +666,11 @@ async def validate_form(
 ):
     """Basic validity check for uploaded XLSForm.
 
-    Does not append all addition values to make this a valid FMTM form for mapping.
+    Parses the form using ODK pyxform to check that it is valid.
+
+    If the `debug` param is used, the form is returned for inspection.
+    NOTE that this debug form has additional fields appended and should
+        not be used for FMTM project creation.
     """
     if debug:
         updated_form = await central_crud.append_fields_to_user_xlsform(
@@ -685,7 +689,10 @@ async def validate_form(
             xlsform,
             task_count=1,  # NOTE this must be included to append task_filter choices
         )
-        return Response(status_code=HTTPStatus.OK)
+        return JSONResponse(
+            status_code=HTTPStatus.OK,
+            content={"message": "Your form is valid"},
+        )
 
 
 @router.post("/{project_id}/generate-project-data")

--- a/src/backend/app/projects/project_schemas.py
+++ b/src/backend/app/projects/project_schemas.py
@@ -317,7 +317,7 @@ class ProjectBase(BaseModel):
     """Base project model."""
 
     outline: Any = Field(exclude=True)
-    forms: Any = Field(exclude=True)
+    odk_form_id: Optional[str] = Field(exclude=True)
 
     id: int
     odkid: int
@@ -360,10 +360,13 @@ class ProjectBase(BaseModel):
     @computed_field
     @property
     def xform_id(self) -> Optional[str]:
-        """Compute the XForm ID from the linked DbXForm."""
-        if not self.forms:
+        """Generate from odk_form_id.
+
+        TODO this could be refactored out in future.
+        """
+        if not self.odk_form_id:
             return None
-        return self.forms[0].odk_form_id
+        return self.odk_form_id
 
 
 class ProjectWithTasks(ProjectBase):

--- a/src/backend/app/submissions/submission_routes.py
+++ b/src/backend/app/submissions/submission_routes.py
@@ -329,9 +329,7 @@ async def get_submission_form_fields(
     project = project_user.get("project")
     odk_credentials = await project_deps.get_odk_credentials(db, project.id)
     odk_form = central_crud.get_odk_form(odk_credentials)
-    db_xform = await project_deps.get_project_xform(db, project.id)
-
-    return odk_form.formFields(project.odkid, db_xform.odk_form_id)
+    return odk_form.formFields(project.odkid, project.odk_form_id)
 
 
 @router.get("/submission_table")
@@ -440,11 +438,10 @@ async def update_review_state(
         project = current_user.get("project")
         odk_creds = await project_deps.get_odk_credentials(db, project.id)
         odk_project = central_crud.get_odk_project(odk_creds)
-        db_xform = await project_deps.get_project_xform(db, project.id)
 
         response = odk_project.updateReviewState(
             project.odkid,
-            db_xform.odk_form_id,
+            project.odk_form_id,
             instance_id,
             {"reviewState": review_state},
         )

--- a/src/backend/app/tasks/task_deps.py
+++ b/src/backend/app/tasks/task_deps.py
@@ -18,39 +18,13 @@
 
 """Task dependencies for use in Depends."""
 
-from typing import Union
-
 from fastapi import Depends
 from fastapi.exceptions import HTTPException
 from sqlalchemy.orm import Session
 
 from app.db.database import get_db
-from app.db.db_models import DbProject, DbTask
+from app.db.db_models import DbTask
 from app.models.enums import HTTPStatus
-
-
-async def get_xform_name(
-    project: Union[int, DbProject],
-    task_id: int,
-    db: Session = Depends(get_db),
-) -> str:
-    """Get a project xform name."""
-    if isinstance(project, int):
-        db_project = db.query(DbProject).filter(DbProject.id == project).first()
-        if not db_project:
-            raise HTTPException(
-                status_code=HTTPStatus.NOT_FOUND,
-                detail=f"Project with ID ({project}) does not exist",
-            )
-    else:
-        db_project = project
-
-    project_name = db_project.project_name_prefix
-    # TODO in the future we may possibly support multiple forms per project.
-    # TODO to facilitate this we need to add the _{category} suffix and track.
-    # TODO this in the new xforms.category field/table.
-    form_name = project_name
-    return form_name
 
 
 async def get_task_by_id(

--- a/src/backend/migrations/007-remove-xform-table.sql
+++ b/src/backend/migrations/007-remove-xform-table.sql
@@ -1,0 +1,74 @@
+-- ## Migration to:
+-- * Rename projects.form_xls --> projects.xlsform_content
+-- * Remove projects.form_config_file until required
+-- * Add missed foreign keys to submission_photos
+-- * Remove public.xforms table, moving odk_form_id to public.projects
+-- Decided to remove the XForms table as projects likely always have a
+--      1:1 relationship with xforms (spwoodcock)
+
+-- Start a transaction
+BEGIN;
+
+-- Add foreign keys to submission_photos table, if they don't exist
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.table_constraints
+        WHERE constraint_name = 'fk_project_id'
+          AND table_name = 'submission_photos'
+    ) THEN
+        ALTER TABLE ONLY public.submission_photos
+        ADD CONSTRAINT fk_project_id FOREIGN KEY (project_id)
+        REFERENCES public.projects (id);
+    END IF;
+    
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.table_constraints
+        WHERE constraint_name = 'fk_tasks'
+          AND table_name = 'submission_photos'
+    ) THEN
+        ALTER TABLE ONLY public.submission_photos
+        ADD CONSTRAINT fk_tasks FOREIGN KEY (
+            task_id, project_id
+        ) REFERENCES public.tasks (id, project_id);
+    END IF;
+END $$;
+
+-- Update public.projects table
+ALTER TABLE public.projects
+-- Remove form_config_file column
+DROP COLUMN IF EXISTS form_config_file,
+-- Add odk_form_id if not exists
+ADD COLUMN IF NOT EXISTS odk_form_id VARCHAR;
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.columns WHERE table_name = 'projects' AND column_name = 'form_xls') THEN
+        ALTER TABLE public.projects
+            RENAME COLUMN form_xls TO xlsform_content;  -- Rename form_xls to xlsform_content
+    END IF;
+END $$;
+
+-- Migrate odk_form_id data from xforms to projects
+DO $$
+BEGIN
+    IF EXISTS (
+        SELECT 1 
+        FROM information_schema.columns 
+        WHERE table_name = 'xforms' 
+          AND column_name = 'odk_form_id'
+    ) THEN
+        -- Perform data migration if odk_form_id exists in xforms
+        UPDATE public.projects p
+        SET odk_form_id = x.odk_form_id
+        FROM public.xforms x
+        WHERE x.project_id = p.id
+          AND p.odk_form_id IS NULL;  -- Avoid overwriting existing values
+    END IF;
+END $$;
+
+-- Drop public.xforms table if it exists
+DROP TABLE IF EXISTS public.xforms;
+DROP SEQUENCE IF EXISTS public.xforms_id_seq;
+
+-- Commit the transaction
+COMMIT;

--- a/src/backend/migrations/init/fmtm_base_schema.sql
+++ b/src/backend/migrations/init/fmtm_base_schema.sql
@@ -260,6 +260,8 @@ CREATE TABLE public.projects (
     status public.projectstatus NOT NULL DEFAULT 'DRAFT',
     total_tasks integer,
     xform_category character varying,
+    xlsform_content bytea,
+    odk_form_id character varying,
     visibility public.projectvisibility NOT NULL DEFAULT 'PUBLIC',
     mapper_level public.mappinglevel NOT NULL DEFAULT 'INTERMEDIATE',
     priority public.projectpriority DEFAULT 'MEDIUM',
@@ -278,8 +280,6 @@ CREATE TABLE public.projects (
     odk_central_user character varying,
     odk_central_password character varying,
     odk_token character varying,
-    form_xls bytea,
-    form_config_file bytea,
     data_extract_type character varying,
     data_extract_url character varying,
     task_split_type public.tasksplittype,
@@ -390,22 +390,24 @@ CACHE 1;
 ALTER TABLE public.xlsforms_id_seq OWNER TO fmtm;
 ALTER SEQUENCE public.xlsforms_id_seq OWNED BY public.xlsforms.id;
 
-CREATE TABLE public.xforms (
+CREATE TABLE public.submission_photos (
     id integer NOT NULL,
-    project_id integer,
-    odk_form_id character varying,
-    category character varying
+    project_id integer NOT NULL,
+    task_id integer NOT NULL,
+    submission_id character varying NOT NULL,
+    s3_path character varying NOT NULL
 );
-ALTER TABLE public.xforms OWNER TO fmtm;
-CREATE SEQUENCE public.xforms_id_seq
+ALTER TABLE public.submission_photos OWNER TO fmtm;
+CREATE SEQUENCE public.submission_photos_id_seq
 AS integer
 START WITH 1
 INCREMENT BY 1
 NO MINVALUE
 NO MAXVALUE
 CACHE 1;
-ALTER TABLE public.xforms_id_seq OWNER TO fmtm;
-ALTER SEQUENCE public.xforms_id_seq OWNED BY public.xforms.id;
+ALTER TABLE public.submission_photos_id_seq OWNER TO fmtm;
+ALTER SEQUENCE public.submission_photos_id_seq
+OWNED BY public.submission_photos.id;
 
 -- nextval for primary keys (autoincrement)
 
@@ -427,8 +429,8 @@ ALTER TABLE ONLY public.tasks ALTER COLUMN id SET DEFAULT nextval(
 ALTER TABLE ONLY public.xlsforms ALTER COLUMN id SET DEFAULT nextval(
     'public.xlsforms_id_seq'::regclass
 );
-ALTER TABLE ONLY public.xforms ALTER COLUMN id SET DEFAULT nextval(
-    'public.xforms_id_seq'::regclass
+ALTER TABLE ONLY public.submission_photos ALTER COLUMN id SET DEFAULT nextval(
+    'public.submission_photos_id_seq'::regclass
 );
 
 
@@ -482,8 +484,8 @@ ADD CONSTRAINT xlsforms_pkey PRIMARY KEY (id);
 ALTER TABLE ONLY public.xlsforms
 ADD CONSTRAINT xlsforms_title_key UNIQUE (title);
 
-ALTER TABLE ONLY public.xforms
-ADD CONSTRAINT xforms_pkey PRIMARY KEY (id);
+ALTER TABLE ONLY public.submission_photos
+ADD CONSTRAINT submission_photos_pkey PRIMARY KEY (id);
 
 -- Indexing
 
@@ -593,11 +595,15 @@ ADD CONSTRAINT user_roles_user_id_fkey FOREIGN KEY (
     user_id
 ) REFERENCES public.users (id);
 
-ALTER TABLE ONLY public.xforms
+ALTER TABLE ONLY public.submission_photos
 ADD CONSTRAINT fk_project_id FOREIGN KEY (
     project_id
 ) REFERENCES public.projects (id);
 
+ALTER TABLE ONLY public.submission_photos
+ADD CONSTRAINT fk_tasks FOREIGN KEY (
+    task_id, project_id
+) REFERENCES public.tasks (id, project_id);
 
 -- Finalise
 

--- a/src/backend/pdm.lock
+++ b/src/backend/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "debug", "dev", "docs", "test", "monitoring"]
 strategy = ["cross_platform"]
 lock_version = "4.4.1"
-content_hash = "sha256:8c65c80f5e570cc8e16aad773965a60059d14e05b51e55dd334de4b4082329bb"
+content_hash = "sha256:91a846c4568a07ac5f12763235018c5862ebb3426d472b969d015884b1820b54"
 
 [[package]]
 name = "aiohttp"

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -42,7 +42,6 @@ dependencies = [
     "asgiref==3.8.1",
     "sozipfile==0.3.2",
     "cryptography>=42.0.8",
-    "defusedxml>=0.7.1",
     "pyjwt>=2.8.0",
     "async-lru>=2.0.4",
     "osm-fieldwork>=0.16.4",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [x] 🧑‍💻 Refactor
- [ ] ✅ Test
- [x] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Describe this PR

- Simplified logic during project creation.
- Added migration to remove `xforms` table, replacing with `projects.odk_form_id` an `projects.xlsform_content`.
- Previously I thought we might have multiple xlsforms per project, but it's become clear that this is not actually desirable. Instead we just want to map multiple features via the same form; functionality we have almost finished adding.
- I also removed all remaining XML manipulation, in favour of the new Pandas XLSX editing we have added in osm-fieldwork. I could remove the `defusedxml` dependency too.

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
