### PR TITLE
Remove task_id and task_filter params from XLSForm

### DIFF
--- a/src/backend/app/central/central_crud.py
+++ b/src/backend/app/central/central_crud.py
@@ -321,7 +321,6 @@ async def append_fields_to_user_xlsform(
     xlsform: BytesIO,
     form_category: str = "buildings",
     additional_entities: list[str] = None,
-    task_count: int = None,
     existing_id: str = None,
 ) -> tuple[str, BytesIO]:
     """Helper to return the intermediate XLSForm prior to convert."""
@@ -330,7 +329,6 @@ async def append_fields_to_user_xlsform(
         xlsform,
         form_category=form_category,
         additional_entities=additional_entities,
-        task_count=task_count,
         existing_id=existing_id,
     )
 
@@ -339,7 +337,6 @@ async def validate_and_update_user_xlsform(
     xlsform: BytesIO,
     form_category: str = "buildings",
     additional_entities: list[str] = None,
-    task_count: int = None,
     existing_id: str = None,
 ) -> BytesIO:
     """Wrapper to append mandatory fields and validate user uploaded XLSForm."""
@@ -347,7 +344,6 @@ async def validate_and_update_user_xlsform(
         xlsform,
         form_category=form_category,
         additional_entities=additional_entities,
-        task_count=task_count,
         existing_id=existing_id,
     )
 
@@ -361,7 +357,6 @@ async def update_project_xform(
     odk_id: int,
     xlsform: BytesIO,
     category: str,
-    task_count: int,
     odk_credentials: project_schemas.ODKCentralDecrypted,
 ) -> None:
     """Update and publish the XForm for a project.
@@ -371,7 +366,6 @@ async def update_project_xform(
         odk_id (int): ODK Central form ID.
         xlsform (UploadFile): XForm data.
         category (str): Category of the XForm.
-        task_count (int): The number of tasks in a project.
         odk_credentials (project_schemas.ODKCentralDecrypted): ODK Central creds.
 
     Returns: None

--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -675,7 +675,6 @@ async def validate_form(
     if debug:
         xform_id, updated_form = await central_crud.append_fields_to_user_xlsform(
             xlsform,
-            task_count=1,  # NOTE this must be included to append task_filter choices
         )
         return StreamingResponse(
             updated_form,
@@ -687,7 +686,6 @@ async def validate_form(
     else:
         await central_crud.validate_and_update_user_xlsform(
             xlsform,
-            task_count=1,  # NOTE this must be included to append task_filter choices
         )
         return JSONResponse(
             status_code=HTTPStatus.OK,
@@ -735,7 +733,6 @@ async def generate_files(
     project = project_user_dict.get("project")
     project_id = project.id
     form_category = project.xform_category
-    task_count = len(project.tasks)
 
     log.debug(f"Generating additional files for project: {project.id}")
 
@@ -746,7 +743,6 @@ async def generate_files(
         await central_crud.validate_and_update_user_xlsform(
             xlsform=xlsform_upload,
             form_category=form_category,
-            task_count=task_count,
             additional_entities=additional_entities,
         )
         xlsform = xlsform_upload
@@ -762,7 +758,6 @@ async def generate_files(
     xform_id, project_xlsform = await central_crud.append_fields_to_user_xlsform(
         xlsform=xlsform,
         form_category=form_category,
-        task_count=task_count,
         additional_entities=additional_entities,
     )
     # Write XLS form content to db

--- a/src/backend/pdm.lock
+++ b/src/backend/pdm.lock
@@ -5,7 +5,7 @@
 groups = ["default", "debug", "dev", "docs", "test", "monitoring"]
 strategy = ["cross_platform"]
 lock_version = "4.4.1"
-content_hash = "sha256:d3b1cf0233422641fe8c1e49bb518a57c17fccc8c4d74f2b35cfa55eebbeca7d"
+content_hash = "sha256:714741fe6a8df3b2625f3bdda0fa0be99d488d1a1d814eadb6bfbc9c6fbdf17e"
 
 [[package]]
 name = "aiohttp"
@@ -1579,7 +1579,7 @@ files = [
 
 [[package]]
 name = "osm-fieldwork"
-version = "0.16.5rc0"
+version = "0.16.5"
 requires_python = ">=3.10"
 summary = "Processing field data from ODK to OpenStreetMap format."
 dependencies = [
@@ -1605,8 +1605,8 @@ dependencies = [
     "xmltodict>=0.13.0",
 ]
 files = [
-    {file = "osm-fieldwork-0.16.5rc0.tar.gz", hash = "sha256:34efa14be5bfb111f8227809867d8c73bbdf3893e472d5c239643a727fe1c769"},
-    {file = "osm_fieldwork-0.16.5rc0-py3-none-any.whl", hash = "sha256:a879a8b0dce9273d7c72d03ec6d704152305ccc8be72bc9404b95877737eec67"},
+    {file = "osm-fieldwork-0.16.5.tar.gz", hash = "sha256:db608ba8f71459673882f7f0baece64e0963aa9b715d10d0f87ca8c71c955cc1"},
+    {file = "osm_fieldwork-0.16.5-py3-none-any.whl", hash = "sha256:b24906bd28646a3766d52a8eaa4e515ef9195f24be3757eebbe240c7018a4299"},
 ]
 
 [[package]]

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "cryptography>=42.0.8",
     "pyjwt>=2.8.0",
     "async-lru>=2.0.4",
-    "osm-fieldwork>=0.16.5rc0",
+    "osm-fieldwork>=0.16.5",
     "osm-login-python==2.0.0",
     "osm-rawdata==0.3.2",
     "fmtm-splitter==1.3.1",

--- a/src/frontend/src/components/DialogTaskActions.tsx
+++ b/src/frontend/src/components/DialogTaskActions.tsx
@@ -232,7 +232,7 @@ export default function Dialog({ taskId, feature }: dialogPropType) {
               );
 
               if (isMobile) {
-                document.location.href = `odkcollect://form/${projectInfo.xform_id}?task_filter=${taskId}`;
+                document.location.href = `odkcollect://form/${projectInfo.xform_id}`;
               } else {
                 dispatch(
                   CommonActions.SetSnackBar({

--- a/src/frontend/src/views/SubmissionDetails.tsx
+++ b/src/frontend/src/views/SubmissionDetails.tsx
@@ -94,11 +94,7 @@ const SubmissionDetails = () => {
   const projectDashboardLoading = useAppSelector((state) => state.project.projectDashboardLoading);
   const submissionDetails = useAppSelector((state) => state.submission.submissionDetails);
   const submissionDetailsLoading = useAppSelector((state) => state.submission.submissionDetailsLoading);
-  const taskId = submissionDetails?.task_id
-    ? submissionDetails?.task_id
-    : submissionDetails?.task_filter
-      ? submissionDetails?.task_filter
-      : '-';
+  const taskId = submissionDetails?.task_id ? submissionDetails?.task_id : '-';
 
   const { start, end, today, deviceid, ...restSubmissionDetails } = submissionDetails || {};
   const dateDeviceDetails = { start, end, today, deviceid };

--- a/src/frontend/src/views/SubmissionDetails.tsx
+++ b/src/frontend/src/views/SubmissionDetails.tsx
@@ -154,7 +154,7 @@ const SubmissionDetails = () => {
   const newFeaturePoint = {
     type: 'Feature',
     geometry: {
-      ...restSubmissionDetails?.new_feature_point,
+      ...restSubmissionDetails?.new_feature,
     },
     properties: {},
   };
@@ -246,7 +246,7 @@ const SubmissionDetails = () => {
                 featureGeojson={
                   submissionDetailsLoading
                     ? {}
-                    : restSubmissionDetails?.new_feature === 'yes'
+                    : restSubmissionDetails?.new_feature
                       ? newFeaturePoint
                       : coordinatesArray
                         ? geojsonFeature


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [x] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Describe this PR

- Simplify logic for digitisation and mandatory fields XLSForms based on field feedback.
- Remove the task_id and task_filter fields to simplify logic.
  - They make it slightly easier to select a geometry by filtering down the available options, at the expense of complicating many things.
  - Ideally the user just selects a geom via intent and doesn't even need to open the map anyway.

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
