### PR TITLE
Fix/pass additional entity name

### DIFF
--- a/src/frontend/src/api/CreateProjectService.ts
+++ b/src/frontend/src/api/CreateProjectService.ts
@@ -206,9 +206,10 @@ const GenerateProjectFilesService = (url: string, projectData: any, formUpload: 
           });
         } else {
           const generateApiFormData = new FormData();
-          if (additional_entities?.length > 0) {
-            generateApiFormData.append('additional_entities', additional_entities);
-          }
+          generateApiFormData.append(
+            'additional_entities',
+            additional_entities?.length > 0 ? additional_entities : null,
+          );
           response = await axios.post(url, generateApiFormData, {
             headers: {
               'Content-Type': 'multipart/form-data',

--- a/src/frontend/src/api/CreateProjectService.ts
+++ b/src/frontend/src/api/CreateProjectService.ts
@@ -190,18 +190,30 @@ const GenerateProjectFilesService = (url: string, projectData: any, formUpload: 
       let isAPISuccess = true;
       try {
         let response;
-
+        const additional_entities: string[] =
+          projectData?.additional_entities?.length > 0 ? [projectData?.additional_entities?.[0].replace(' ', '_')] : [];
         if (projectData.form_ways === 'custom_form') {
           // TODO move form upload to a separate service / endpoint?
           const generateApiFormData = new FormData();
           generateApiFormData.append('xlsform', formUpload);
+          if (additional_entities?.length > 0) {
+            generateApiFormData.append('additional_entities', additional_entities);
+          }
           response = await axios.post(url, generateApiFormData, {
             headers: {
               'Content-Type': 'multipart/form-data',
             },
           });
         } else {
-          response = await axios.post(url, {});
+          const generateApiFormData = new FormData();
+          if (additional_entities?.length > 0) {
+            generateApiFormData.append('additional_entities', additional_entities);
+          }
+          response = await axios.post(url, generateApiFormData, {
+            headers: {
+              'Content-Type': 'multipart/form-data',
+            },
+          });
         }
         isAPISuccess = isStatusSuccess(response.status);
         if (!isAPISuccess) {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue
- Related to #1859

## Describe this PR
This PR contains works to pass additional-entity as a payload to /generate-project-data containing uploaded additional entity geojson's file name.

## Screenshots
![image_720](https://github.com/user-attachments/assets/0446fb39-1285-46d5-bfa7-1267b22e8ba2)