### PR TITLE
Add submission ids as a dataset property for the entities

### DIFF
--- a/src/backend/app/central/central_schemas.py
+++ b/src/backend/app/central/central_schemas.py
@@ -256,6 +256,7 @@ class EntityMappingStatus(EntityOsmID, EntityTaskID):
 
     updatedAt: Optional[str] = Field(exclude=True)  # noqa: N815
     status: Optional[EntityState] = None
+    submission_ids: Optional[str] = None
 
     @computed_field
     @property

--- a/src/backend/app/db/postgis_utils.py
+++ b/src/backend/app/db/postgis_utils.py
@@ -391,6 +391,7 @@ def add_required_geojson_properties(
             properties["changeset"] = 1
         if not properties.get("timestamp"):
             properties["timestamp"] = timestamp().strftime("%Y-%m-%dT%H:%M:%S")
+        properties["submission_ids"] = None
 
     return geojson
 

--- a/src/backend/app/projects/project_crud.py
+++ b/src/backend/app/projects/project_crud.py
@@ -538,6 +538,7 @@ async def generate_project_files(
     entity_properties = list(
         feature_collection.get("features")[0].get("properties").keys()
     )
+    entity_properties.append("submission_ids")
 
     # Split extract by task area
     log.debug("Splitting data extract per task area")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- Issue: #1946

## Describe this PR

- new property submission_ids is added to dataset and entity properties in order to link each submissions with their respective entity.

## Response

response of `entity/status` endpoint:

```json
{
  "id": "8b3508c8-5ac5-4983-8e4a-d67c6ab51eb9",
  "task_id": 3,
  "osm_id": 954555442,
  "status": 2,
  "submission_id": "uuid:5db29b57-c104-4b74-a49d-a4ad042bc015,uuid:1cdf791b-285b-4bca-8c89-578d7cf71e48, uuid:f3c8a289-4bbc-4671-a780-c0111b374e7c",
  "updated_at": "2024-12-19T08:26:45.065Z"
}

```
## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
