### PR TITLE
Persist osm login across playwright tests (temp login removed)

### DIFF
--- a/src/backend/app/auth/auth_routes.py
+++ b/src/backend/app/auth/auth_routes.py
@@ -315,7 +315,6 @@ async def temp_login(
     setting it as a cookie.
 
     Args:
-        request (Request): The incoming request object.
         email: email of non-osm user.
 
     Returns:

--- a/src/frontend/.gitignore
+++ b/src/frontend/.gitignore
@@ -122,5 +122,5 @@ dist
 /playwright-report/
 /blob-report/
 /playwright/.cache/
-
-playwright/.auth
+/e2e/.cache/
+e2e/.auth

--- a/src/frontend/e2e/01-create-new-project.spec.ts
+++ b/src/frontend/e2e/01-create-new-project.spec.ts
@@ -3,18 +3,14 @@
 
 import { test, expect } from '@playwright/test';
 
-import { tempLogin } from './helpers';
-
 test('create new project', async ({ browserName, page }) => {
   // Specific for this large test, only run in one browser
   // (playwright.config.ts is configured to run all browsers by default)
   test.skip(browserName !== 'chromium', 'Test only for chromium!');
 
-  // 0. Temp Login
-  await tempLogin(page);
-  await page.getByRole('button', { name: '+ Create New Project' }).click();
-
   // 1. Project Details Step
+  await page.goto('/');
+  await page.getByRole('button', { name: '+ Create New Project' }).click();
   await page.getByRole('button', { name: 'NEXT' }).click();
   await expect(page.getByText('Project Name is Required.')).toBeVisible();
   await expect(page.getByText('Short Description is Required.', { exact: true })).toBeVisible();

--- a/src/frontend/e2e/02-mapper-flow.spec.ts
+++ b/src/frontend/e2e/02-mapper-flow.spec.ts
@@ -3,7 +3,7 @@
 
 import { test, expect } from '@playwright/test';
 
-import { tempLogin, openTestProject } from './helpers';
+import { openTestProject } from './helpers';
 
 test.describe('mapper flow', () => {
   test('task actions', async ({ browserName, page }) => {
@@ -11,11 +11,8 @@ test.describe('mapper flow', () => {
     // (playwright.config.ts is configured to run all browsers by default)
     test.skip(browserName !== 'chromium', 'Test only for chromium!');
 
-    // 0. Temp Login
-    await tempLogin(page);
-    await openTestProject(page);
-
     // 1. Click on task area on map
+    await openTestProject(page);
     await page.locator('canvas').click({
       position: {
         x: 445,

--- a/src/frontend/e2e/auth.setup.ts
+++ b/src/frontend/e2e/auth.setup.ts
@@ -1,24 +1,15 @@
-import { test as setup, expect } from '@playwright/test';
+import { test as setup } from '@playwright/test';
 import path from 'path';
 
 const authFile = path.join(__dirname, './.auth/user.json');
 
 setup('authenticate', async ({ page }) => {
-  // Navigate to the app's base URL
-  await page.goto('/');
-  await page.getByRole('button', { name: 'Sign in' }).click();
+  // Note this sets a token so we can proceed, but the login will be
+  // overwritten by svcfmtm localadmin user (as DEBUG=True)
+  await page.goto('/playwright-temp-login/');
 
-  // Select OSM login
-  await page.getByText('Personal OSM Account').click();
-  await page.waitForSelector('text=Log in to OpenStreetMap');
-
-  // OSM Login page
-  await page.getByLabel('Email Address or Username').fill(process.env.OSM_USERNAME || 'username');
-  await page.getByLabel('Password').fill(process.env.OSM_PASSWORD || 'password');
-  await page.getByRole('button', { name: 'Log in' }).click();
-
-  // Wait for redirect and valid login (sign out button)
-  await page.waitForSelector('text=Sign Out');
+  // Now check we are signed in as localadmin
+  await page.waitForSelector('text=localadmin');
 
   // Save authentication state
   await page.context().storageState({ path: authFile });

--- a/src/frontend/e2e/auth.setup.ts
+++ b/src/frontend/e2e/auth.setup.ts
@@ -1,0 +1,25 @@
+import { test as setup, expect } from '@playwright/test';
+import path from 'path';
+
+const authFile = path.join(__dirname, './.auth/user.json');
+
+setup('authenticate', async ({ page }) => {
+  // Navigate to the app's base URL
+  await page.goto('/');
+  await page.getByRole('button', { name: 'Sign in' }).click();
+
+  // Select OSM login
+  await page.getByText('Personal OSM Account').click();
+  await page.waitForSelector('text=Log in to OpenStreetMap');
+
+  // OSM Login page
+  await page.getByLabel('Email Address or Username').fill(process.env.OSM_USERNAME || 'username');
+  await page.getByLabel('Password').fill(process.env.OSM_PASSWORD || 'password');
+  await page.getByRole('button', { name: 'Log in' }).click();
+
+  // Wait for redirect and valid login (sign out button)
+  await page.waitForSelector('text=Sign Out');
+
+  // Save authentication state
+  await page.context().storageState({ path: authFile });
+});

--- a/src/frontend/e2e/helpers.ts
+++ b/src/frontend/e2e/helpers.ts
@@ -1,11 +1,5 @@
 import { Page } from '@playwright/test';
 
-export async function tempLogin(page: Page) {
-  await page.goto('/');
-  await page.getByRole('button', { name: 'Sign in' }).click();
-  await page.getByText('Temporary Account').click();
-}
-
 export async function openTestProject(page: Page) {
   // open project card with regex text 'Project Create Playwright xxx'
   await page

--- a/src/frontend/playwright.config.ts
+++ b/src/frontend/playwright.config.ts
@@ -28,17 +28,31 @@ export default defineConfig({
 
   /* Configure projects for major browsers */
   projects: [
+    // Setup project
+    { name: 'setup', testMatch: /.*\.setup\.ts/ },
     {
       name: 'chromium',
-      use: { browserName: 'chromium' },
+      use: {
+        browserName: 'chromium',
+        storageState: 'e2e/.auth/user.json',
+      },
+      dependencies: ['setup'],
     },
     {
       name: 'firefox',
-      use: { browserName: 'firefox' },
+      use: {
+        browserName: 'firefox',
+        storageState: 'e2e/.auth/user.json',
+      },
+      dependencies: ['setup'],
     },
     {
       name: 'webkit',
-      use: { browserName: 'webkit' },
+      use: {
+        browserName: 'webkit',
+        storageState: 'playwright/.auth/user.json',
+      },
+      dependencies: ['setup'],
     },
 
     /* Test against mobile viewports. */

--- a/src/frontend/src/routes.jsx
+++ b/src/frontend/src/routes.jsx
@@ -8,6 +8,7 @@ import Organisation from '@/views/Organisation';
 import CreateEditOrganization from '@/views/CreateEditOrganization';
 import ApproveOrganization from '@/views/ApproveOrganization';
 import OsmAuth from '@/views/OsmAuth';
+import PlaywrightTempLogin from '@/views/PlaywrightTempLogin';
 import SubmissionDetails from '@/views/SubmissionDetails';
 import CreateNewProject from '@/views/CreateNewProject';
 import UnderConstruction from '@/views/UnderConstruction';
@@ -183,6 +184,16 @@ const routes = createBrowserRouter([
           <Suspense fallback={<div>Loading...</div>}>
             <ErrorBoundary>
               <OsmAuth />
+            </ErrorBoundary>
+          </Suspense>
+        ),
+      },
+      {
+        path: '/playwright-temp-login/',
+        element: (
+          <Suspense fallback={<div>Loading...</div>}>
+            <ErrorBoundary>
+              <PlaywrightTempLogin />
             </ErrorBoundary>
           </Suspense>
         ),

--- a/src/frontend/src/views/PlaywrightTempLogin.tsx
+++ b/src/frontend/src/views/PlaywrightTempLogin.tsx
@@ -1,0 +1,32 @@
+// This file is a workaround to populate state.login.authDetails
+// the auth is overridden when testing due to DEBUG=True on the backend,
+// but we need to update the frontend state to show we are logged in
+
+import axios from 'axios';
+import { getUserDetailsFromApi } from '@/utilfunctions/login';
+import { CommonActions } from '@/store/slices/CommonSlice';
+import CoreModules from '@/shared/CoreModules.js';
+import { LoginActions } from '@/store/slices/LoginSlice';
+
+async function PlaywrightTempAuth() {
+  const dispatch = CoreModules.useAppDispatch();
+  // Sets a cookie in the browser that is used for auth
+  await axios.get(`${import.meta.env.VITE_API_URL}/auth/temp-login`);
+
+  const apiUser = await getUserDetailsFromApi();
+  if (!apiUser) {
+    dispatch(
+      CommonActions.SetSnackBar({
+        open: true,
+        message: 'Temp login failed. Try OSM.',
+        variant: 'error',
+        duration: 2000,
+      }),
+    );
+    return;
+  }
+
+  dispatch(LoginActions.setAuthDetails(apiUser));
+}
+
+export default PlaywrightTempAuth;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [x] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related

#1903 as the PR where this issue was discussed


## Describe this PR

- Didn't get a chance to finish this due to my flight, but hopefully you get the idea here @NSUWAL123 
- If I don't get to look at this until Monday, we could go over it together in person 😄
- The context should probably be set just after the OSM login succeeds, then waiting for the redirect will allow the cookie to be set for the subsequent test. 
- The context wont save the cookie as it's httpOnly, but should save the OSM login part hopefully, to avoid having to do the Oauth flow for OSM again - let's see!
- In the end the main goal is automated OSM login. To do that we need to make a test OSM account and can just hardcode the creds to this repo. If we optimise by reducing calls to OSM via the auth context, this is a bonus, but not essential for now.

## Alternative Approaches Considered

- Disable auth on the backend when DEBUG=true.
- But this would mean we can't test properly with roles, and this could be important in future. 

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
