### PR TITLE
Replace pwa in manager frontend with dummy service worker (prep for removal)

### DIFF
--- a/src/frontend/vite.config.ts
+++ b/src/frontend/vite.config.ts
@@ -7,18 +7,9 @@ import { VitePWA } from 'vite-plugin-pwa';
 import type { VitePWAOptions } from 'vite-plugin-pwa';
 
 const pwaOptions: Partial<VitePWAOptions> = {
-  registerType: 'autoUpdate',
-  devOptions: {
-    enabled: true,
-  },
-  // // add this to cache all the imports, including favicon
-  workbox: {
-    globPatterns: ['**/*.{js,css,html}', '**/*.{ico,svg,png,jpg,gif}'],
-    // maximumFileSizeToCacheInBytes: 3000000,
-    // navigateFallback: null,
-  },
-  // add this to cache all the static assets in the public folder
-  includeAssets: ['**/*'],
+  // this is temporary to remove the existing service worker
+  // prior to complete PWA removal
+  selfDestroying: true,
   manifest: {
     name: 'Field Mapping Tasking Manager',
     short_name: 'FMTM',


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [x] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Describe this PR

- The caching from the PWA on the manager frontend prevents loading the `/mapnow/ID/` URLs for the mapper frontend.
- We don't actually need a PWA for the manager frontend anymore - this will eventually be transferred to the mapper frontend only.
- To facilitate this I added configure to create a dummy service worker that's purpose is to unregister the old service worker.
- Users that visit FMTM will have the PWA service worker removed, so they can correctly load the mapper frontend.
- Later on, the PWA can be removed entirely (once this is pushed through to prod and most users have unregistered the old service worker / or had it expire).

@manjitapandey hopefully the fix for your demo tomorrow 👍 

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
