### PR TITLE
Avoid double encryption of odk creds while creating organisation

### DIFF
--- a/src/backend/app/organisations/organisation_deps.py
+++ b/src/backend/app/organisations/organisation_deps.py
@@ -85,9 +85,9 @@ async def get_org_odk_creds(
         )
 
     return central_schemas.ODKCentralDecrypted(
-        odk_central_url=org.odk_central_url,
-        odk_central_user=org.odk_central_user,
-        odk_central_password=org.odk_central_password,
+        odk_central_url=url,
+        odk_central_user=user,
+        odk_central_password=password,
     )
 
 

--- a/src/backend/app/organisations/organisation_schemas.py
+++ b/src/backend/app/organisations/organisation_schemas.py
@@ -79,20 +79,16 @@ def parse_organisation_input(
     The parsed data is returned as an OrganisationIn instance, with the
     ODKCentralIn fields merged in.
     """
-    odk_central_data = ODKCentralIn(
-        odk_central_url=odk_central_url,
-        odk_central_user=odk_central_user,
-        odk_central_password=odk_central_password,
-    )
-    org_data = OrganisationUpdate(
+    return OrganisationUpdate(
         name=name,
         slug=slug,
         created_by=created_by,
         community_type=community_type,
         type=type,
-        **odk_central_data.dict(exclude_unset=True),
+        odk_central_url=odk_central_url,
+        odk_central_user=odk_central_user,
+        odk_central_password=odk_central_password,
     )
-    return org_data
 
 
 class OrganisationOut(BaseModel):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- Issue #1944 

## Describe this PR

This PR updates the `parse_organisation_input` passing odk credentials directly without calling `OdkCentralIn`. Calling OdkCentralIn will encrypt password which is called again in the `OrganisationUpdate` (schema) pydantic model.

## Screenshots

N/A

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
