### PR TITLE
Fix: Submission Instance Page, Create Project

### DIFF
--- a/src/frontend/src/api/Project.ts
+++ b/src/frontend/src/api/Project.ts
@@ -48,6 +48,7 @@ export const ProjectById = (projectId: string) => {
             custom_tms_url: projectResp?.custom_tms_url,
             organisation_id: projectResp?.organisation_id,
             organisation_logo: projectResp?.organisation_logo,
+            organisation_name: projectResp?.organisation_name,
             created_at: projectResp?.created_at,
           }),
         );

--- a/src/frontend/src/api/Submission.ts
+++ b/src/frontend/src/api/Submission.ts
@@ -3,6 +3,7 @@ import { SubmissionActions } from '@/store/slices/SubmissionSlice';
 
 export const SubmissionService: Function = (url: string) => {
   return async (dispatch) => {
+    dispatch(SubmissionActions.SetSubmissionDetails(null));
     dispatch(SubmissionActions.SetSubmissionDetailsLoading(true));
     const getSubmissionDetails = async (url: string) => {
       try {

--- a/src/frontend/src/components/ProjectDetailsV2/ProjectInfo.tsx
+++ b/src/frontend/src/components/ProjectDetailsV2/ProjectInfo.tsx
@@ -106,6 +106,7 @@ const ProjectInfo: React.FC = () => {
                 alt="Organization Photo"
               />
             </div>
+            <p>{projectInfo?.organisation_name}</p>
           </div>
         )}
       </div>

--- a/src/frontend/src/components/ProjectSubmissions/SubmissionsTable.tsx
+++ b/src/frontend/src/components/ProjectSubmissions/SubmissionsTable.tsx
@@ -464,7 +464,7 @@ const SubmissionsTable = ({ toggleView }) => {
             headerClassName="updatedHeader !fmtm-sticky fmtm-right-0 fmtm-shadow-[-10px_0px_20px_0px_rgba(0,0,0,0.1)] fmtm-text-center"
             rowClassName="updatedRow !fmtm-sticky fmtm-right-0 fmtm-bg-white fmtm-shadow-[-10px_0px_20px_0px_rgba(0,0,0,0.1)]"
             dataFormat={(row) => {
-              const taskUid = taskList?.find((task) => task?.id == row?.task_id)?.id;
+              const taskUid = taskList?.find((task) => task?.index == row?.task_id)?.id;
               return (
                 <div className="fmtm-w-[5rem] fmtm-overflow-hidden fmtm-truncate fmtm-text-center">
                   <Link to={`/project-submissions/${projectId}/tasks/${taskUid}/submission/${row?.meta?.instanceID}`}>

--- a/src/frontend/src/components/createnewproject/UploadArea.tsx
+++ b/src/frontend/src/components/createnewproject/UploadArea.tsx
@@ -33,9 +33,9 @@ const uploadAreaOptions = [
 
 const UploadArea = ({ flag, geojsonFile, setGeojsonFile, setCustomDataExtractUpload, setAdditionalFeature }) => {
   useDocumentTitle('Create Project: Upload Area');
+
   const dispatch = useDispatch();
   const navigate = useNavigate();
-  // const [uploadAreaFile, setUploadAreaFile] = useState(null);
   const [isGeojsonWGS84, setIsGeojsonWG84] = useState(true);
 
   const projectDetails = useAppSelector((state) => state.createproject.projectDetails);
@@ -66,13 +66,15 @@ const UploadArea = ({ flag, geojsonFile, setGeojsonFile, setCustomDataExtractUpl
     navigate('/upload-survey');
     dispatch(CreateProjectActions.SetToggleSplittedGeojsonEdit(false));
   };
+
   const {
     handleSubmit,
     handleCustomChange,
     values: formValues,
     errors,
   }: any = useForm(projectDetails, submission, UploadAreaValidation);
-  const toggleStep = (step, url) => {
+
+  const toggleStep = (step: number, url: string) => {
     dispatch(CommonActions.SetCurrentStepFormStep({ flag: flag, step: step }));
     navigate(url);
     dispatch(CreateProjectActions.SetToggleSplittedGeojsonEdit(false));
@@ -282,38 +284,6 @@ const UploadArea = ({ flag, geojsonFile, setGeojsonFile, setCustomDataExtractUpl
                   btnText="Upload a Geojson"
                   errorMsg={errors.uploadedAreaFile}
                 />
-                // <div className="fmtm-mt-5 fmtm-pb-3">
-                //   <div className="fmtm-flex fmtm-items-center fmtm-gap-4">
-                //     <label
-                //       id="file-input"
-                //       className="fmtm-bg-primaryRed fmtm-text-white fmtm-px-4 fmtm-py-1 fmtm-rounded-md fmtm-cursor-pointer"
-                //     >
-                //       <p>Select a file</p>
-                //       <input
-                //         id="upload-area-geojson-file"
-                //         ref={geojsonFileRef}
-                //         type="file"
-                //         className="fmtm-hidden"
-                //         onChange={changeFileHandler}
-                //         accept=".geojson, .json"
-                //       />
-                //     </label>
-                //     <div className="fmtm-rounded-full fmtm-p-1 hover:fmtm-bg-slate-100 fmtm-duration-300 fmtm-cursor-pointer">
-                //       <AssetModules.ReplayIcon className="fmtm-text-gray-600" onClick={() => resetFile()} />
-                //     </div>
-                //   </div>
-                //   {geojsonFile && (
-                //     <div className="fmtm-mt-2">
-                //       <p>{geojsonFile?.name}</p>
-                //     </div>
-                //   )}
-                //   <p className="fmtm-text-gray-700 fmtm-mt-3">
-                //     *The supported file formats are zipped shapefile, geojson or kml files.
-                //   </p>
-                //   <p className="fmtm-text-gray-700 fmtm-pt-8">
-                //     Total Area: <span className="fmtm-font-bold">234 sq.km</span>
-                //   </p>
-                // </div>
               )}
             </div>
             <div className="fmtm-flex fmtm-gap-5 fmtm-mx-auto fmtm-mt-10 fmtm-my-5">

--- a/src/frontend/src/components/createnewproject/UploadArea.tsx
+++ b/src/frontend/src/components/createnewproject/UploadArea.tsx
@@ -31,7 +31,7 @@ const uploadAreaOptions = [
   },
 ];
 
-const UploadArea = ({ flag, geojsonFile, setGeojsonFile, setCustomDataExtractUpload }) => {
+const UploadArea = ({ flag, geojsonFile, setGeojsonFile, setCustomDataExtractUpload, setAdditionalFeature }) => {
   useDocumentTitle('Create Project: Upload Area');
   const dispatch = useDispatch();
   const navigate = useNavigate();
@@ -168,11 +168,14 @@ const UploadArea = ({ flag, geojsonFile, setGeojsonFile, setCustomDataExtractUpl
 
   const resetFile = () => {
     setGeojsonFile(null);
+    setCustomDataExtractUpload(null);
     handleCustomChange('uploadedAreaFile', null);
     handleCustomChange('drawnGeojson', null);
+    setAdditionalFeature(null);
     dispatch(CreateProjectActions.SetDrawnGeojson(null));
     dispatch(CreateProjectActions.SetTotalAreaSelection(null));
-    dispatch(CreateProjectActions.ClearProjectStepState(formValues));
+    dispatch(CreateProjectActions.SetAdditionalFeatureGeojson(null));
+    dispatch(CreateProjectActions.ClearProjectStepState({ ...formValues, uploadedAreaFile: null, drawnGeojson: null }));
   };
 
   useEffect(() => {

--- a/src/frontend/src/models/project/projectModel.ts
+++ b/src/frontend/src/models/project/projectModel.ts
@@ -51,6 +51,7 @@ export type projectInfoType = {
   total_tasks: any;
   organisation_id: number;
   organisation_logo: string;
+  organisation_name: string;
   instructions: string;
   custom_tms_url: string;
   created_at: string;

--- a/src/frontend/src/views/CreateNewProject.tsx
+++ b/src/frontend/src/views/CreateNewProject.tsx
@@ -67,6 +67,7 @@ const CreateNewProject = () => {
             geojsonFile={geojsonFile}
             setGeojsonFile={setGeojsonFile}
             setCustomDataExtractUpload={setCustomDataExtractUpload}
+            setAdditionalFeature={setAdditionalFeature}
           />
         );
       case '/upload-survey':


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue
- Related to #1954
- Fix showing of previously rendered submission geometries on the submission instance page
- Create project: fix uploaded, drawn, splitted, dataExtract geojson state being persisted even if geojson file being reset

## Describe this PR
This PR contains following works: 
- Fix task undefined issue on project instact page updating task_id accessor key
- Fix previously fetched submission geometries appearing to submission instance page
- Create project geojson state fix

## Screenshots
![image](https://github.com/user-attachments/assets/9e43aa2e-ec6a-4e94-be2e-0e7514c31403)
