### PR TITLE
Prompt user to download custom ODK Collect on first load

### DIFF
--- a/src/mapper/src/lib/components/header.svelte
+++ b/src/mapper/src/lib/components/header.svelte
@@ -100,7 +100,7 @@
 		{#if isFirstLoad}
 		<hot-tooltip
 			bind:this={drawerOpenButtonRef}
-			content="Download the custom ODK Collect app here"
+			content="First download the custom ODK Collect app here"
 			open={true}
 			placement="bottom"
 			onsl-after-hide={() => {

--- a/src/mapper/src/lib/components/header.svelte
+++ b/src/mapper/src/lib/components/header.svelte
@@ -6,10 +6,16 @@
 	import { drawerItems as menuItems } from '$constants/drawerItems.ts';
 	import { revokeCookies } from '$lib/utils/login';
 	import { getAlertStore } from '$store/common.svelte';
+	import { getProjectSetupStepStore } from '$store/common.svelte.ts';
+	import { projectSetupStep as projectSetupStepEnum } from '$constants/enums.ts';
 
 	let drawerRef: any = $state();
+	let drawerOpenButtonRef: any = $state();
 	const loginStore = getLoginStore();
 	const alertStore = getAlertStore();
+	const projectSetupStepStore = getProjectSetupStepStore();
+
+	let isFirstLoad = $derived(+projectSetupStepStore.projectSetupStep === projectSetupStepEnum['odk_project_load']);
 
 	const handleSignOut = async () => {
 		try {
@@ -74,19 +80,40 @@
 			</sl-button>
 		{/if}
 
-		<!-- drawer component toggle trigger -->
-		<hot-icon
-			name="list"
-			class="!text-[1.8rem] text-[#52525B] leading-0 cursor-pointer hover:text-red-600 duration-200"
-			onclick={() => {
-				drawerRef.show();
+		<!-- drawer component toggle trigger (snippet to reuse below) -->
+		{#snippet drawerOpenButton()}
+			<hot-icon
+				name="list"
+				class="!text-[1.8rem] text-[#52525B] leading-0 cursor-pointer hover:text-red-600 duration-200"
+				style={isFirstLoad ? 'background-color: var(--sl-color-yellow-300);' : ''}
+				onclick={() => {
+					drawerRef.show();
+				}}
+				onkeydown={() => {
+					drawerRef.show();
+				}}
+				role="button"
+				tabindex="0"
+			></hot-icon>
+	  	{/snippet}
+		<!-- add tooltip on first load -->
+		{#if isFirstLoad}
+		<hot-tooltip
+			bind:this={drawerOpenButtonRef}
+			content="Download the custom ODK Collect app here"
+			open={true}
+			placement="bottom"
+			onsl-after-hide={() => {
+				// Always keep tooltip open
+				drawerOpenButtonRef.show();
 			}}
-			onkeydown={() => {
-				drawerRef.show();
-			}}
-			role="button"
-			tabindex="0"
-		></hot-icon>
+		>
+			{@render drawerOpenButton()}
+		</hot-tooltip>
+		<!-- else render with no tooltip -->
+		{:else}
+			{@render drawerOpenButton()}
+		{/if}
 	</div>
 </div>
 <Login />


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Describe this PR

- Added a small prompt on first load to show the user where to download custom ODK Collect:

![image](https://github.com/user-attachments/assets/11ee598a-f521-49c2-9c07-ac7bf99925a7)

- This is done via tooltip and a svelte snippet.
- It is linked to the localStorage status where we show the QR Code tab by default too.

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
