### PR TITLE
Edit multi additional entities names replacing space with '_'

### DIFF
--- a/src/frontend/src/api/CreateProjectService.ts
+++ b/src/frontend/src/api/CreateProjectService.ts
@@ -191,34 +191,41 @@ const GenerateProjectFilesService = (url: string, projectData: any, formUpload: 
       try {
         let response;
 
-        const additional_entities: string[] =
+        const additional_entities =
           projectData?.additional_entities?.length > 0
-            ? [projectData?.additional_entities?.[0]?.replaceAll(' ', '_')]
+            ? projectData.additional_entities.map((e: string) => e.replaceAll(' ', '_'))
             : [];
+        const generateApiFormData = new FormData();
+
+        if (additional_entities?.length > 0) {
+          generateApiFormData.append('additional_entities', additional_entities);
+        }
 
         if (projectData.form_ways === 'custom_form') {
           // TODO move form upload to a separate service / endpoint?
-          const generateApiFormData = new FormData();
           generateApiFormData.append('xlsform', formUpload);
-
-          if (additional_entities?.length > 0) {
-            generateApiFormData.append('additional_entities', additional_entities);
-          }
-
           response = await axios.post(url, generateApiFormData, {
             headers: {
               'Content-Type': 'multipart/form-data',
             },
           });
         } else {
-          const payload = {
-            additional_entities: additional_entities.length > 0 ? additional_entities : null,
-          };
-          response = await axios.post(url, payload, {
-            headers: {
-              'Content-Type': 'application/json',
-            },
-          });
+          if (additional_entities?.length > 0) {
+            response = await axios.post(url, generateApiFormData, {
+              headers: {
+                'Content-Type': 'multipart/form-data',
+              },
+            });
+          } else {
+            const payload = {
+              additional_entities: null,
+            };
+            response = await axios.post(url, payload, {
+              headers: {
+                'Content-Type': 'application/json',
+              },
+            });
+          }
         }
 
         isAPISuccess = isStatusSuccess(response.status);


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation
- [X] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

If multiple additional entities are uploaded only the first filename of additional entities is edited to remove space with '_'. This feature is yet to be implemented in UI to allow the uploading of multiple additional entities. Only a single file can be uploaded as an additional entity.

## Describe this PR

This PR updates the frontend code to update the filename for multiple additional entities. Some changes have been made to refactor some repeated code and fix the issue of not passing additional entities list when no custom form is uploaded. If `additional_entities` or custom form is uploaded then it passes payload as a multipart/form-data content type else JSON body.

## Screenshots

N/A

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
