### PR TITLE
Resolve route ambiguity for /tasks/activity endpoint

### DIFF
--- a/src/backend/app/tasks/task_routes.py
+++ b/src/backend/app/tasks/task_routes.py
@@ -55,6 +55,27 @@ async def get_tasks_near_me(
     return "Coming..."
 
 
+@router.get("/activity", response_model=list[task_schemas.TaskEventCount])
+async def task_activity(
+    project_id: int,
+    db: Annotated[Connection, Depends(db_conn)],
+    project_user: Annotated[ProjectUserDict, Depends(mapper)],
+    days: int = 10,
+):
+    """Get the number of mapped or validated tasks on each day.
+
+    Return format:
+    [
+        {
+            date: DD/MM/YYYY,
+            validated: int,
+            mapped: int,
+        }
+    ]
+    """
+    return await task_crud.get_project_task_activity(db, project_id, days)
+
+
 @router.get("/{task_id}", response_model=task_schemas.TaskOut)
 async def get_specific_task(
     task_id: int,
@@ -82,27 +103,6 @@ async def add_new_task_event(
     new_event.user_id = user_id
     new_event.task_id = task_id
     return await DbTaskEvent.create(db, new_event)
-
-
-@router.get("/activity/", response_model=list[task_schemas.TaskEventCount])
-async def task_activity(
-    project_id: int,
-    db: Annotated[Connection, Depends(db_conn)],
-    project_user: Annotated[ProjectUserDict, Depends(mapper)],
-    days: int = 10,
-):
-    """Get the number of mapped or validated tasks on each day.
-
-    Return format:
-    [
-        {
-            date: DD/MM/YYYY,
-            validated: int,
-            mapped: int,
-        }
-    ]
-    """
-    return await task_crud.get_project_task_activity(db, project_id, days)
 
 
 @router.get("/{task_id}/history", response_model=list[task_schemas.TaskEventOut])

--- a/src/backend/app/tasks/task_routes.py
+++ b/src/backend/app/tasks/task_routes.py
@@ -84,7 +84,7 @@ async def add_new_task_event(
     return await DbTaskEvent.create(db, new_event)
 
 
-@router.get("/activity", response_model=list[task_schemas.TaskEventCount])
+@router.get("/activity/", response_model=list[task_schemas.TaskEventCount])
 async def task_activity(
     project_id: int,
     db: Annotated[Connection, Depends(db_conn)],

--- a/src/frontend/src/views/ProjectSubmissions.tsx
+++ b/src/frontend/src/views/ProjectSubmissions.tsx
@@ -53,7 +53,7 @@ const ProjectSubmissions = () => {
 
   useEffect(() => {
     dispatch(
-      MappedVsValidatedTaskService(`${import.meta.env.VITE_API_URL}/tasks/activity?project_id=${projectId}&days=30`),
+      MappedVsValidatedTaskService(`${import.meta.env.VITE_API_URL}/tasks/activity/?project_id=${projectId}&days=30`),
     );
   }, []);
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- Issue: #1923
```python
{
  "errors": [
    {
      "loc": [
        "path",
        "task_id"
      ],
      "msg": "Input should be a valid integer, unable to parse string as an integer",
      "error": "Input should be a valid integer, unable to parse string as an integer['path', 'task_id']"
    }
  ]
}
```

## Describe this PR

This PR resolves a routing issue in the `/tasks/activity` endpoint. A trailing slash (/) was added to the endpoint definition to ensure unambiguous route matching.

Previously, the `/tasks/activity` route conflicted with the dynamic route` /tasks/{task_id}`, causing the framework to misinterpret activity as a task_id, resulting in validation errors.

## Screenshots

N/A

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
