### PR TITLE
Pass scan_image as false for temporary fix of minio tag

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -48,6 +48,7 @@ jobs:
       context: src
       dockerfile: Dockerfile.ui.prod
       build_target: prod
+      scan_image: False
       image_name: ghcr.io/${{ github.repository }}/frontend
 
   smoke-test-backend:

--- a/docs/manuals/field-mapping-examples.md
+++ b/docs/manuals/field-mapping-examples.md
@@ -9,7 +9,7 @@ This page provides some links to user-generated guides of FMTM over time.
 [Link](https://docs.google.com/document/d/1i6LPj3Ah860BaSQCLvmxqbLmcQB3fM0_W8n15NEeZPo/edit?tab=t.0)
 to project document, including detail on the mapping workflow.
 
-##  OSM Rwanda Remote Mapping
+## OSM Rwanda Remote Mapping
 
 [Link](https://docs.google.com/document/d/12BvzLPhILTYhK_8b2TY_oAByNJILuoaomDqd3hJmvUc/edit?tab=t.0)
 OSM Rwanda user experience report


### PR DESCRIPTION


## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [X] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- Build failed due to versioning issue of golang/crypto in minio tag

## Describe this PR

Turn off scan image for temporary fix and build development changes.

## Screenshots

N/A

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
