### PR TITLE
Fix(additional-entity) allow custom properties to create entities list

### DIFF
--- a/src/backend/app/projects/project_crud.py
+++ b/src/backend/app/projects/project_crud.py
@@ -474,6 +474,7 @@ async def generate_odk_central_project_content(
     odk_credentials: central_schemas.ODKCentralDecrypted,
     xlsform: BytesIO,
     task_extract_dict: dict[int, geojson.FeatureCollection],
+    entity_properties: list[str],
 ) -> str:
     """Populate the project in ODK Central with XForm, Appuser, Permissions."""
     # The ODK Dataset (Entity List) must exist prior to main XLSForm
@@ -485,6 +486,7 @@ async def generate_odk_central_project_content(
     await central_crud.create_entity_list(
         odk_credentials,
         project_odk_id,
+        properties=entity_properties,
         dataset_name="features",
         entities_list=entities_list,
     )
@@ -530,6 +532,11 @@ async def generate_project_files(
     log.debug("Getting data extract geojson from flatgeobuf")
     feature_collection = await get_project_features_geojson(db, project)
 
+    # Get properties to create datasets
+    entity_properties = list(
+        feature_collection.get("features")[0].get("properties").keys()
+    )
+
     # Split extract by task area
     log.debug("Splitting data extract per task area")
     # TODO in future this splitting could be removed if the task_id is
@@ -550,6 +557,7 @@ async def generate_project_files(
         project_odk_creds,
         BytesIO(project_xlsform),
         task_extract_dict,
+        entity_properties,
     )
     log.debug(
         f"Setting encrypted odk token for FMTM project ({project_id}) "

--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -652,15 +652,18 @@ async def add_additional_entity_list(
     # Parse geojson + divide by task
     # (not technically required, but also appends properties in correct format)
     featcol = parse_geojson_file_to_featcol(await geojson.read())
+    properties = list(featcol.get("features")[0].get("properties").keys())
     feature_split_by_task = await split_geojson_by_task_areas(db, featcol, project_id)
     entities_list = await central_crud.task_geojson_dict_to_entity_values(
         feature_split_by_task
     )
+    dataset_name = entity_name.replace(" ", "_")
 
     await central_crud.create_entity_list(
         project_odk_creds,
         project_odk_id,
-        dataset_name=entity_name,
+        properties=properties,
+        dataset_name=dataset_name,
         entities_list=entities_list,
     )
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- Issue #1800 

There were issues with custom additional entities `geojson` properties which weren't supported by odk-central failing the creation of entities and dataset properties. Some keywords of `odk-central` such as `uuid`, name, label are not supported by `odk-central` to avoid duplicate entries.

## Describe this PR

This PR fixes the mentioned issue where valid properties are prepared from the uploaded additional entity `geojson`.

**changes**
- Custom properties are filtered in one step to include only valid, sanitized properties free of reserved keywords. Invalid properties (having invalid characters such as ":") are excluded to prevent API errors.
- Any default property missing from the custom list is appended to ensure dataset requirements for fmtm in ODK Central.


## Screenshots

N/A

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
