### PR TITLE
Remove trailing slashes from endpoints, fix check_access for backend roles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,7 @@ OSM_CLIENT_ID=${OSM_CLIENT_ID}
 OSM_CLIENT_SECRET=${OSM_CLIENT_SECRET}
 OSM_URL=${OSM_URL:-"https://www.openstreetmap.org"}
 OSM_SCOPE=${OSM_SCOPE:-'["read_prefs", "send_messages"]'}
-OSM_LOGIN_REDIRECT_URI="http${FMTM_DOMAIN:+s}://${FMTM_DOMAIN:-127.0.0.1:7051}/osmauth/"
+OSM_LOGIN_REDIRECT_URI="http${FMTM_DOMAIN:+s}://${FMTM_DOMAIN:-127.0.0.1:7051}/osmauth"
 OSM_SECRET_KEY=${OSM_SECRET_KEY}
 
 ### S3 File Storage ###

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -99,8 +99,8 @@ To properly configure your FMTM project, you will need to create keys for OSM.
 
 2. Register your FMTM instance to OAuth 2 applications.
 
-   Put your login redirect url as `http://127.0.0.1:7051/osmauth/` if running locally,
-   or for production replace with https://{YOUR_DOMAIN}/osmauth/
+   Put your login redirect url as `http://127.0.0.1:7051/osmauth` if running locally,
+   or for production replace with https://{YOUR_DOMAIN}/osmauth
 
    > Note: `127.0.0.1` is required for debugging instead of `localhost`
    > due to OSM restrictions.

--- a/scripts/gen-env.sh
+++ b/scripts/gen-env.sh
@@ -305,7 +305,7 @@ set_domains() {
 set_osm_credentials() {
     pretty_echo "OSM OAuth2 Credentials"
 
-    redirect_uri="http${FMTM_DOMAIN:+s}://${FMTM_DOMAIN:-127.0.0.1:7051}/osmauth/"
+    redirect_uri="http${FMTM_DOMAIN:+s}://${FMTM_DOMAIN:-127.0.0.1:7051}/osmauth"
 
     echo "App credentials are generated from your OSM user profile."
     echo

--- a/src/backend/app/auth/auth_routes.py
+++ b/src/backend/app/auth/auth_routes.py
@@ -49,7 +49,7 @@ router = APIRouter(
 )
 
 
-@router.get("/osm-login/")
+@router.get("/osm-login")
 async def login_url(osm_auth=Depends(init_osm_auth)):
     """Get Login URL for OSM Oauth Application.
 
@@ -69,7 +69,7 @@ async def login_url(osm_auth=Depends(init_osm_auth)):
     return JSONResponse(content=login_url, status_code=HTTPStatus.OK)
 
 
-@router.get("/callback/")
+@router.get("/callback")
 async def callback(
     request: Request, osm_auth: Annotated[AuthUser, Depends(init_osm_auth)]
 ) -> JSONResponse:
@@ -135,7 +135,7 @@ async def callback(
         ) from e
 
 
-@router.get("/logout/")
+@router.get("/logout")
 async def logout():
     """Reset httpOnly cookie to sign out user."""
     response = Response(status_code=HTTPStatus.OK)
@@ -229,7 +229,7 @@ async def get_or_create_user(
             ) from e
 
 
-@router.get("/me/", response_model=FMTMUser)
+@router.get("/me", response_model=FMTMUser)
 async def my_data(
     db: Annotated[Connection, Depends(db_conn)],
     current_user: Annotated[AuthUser, Depends(login_required)],

--- a/src/backend/app/auth/auth_schemas.py
+++ b/src/backend/app/auth/auth_schemas.py
@@ -16,10 +16,9 @@
 #
 """Pydantic models for Auth."""
 
-from typing import Any, Optional, TypedDict
+from typing import Optional, TypedDict
 
 from pydantic import BaseModel, ConfigDict, PrivateAttr, computed_field
-from pydantic.functional_validators import field_validator
 
 from app.db.enums import ProjectRole, UserRole
 from app.db.models import DbOrganisation, DbProject, DbUser
@@ -80,30 +79,5 @@ class FMTMUser(BaseModel):
     username: str
     profile_img: str
     role: UserRole
-    project_roles: Optional[dict[int, ProjectRole]] = {}
-    orgs_managed: Optional[list[int]] = []
-
-    @field_validator("role", mode="before")
-    @classmethod
-    def convert_user_role_str_to_ints(cls, role: Any) -> Optional[UserRole]:
-        """User role strings returned from db converted to enum integers."""
-        if not role:
-            return None
-        if isinstance(role, str):
-            return UserRole[role]
-        return role
-
-    @field_validator("project_roles", mode="before")
-    @classmethod
-    def convert_project_role_str_to_ints(
-        cls, roles: dict[int, Any]
-    ) -> Optional[dict[int, ProjectRole]]:
-        """User project strings returned from db converted to enum integers."""
-        if not roles:
-            return {}
-
-        first_value = next(iter(roles.values()), None)
-        if isinstance(first_value, str):
-            return {id: ProjectRole[role] for id, role in roles.items()}
-
-        return roles
+    project_roles: Optional[dict[int, ProjectRole]] = None
+    orgs_managed: Optional[list[int]] = None

--- a/src/backend/app/auth/roles.py
+++ b/src/backend/app/auth/roles.py
@@ -86,38 +86,53 @@ async def check_access(
     user_id = await get_uid(user)
 
     sql = """
+        WITH role_hierarchy AS (
+            SELECT 'MAPPER' AS role, 0 AS level
+            UNION ALL SELECT 'VALIDATOR', 1
+            UNION ALL SELECT 'FIELD_MANAGER', 2
+            UNION ALL SELECT 'ASSOCIATE_PROJECT_MANAGER', 3
+            UNION ALL SELECT 'PROJECT_MANAGER', 4
+        )
         SELECT *
         FROM users
         WHERE id = %(user_id)s
             AND (
                 CASE
-                    WHEN role = 'ADMIN' THEN true
-                    WHEN role = 'READ_ONLY' THEN false
+                    -- Simple check to see if ADMIN or blocked (READ_ONLY)
+                    WHEN role = 'ADMIN'::public.userrole THEN true
+                    WHEN role = 'READ_ONLY'::public.userrole THEN false
                     ELSE
+                        -- Check to see if user is org admin
                         EXISTS (
                             SELECT 1
                             FROM organisation_managers
                             WHERE organisation_managers.user_id = %(user_id)s
-                              AND
-                              organisation_managers.organisation_id = %(org_id)s
+                            AND organisation_managers.organisation_id = %(org_id)s
                         )
+                        -- Check to see if user has equal or greater than project role
                         OR EXISTS (
                             SELECT 1
                             FROM user_roles
+                            JOIN role_hierarchy AS user_role_h
+                                ON user_roles.role = user_role_h.role
+                            JOIN role_hierarchy AS required_role_h
+                                ON %(role)s::public.projectrole = required_role_h.role
                             WHERE user_roles.user_id = %(user_id)s
-                              AND user_roles.project_id = %(project_id)s
-                              AND user_roles.role >= %(role)s
+                            AND user_roles.project_id = %(project_id)s
+                            AND user_role_h.level >= required_role_h.level
                         )
+                        -- Extract organisation id from project,
+                        -- then check to see if user is org admin
                         OR (
                             %(org_id)s IS NULL
                             AND EXISTS (
                                 SELECT 1
                                 FROM organisation_managers
-                                JOIN projects ON
-                                  projects.organisation_id
-                                    = organisation_managers.organisation_id
+                                JOIN projects
+                                    ON projects.organisation_id =
+                                        organisation_managers.organisation_id
                                 WHERE organisation_managers.user_id = %(user_id)s
-                                  AND projects.id = %(project_id)s
+                                AND projects.id = %(project_id)s
                             )
                         )
                 END

--- a/src/backend/app/auth/roles.py
+++ b/src/backend/app/auth/roles.py
@@ -93,6 +93,7 @@ async def check_access(
             UNION ALL SELECT 'ASSOCIATE_PROJECT_MANAGER', 3
             UNION ALL SELECT 'PROJECT_MANAGER', 4
         )
+
         SELECT *
         FROM users
         WHERE id = %(user_id)s
@@ -102,6 +103,7 @@ async def check_access(
                     WHEN role = 'ADMIN'::public.userrole THEN true
                     WHEN role = 'READ_ONLY'::public.userrole THEN false
                     ELSE
+
                         -- Check to see if user is org admin
                         EXISTS (
                             SELECT 1
@@ -109,18 +111,22 @@ async def check_access(
                             WHERE organisation_managers.user_id = %(user_id)s
                             AND organisation_managers.organisation_id = %(org_id)s
                         )
+
                         -- Check to see if user has equal or greater than project role
                         OR EXISTS (
                             SELECT 1
                             FROM user_roles
                             JOIN role_hierarchy AS user_role_h
-                                ON user_roles.role = user_role_h.role
+                                ON user_roles.role::public.projectrole
+                                    = user_role_h.role::public.projectrole
                             JOIN role_hierarchy AS required_role_h
-                                ON %(role)s::public.projectrole = required_role_h.role
+                                ON %(role)s::public.projectrole
+                                    = required_role_h.role::public.projectrole
                             WHERE user_roles.user_id = %(user_id)s
                             AND user_roles.project_id = %(project_id)s
                             AND user_role_h.level >= required_role_h.level
                         )
+
                         -- Extract organisation id from project,
                         -- then check to see if user is org admin
                         OR (

--- a/src/backend/app/config.py
+++ b/src/backend/app/config.py
@@ -234,7 +234,7 @@ class Settings(BaseSettings):
     # https://github.com/openstreetmap/operations/issues/951#issuecomment-1748717154
     OSM_URL: HttpUrlStr = "https://www.openstreetmap.org"
     OSM_SCOPE: list[str] = ["read_prefs", "send_messages"]
-    OSM_LOGIN_REDIRECT_URI: str = "http://127.0.0.1:7051/osmauth/"
+    OSM_LOGIN_REDIRECT_URI: str = "http://127.0.0.1:7051/osmauth"
 
     S3_ENDPOINT: str = "http://s3:9000"
     S3_ACCESS_KEY: Optional[str] = ""

--- a/src/backend/app/db/database.py
+++ b/src/backend/app/db/database.py
@@ -57,7 +57,7 @@ async def db_conn(request: Request) -> Connection:
     To use the connection in endpoints:
     -----------------------------------
 
-    @app.get("/something/")
+    @app.get("/something")
     async def do_stuff(db = Depends(db_conn)):
         async with db.cursor() as cursor:
             await cursor.execute("SELECT * FROM items")

--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -121,6 +121,8 @@ def get_application() -> FastAPI:
         debug=settings.DEBUG,
         lifespan=lifespan,
         root_path=settings.API_PREFIX,
+        # NOTE REST APIs should not have trailing slashes
+        redirect_slashes=False,
     )
 
     # Set custom logger

--- a/src/backend/app/organisations/organisation_routes.py
+++ b/src/backend/app/organisations/organisation_routes.py
@@ -52,7 +52,7 @@ router = APIRouter(
 )
 
 
-@router.get("/", response_model=list[OrganisationOut])
+@router.get("", response_model=list[OrganisationOut])
 async def get_organisations(
     db: Annotated[Connection, Depends(db_conn)],
     current_user: Annotated[AuthUser, Depends(login_required)],
@@ -70,7 +70,7 @@ async def get_my_organisations(
     return await organisation_crud.get_my_organisations(db, current_user)
 
 
-@router.get("/unapproved/", response_model=list[OrganisationOut])
+@router.get("/unapproved", response_model=list[OrganisationOut])
 async def list_unapproved_organisations(
     db: Annotated[Connection, Depends(db_conn)],
     current_user: Annotated[AuthUser, Depends(login_required)],
@@ -88,7 +88,7 @@ async def get_organisation_detail(
     return organisation
 
 
-@router.post("/", response_model=OrganisationOut)
+@router.post("", response_model=OrganisationOut)
 async def create_organisation(
     db: Annotated[Connection, Depends(db_conn)],
     current_user: Annotated[AuthUser, Depends(login_required)],
@@ -109,7 +109,7 @@ async def create_organisation(
     return await DbOrganisation.create(db, org_in, current_user.id, logo)
 
 
-@router.patch("/{org_id}/", response_model=OrganisationOut)
+@router.patch("/{org_id}", response_model=OrganisationOut)
 async def update_organisation(
     db: Annotated[Connection, Depends(db_conn)],
     org_user_dict: Annotated[AuthUser, Depends(org_admin)],
@@ -164,7 +164,7 @@ async def delete_unapproved_org(
     return Response(status_code=HTTPStatus.NO_CONTENT)
 
 
-@router.post("/approve/", response_model=OrganisationOut)
+@router.post("/approve", response_model=OrganisationOut)
 async def approve_organisation(
     org_id: int,
     db: Annotated[Connection, Depends(db_conn)],
@@ -189,7 +189,7 @@ async def approve_organisation(
     return approved_org
 
 
-@router.post("/new-admin/")
+@router.post("/new-admin")
 async def add_new_organisation_admin(
     db: Annotated[Connection, Depends(db_conn)],
     org_user_dict: Annotated[OrgUserDict, Depends(org_admin)],

--- a/src/backend/app/submissions/submission_routes.py
+++ b/src/backend/app/submissions/submission_routes.py
@@ -47,7 +47,7 @@ router = APIRouter(
 )
 
 
-@router.get("/")
+@router.get("")
 async def read_submissions(
     project_user: Annotated[ProjectUserDict, Depends(mapper)],
 ) -> list[dict]:
@@ -383,7 +383,7 @@ async def download_submission_geojson(
     return Response(submission_data.getvalue(), headers=headers)
 
 
-@router.get("/conflate-submission-geojson/")
+@router.get("/conflate-submission-geojson")
 async def conflate_geojson(
     db_task: Annotated[DbTask, Depends(get_task)],
     project_user: Annotated[ProjectUserDict, Depends(mapper)],

--- a/src/backend/app/tasks/task_routes.py
+++ b/src/backend/app/tasks/task_routes.py
@@ -37,7 +37,7 @@ router = APIRouter(
 )
 
 
-@router.get("/", response_model=list[task_schemas.TaskOut])
+@router.get("", response_model=list[task_schemas.TaskOut])
 async def read_tasks(
     project_id: int,
     db: Annotated[Connection, Depends(db_conn)],
@@ -84,7 +84,7 @@ async def add_new_task_event(
     return await DbTaskEvent.create(db, new_event)
 
 
-@router.get("/activity/", response_model=list[task_schemas.TaskEventCount])
+@router.get("/activity", response_model=list[task_schemas.TaskEventCount])
 async def task_activity(
     project_id: int,
     db: Annotated[Connection, Depends(db_conn)],
@@ -105,7 +105,7 @@ async def task_activity(
     return await task_crud.get_project_task_activity(db, project_id, days)
 
 
-@router.get("/{task_id}/history/", response_model=list[task_schemas.TaskEventOut])
+@router.get("/{task_id}/history", response_model=list[task_schemas.TaskEventOut])
 async def get_task_event_history(
     task_id: int,
     db: Annotated[Connection, Depends(db_conn)],

--- a/src/backend/app/users/user_routes.py
+++ b/src/backend/app/users/user_routes.py
@@ -47,6 +47,15 @@ async def get_users(
     return await DbUser.all(db)
 
 
+@router.get("/user-role-options")
+async def get_user_roles(current_user: Annotated[DbUser, Depends(mapper)]):
+    """Check for available user role options."""
+    user_roles = {}
+    for role in UserRoleEnum:
+        user_roles[role.name] = role.value
+    return user_roles
+
+
 @router.get("/{id}", response_model=user_schemas.UserOut)
 async def get_user_by_identifier(
     user: Annotated[DbUser, Depends(get_user)],
@@ -59,15 +68,6 @@ async def get_user_by_identifier(
     for the username.
     """
     return user
-
-
-@router.get("/user-role-options")
-async def get_user_roles(current_user: Annotated[DbUser, Depends(mapper)]):
-    """Check for available user role options."""
-    user_roles = {}
-    for role in UserRoleEnum:
-        user_roles[role.name] = role.value
-    return user_roles
 
 
 @router.delete("/{id}")

--- a/src/backend/app/users/user_routes.py
+++ b/src/backend/app/users/user_routes.py
@@ -38,7 +38,7 @@ router = APIRouter(
 )
 
 
-@router.get("/", response_model=List[user_schemas.UserOut])
+@router.get("", response_model=List[user_schemas.UserOut])
 async def get_users(
     db: Annotated[Connection, Depends(db_conn)],
     current_user: Annotated[DbUser, Depends(super_admin)],
@@ -61,7 +61,7 @@ async def get_user_by_identifier(
     return user
 
 
-@router.get("/user-role-options/")
+@router.get("/user-role-options")
 async def get_user_roles(current_user: Annotated[DbUser, Depends(mapper)]):
     """Check for available user role options."""
     user_roles = {}

--- a/src/backend/tests/test_organisation_routes.py
+++ b/src/backend/tests/test_organisation_routes.py
@@ -22,7 +22,7 @@ import pytest
 
 async def test_get_organisation(client, organisation):
     """Test get list of organisations."""
-    response = await client.get("/organisation/")
+    response = await client.get("/organisation")
     assert response.status_code == 200
 
     data = response.json()[-1]

--- a/src/backend/tests/test_projects_routes.py
+++ b/src/backend/tests/test_projects_routes.py
@@ -275,14 +275,14 @@ async def test_upload_data_extracts(client, project):
         )
     }
     response = await client.post(
-        f"/projects/upload-custom-extract/?project_id={project.id}",
+        f"/projects/upload-custom-extract?project_id={project.id}",
         files=fgb_file,
     )
 
     assert response.status_code == 200
 
     response = await client.get(
-        f"/projects/data-extract-url/?project_id={project.id}",
+        f"/projects/data-extract-url?project_id={project.id}",
     )
     assert "url" in response.json()
 
@@ -294,14 +294,14 @@ async def test_upload_data_extracts(client, project):
         )
     }
     response = await client.post(
-        f"/projects/upload-custom-extract/?project_id={project.id}",
+        f"/projects/upload-custom-extract?project_id={project.id}",
         files=geojson_file,
     )
 
     assert response.status_code == 200
 
     response = await client.get(
-        f"/projects/data-extract-url/?project_id={project.id}",
+        f"/projects/data-extract-url?project_id={project.id}",
     )
     assert "url" in response.json()
 

--- a/src/backend/tests/test_users.py
+++ b/src/backend/tests/test_users.py
@@ -44,18 +44,18 @@ async def test_nothing():
 
 
 # async def test_create_users(client):
-#     response = await client.post("/users/", json={
+#     response = await client.post("/users", json={
 # "username": "test3", "password": "test1"})
 #     assert response.status_code == status.HTTP_200_OK
 
-#     response = await client.post("/users/", json={
+#     response = await client.post("/users", json={
 # "username": "niraj", "password": "niraj"})
 #     assert response.status_code == status.HTTP_200_OK
 
-#     response = await client.post("/users/", json={"username": "niraj"})
+#     response = await client.post("/users", json={"username": "niraj"})
 #     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
 
-#     response = await client.post("/users/", json={
+#     response = await client.post("/users", json={
 # "username": "niraj", "password": "niraj"})
 #     assert response.status_code == status.HTTP_400_BAD_REQUEST
 #     assert response.json() == {"detail": "Username already registered"}

--- a/src/frontend/src/api/CreateProjectService.ts
+++ b/src/frontend/src/api/CreateProjectService.ts
@@ -55,7 +55,7 @@ const CreateProjectService = (
       if (isOsmExtract) {
         // Generated extract from raw-data-api
         extractResponse = await API.get(
-          `${import.meta.env.VITE_API_URL}/projects/data-extract-url/?project_id=${projectId}&url=${
+          `${import.meta.env.VITE_API_URL}/projects/data-extract-url?project_id=${projectId}&url=${
             projectData.data_extract_url
           }`,
         );
@@ -64,7 +64,7 @@ const CreateProjectService = (
         const dataExtractFormData = new FormData();
         dataExtractFormData.append('custom_extract_file', dataExtractFile);
         extractResponse = await API.post(
-          `${import.meta.env.VITE_API_URL}/projects/upload-custom-extract/?project_id=${projectId}`,
+          `${import.meta.env.VITE_API_URL}/projects/upload-custom-extract?project_id=${projectId}`,
           dataExtractFormData,
         );
       }

--- a/src/frontend/src/api/Project.ts
+++ b/src/frontend/src/api/Project.ts
@@ -157,7 +157,7 @@ export const GenerateProjectTiles = (url: string, projectId: string, data: objec
     const generateProjectTiles = async (url: string, projectId: string) => {
       try {
         await CoreModules.axios.post(url, data);
-        dispatch(GetTilesList(`${import.meta.env.VITE_API_URL}/projects/${projectId}/tiles/`));
+        dispatch(GetTilesList(`${import.meta.env.VITE_API_URL}/projects/${projectId}/tiles`));
         dispatch(ProjectActions.SetGenerateProjectTilesLoading(false));
       } catch (error) {
         dispatch(ProjectActions.SetGenerateProjectTilesLoading(false));

--- a/src/frontend/src/components/ApproveOrganization/OrganizationForm.tsx
+++ b/src/frontend/src/components/ApproveOrganization/OrganizationForm.tsx
@@ -38,7 +38,7 @@ const OrganizationForm = () => {
     if (organizationId) {
       dispatch(
         ApproveOrganizationService(
-          `${import.meta.env.VITE_API_URL}/organisation/approve/?org_id=${parseInt(organizationId)}`,
+          `${import.meta.env.VITE_API_URL}/organisation/approve?org_id=${parseInt(organizationId)}`,
         ),
       );
     }

--- a/src/frontend/src/components/CreateEditOrganization/CreateEditOrganizationForm.tsx
+++ b/src/frontend/src/components/CreateEditOrganization/CreateEditOrganizationForm.tsx
@@ -42,16 +42,13 @@ const CreateEditOrganizationForm = ({ organizationId }: { organizationId: string
   const submission = () => {
     if (!organizationId) {
       const { fillODKCredentials, ...filteredValues } = values;
-      dispatch(PostOrganisationDataService(`${import.meta.env.VITE_API_URL}/organisation/`, filteredValues));
+      dispatch(PostOrganisationDataService(`${import.meta.env.VITE_API_URL}/organisation`, filteredValues));
     } else {
       const { fillODKCredentials, ...filteredValues } = values;
       const changedValues = diffObject(organisationFormData, filteredValues);
       if (Object.keys(changedValues).length > 0) {
         dispatch(
-          PatchOrganizationDataService(
-            `${import.meta.env.VITE_API_URL}/organisation/${organizationId}/`,
-            changedValues,
-          ),
+          PatchOrganizationDataService(`${import.meta.env.VITE_API_URL}/organisation/${organizationId}`, changedValues),
         );
       }
     }

--- a/src/frontend/src/components/DialogTaskActions.tsx
+++ b/src/frontend/src/components/DialogTaskActions.tsx
@@ -55,7 +55,7 @@ export default function Dialog({ taskId, feature }: dialogPropType) {
     if (taskId) {
       dispatch(
         GetProjectTaskActivity(
-          `${import.meta.env.VITE_API_URL}/tasks/${selectedTask?.id}/history/?project_id=${currentProjectId}&comments=false`,
+          `${import.meta.env.VITE_API_URL}/tasks/${selectedTask?.id}/history?project_id=${currentProjectId}&comments=false`,
         ),
       );
     }

--- a/src/frontend/src/components/GenerateBasemap.tsx
+++ b/src/frontend/src/components/GenerateBasemap.tsx
@@ -36,7 +36,7 @@ const GenerateBasemap = ({ projectInfo }: { projectInfo: Partial<projectInfoType
   };
 
   const getTilesList = () => {
-    dispatch(GetTilesList(`${import.meta.env.VITE_API_URL}/projects/${id}/tiles/`));
+    dispatch(GetTilesList(`${import.meta.env.VITE_API_URL}/projects/${id}/tiles`));
   };
 
   useEffect(() => {

--- a/src/frontend/src/components/ManageProject/EditTab/FormUpdateTab.tsx
+++ b/src/frontend/src/components/ManageProject/EditTab/FormUpdateTab.tsx
@@ -79,7 +79,7 @@ const FormUpdateTab = ({ projectId }) => {
             onClick={() =>
               dispatch(
                 DownloadProjectForm(
-                  `${import.meta.env.VITE_API_URL}/projects/download-form/${projectId}/`,
+                  `${import.meta.env.VITE_API_URL}/projects/download-form/${projectId}`,
                   'form',
                   projectId,
                 ),

--- a/src/frontend/src/components/ProjectDetailsV2/Comments.tsx
+++ b/src/frontend/src/components/ProjectDetailsV2/Comments.tsx
@@ -35,7 +35,7 @@ const Comments = () => {
   useEffect(() => {
     dispatch(
       GetProjectComments(
-        `${import.meta.env.VITE_API_URL}/tasks/${currentStatus?.id}/history/?project_id=${projectId}&comments=true`,
+        `${import.meta.env.VITE_API_URL}/tasks/${currentStatus?.id}/history?project_id=${projectId}&comments=true`,
       ),
     );
   }, [selectedTask, projectId, currentStatus?.id]);
@@ -58,7 +58,7 @@ const Comments = () => {
       return;
     }
     dispatch(
-      PostProjectComments(`${import.meta.env.VITE_API_URL}/tasks/${currentStatus?.id}/event/?project_id=${projectId}`, {
+      PostProjectComments(`${import.meta.env.VITE_API_URL}/tasks/${currentStatus?.id}/event?project_id=${projectId}`, {
         task_id: selectedTask.id,
         comment,
       }),

--- a/src/frontend/src/components/ProjectDetailsV2/ProjectOptions.tsx
+++ b/src/frontend/src/components/ProjectDetailsV2/ProjectOptions.tsx
@@ -28,7 +28,7 @@ const ProjectOptions = ({ projectName }: projectOptionPropTypes) => {
     if (downloadType === 'form') {
       dispatch(
         DownloadProjectForm(
-          `${import.meta.env.VITE_API_URL}/projects/download-form/${projectId}/`,
+          `${import.meta.env.VITE_API_URL}/projects/download-form/${projectId}`,
           downloadType,
           projectId,
         ),
@@ -44,7 +44,7 @@ const ProjectOptions = ({ projectName }: projectOptionPropTypes) => {
     } else if (downloadType === 'extract') {
       dispatch(
         DownloadDataExtract(
-          `${import.meta.env.VITE_API_URL}/projects/features/download/?project_id=${projectId}`,
+          `${import.meta.env.VITE_API_URL}/projects/features/download?project_id=${projectId}`,
           projectId,
         ),
       );

--- a/src/frontend/src/components/ProjectSubmissions/UpdateReviewStatusModal.tsx
+++ b/src/frontend/src/components/ProjectSubmissions/UpdateReviewStatusModal.tsx
@@ -61,7 +61,7 @@ const UpdateReviewStatusModal = () => {
     if (noteComments.trim().length > 0) {
       dispatch(
         PostProjectComments(
-          `${import.meta.env.VITE_API_URL}/tasks/${updateReviewStatusModal?.taskUid}/event/?project_id=${updateReviewStatusModal?.projectId}`,
+          `${import.meta.env.VITE_API_URL}/tasks/${updateReviewStatusModal?.taskUid}/event?project_id=${updateReviewStatusModal?.projectId}`,
           {
             task_id: updateReviewStatusModal?.taskUid,
             comment: `${updateReviewStatusModal?.instanceId}-SUBMISSION_INST-${noteComments}`,

--- a/src/frontend/src/components/createnewproject/DataExtract.tsx
+++ b/src/frontend/src/components/createnewproject/DataExtract.tsx
@@ -84,7 +84,7 @@ const DataExtract = ({
 
     try {
       const response = await axios.post(
-        `${import.meta.env.VITE_API_URL}/projects/generate-data-extract/`,
+        `${import.meta.env.VITE_API_URL}/projects/generate-data-extract`,
         dataExtractRequestFormData,
       );
 

--- a/src/frontend/src/components/createnewproject/ProjectDetailsForm.tsx
+++ b/src/frontend/src/components/createnewproject/ProjectDetailsForm.tsx
@@ -43,7 +43,7 @@ const ProjectDetailsForm = ({ flag }) => {
   );
 
   const onFocus = () => {
-    dispatch(OrganisationService(`${import.meta.env.VITE_API_URL}/organisation/`));
+    dispatch(OrganisationService(`${import.meta.env.VITE_API_URL}/organisation`));
   };
 
   useEffect(() => {

--- a/src/frontend/src/components/createnewproject/SelectForm.tsx
+++ b/src/frontend/src/components/createnewproject/SelectForm.tsx
@@ -175,7 +175,7 @@ const SelectForm = ({ flag, geojsonFile, customFormFile, setCustomFormFile }) =>
                   </p>
                   <p className="fmtm-text-base fmtm-mt-2">
                     <a
-                      href={`https://xlsforms.fmtm.dev/?url=${
+                      href={`https://xlsforms.fmtm.dev?url=${
                         import.meta.env.VITE_API_URL
                       }/helper/download-template-xlsform?category=${formValues.formCategorySelection}`}
                       target="_"

--- a/src/frontend/src/components/createnewproject/SplitTasks.tsx
+++ b/src/frontend/src/components/createnewproject/SplitTasks.tsx
@@ -167,7 +167,7 @@ const SplitTasks = ({ flag, setGeojsonFile, customDataExtractUpload, additionalF
 
     if (splitTasksSelection === task_split_type.DIVIDE_ON_SQUARE) {
       dispatch(
-        GetDividedTaskFromGeojson(`${import.meta.env.VITE_API_URL}/projects/preview-split-by-square/`, {
+        GetDividedTaskFromGeojson(`${import.meta.env.VITE_API_URL}/projects/preview-split-by-square`, {
           geojson: drawnGeojsonFile,
           extract_geojson: formValues.dataExtractWays === 'osm_data_extract' ? null : dataExtractFile,
           dimension: formValues?.dimension,

--- a/src/frontend/src/utilfunctions/login.ts
+++ b/src/frontend/src/utilfunctions/login.ts
@@ -1,5 +1,5 @@
 export const getUserDetailsFromApi = async () => {
-  const resp = await fetch(`${import.meta.env.VITE_API_URL}/auth/me/`, {
+  const resp = await fetch(`${import.meta.env.VITE_API_URL}/auth/me`, {
     credentials: 'include',
   });
 
@@ -16,7 +16,7 @@ export const getUserDetailsFromApi = async () => {
 
 export const osmLoginRedirect = async () => {
   try {
-    const resp = await fetch(`${import.meta.env.VITE_API_URL}/auth/osm-login/`);
+    const resp = await fetch(`${import.meta.env.VITE_API_URL}/auth/osm-login`);
     const data = await resp.json();
     window.location = data.login_url;
   } catch (error) {
@@ -26,7 +26,7 @@ export const osmLoginRedirect = async () => {
 
 export const revokeCookie = async () => {
   try {
-    const response = await fetch(`${import.meta.env.VITE_API_URL}/auth/logout/`, { credentials: 'include' });
+    const response = await fetch(`${import.meta.env.VITE_API_URL}/auth/logout`, { credentials: 'include' });
     if (!response.ok) {
       console.error('/auth/logout endpoint did not return 200 response');
     }

--- a/src/frontend/src/views/DataConflation.tsx
+++ b/src/frontend/src/views/DataConflation.tsx
@@ -17,7 +17,7 @@ const DataConflation = () => {
       SubmissionConflationGeojsonService(
         `${
           import.meta.env.VITE_API_URL
-        }/submission/conflate-submission-geojson/?project_id=${projectId}&task_id=${taskId}`,
+        }/submission/conflate-submission-geojson?project_id=${projectId}&task_id=${taskId}`,
       ),
     );
   }, []);

--- a/src/frontend/src/views/Organisation.tsx
+++ b/src/frontend/src/views/Organisation.tsx
@@ -46,9 +46,9 @@ const Organisation = () => {
 
   useEffect(() => {
     if (verifiedTab) {
-      dispatch(OrganisationDataService(`${import.meta.env.VITE_API_URL}/organisation/`));
+      dispatch(OrganisationDataService(`${import.meta.env.VITE_API_URL}/organisation`));
     } else {
-      dispatch(OrganisationDataService(`${import.meta.env.VITE_API_URL}/organisation/unapproved/`));
+      dispatch(OrganisationDataService(`${import.meta.env.VITE_API_URL}/organisation/unapproved`));
     }
   }, [verifiedTab]);
 

--- a/src/frontend/src/views/OsmAuth.tsx
+++ b/src/frontend/src/views/OsmAuth.tsx
@@ -27,7 +27,7 @@ function OsmAuth() {
     const loginRedirect = async () => {
       // authCode is passed from OpenStreetMap redirect, so get cookie, then redirect
       if (authCode) {
-        const callbackUrl = `${import.meta.env.VITE_API_URL}/auth/callback/?code=${authCode}&state=${state}`;
+        const callbackUrl = `${import.meta.env.VITE_API_URL}/auth/callback?code=${authCode}&state=${state}`;
 
         const completeLogin = async () => {
           // NOTE this encapsulates async methods to call sequentially

--- a/src/frontend/src/views/ProjectSubmissions.tsx
+++ b/src/frontend/src/views/ProjectSubmissions.tsx
@@ -53,7 +53,7 @@ const ProjectSubmissions = () => {
 
   useEffect(() => {
     dispatch(
-      MappedVsValidatedTaskService(`${import.meta.env.VITE_API_URL}/tasks/activity/?project_id=${projectId}&days=30`),
+      MappedVsValidatedTaskService(`${import.meta.env.VITE_API_URL}/tasks/activity?project_id=${projectId}&days=30`),
     );
   }, []);
 

--- a/src/frontend/src/views/SubmissionDetails.tsx
+++ b/src/frontend/src/views/SubmissionDetails.tsx
@@ -117,7 +117,7 @@ const SubmissionDetails = () => {
     if (taskUid == 'undefined') return;
     dispatch(
       GetProjectComments(
-        `${import.meta.env.VITE_API_URL}/tasks/${parseInt(taskUid)}/history/?project_id=${projectId}&comments=true`,
+        `${import.meta.env.VITE_API_URL}/tasks/${parseInt(taskUid)}/history?project_id=${projectId}&comments=true`,
       ),
     );
   }, [taskUid]);

--- a/src/mapper/src/lib/db/events.ts
+++ b/src/mapper/src/lib/db/events.ts
@@ -20,7 +20,7 @@ async function add_event(
 		task_id: taskId,
 		comment: comment,
 	};
-	const resp = await fetch(`${API_URL}/tasks/${taskId}/event/?project_id=${projectId}`, {
+	const resp = await fetch(`${API_URL}/tasks/${taskId}/event?project_id=${projectId}`, {
 		method: 'POST',
 		credentials: 'include',
 		headers: {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [x] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Describe this PR

Trailing slashes, Origin header, and CORS:
- I removed all trailing slashes from routes in FastAPI.
- Proper REST APIs should distinguish between `/route/` and `/route` - they are different.
- We were getting an automatic 307 redirect from FastAPI from `/route` --> `/route/`, which was causing the `Origin` request header to be stripped in Firefox. As a result, with `Origin: null` the CORS check could not complete, so we get a CORS error.
- I removed this default functionality from FastAPI.
- In future all APIs should not end in a trailing slash. Frontend calls should also account for this.

Fixes check_access logic:
- The logic for check_access on the roles was broken a bit.
- If no org_id was passed, then we need to extract the org_id from the project - fixed this.
- I also updated the `project_roles` dict to correctly return when user details are returned from the APIs.
- Finally, I converted the project role enum values into numerical values for assessing the hierarchy in check_access.

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?

![mKwrd0qX7vRuYxQkRf](https://github.com/user-attachments/assets/5e3a9b73-d5cc-4738-9e0b-560f33246c22)

