### PR TITLE
Send notification message to new project manager upon assignment and refactor assignment code

### DIFF
--- a/docs/manuals/field-mapping-examples.md
+++ b/docs/manuals/field-mapping-examples.md
@@ -9,7 +9,7 @@ This page provides some links to user-generated guides of FMTM over time.
 [Link](https://docs.google.com/document/d/1i6LPj3Ah860BaSQCLvmxqbLmcQB3fM0_W8n15NEeZPo/edit?tab=t.0)
 to project document, including detail on the mapping workflow.
 
-##  OSM Rwanda Remote Mapping
+## OSM Rwanda Remote Mapping
 
 [Link](https://docs.google.com/document/d/12BvzLPhILTYhK_8b2TY_oAByNJILuoaomDqd3hJmvUc/edit?tab=t.0)
 OSM Rwanda user experience report

--- a/src/backend/app/projects/project_crud.py
+++ b/src/backend/app/projects/project_crud.py
@@ -949,7 +949,7 @@ async def send_project_manager_message(
     osm_token = get_osm_token(request, osm_auth)
     project_url = f"{settings.FMTM_DOMAIN}/project/{project.id}"
     if not project_url.startswith("http"):
-        project_url = f"http://{project_url}"
+        project_url = f"https://{project_url}"
 
     message_content = dedent(f"""
         You have been assigned to the project **{project.name}** as a

--- a/src/backend/app/projects/project_crud.py
+++ b/src/backend/app/projects/project_crud.py
@@ -21,6 +21,7 @@ import json
 import uuid
 from io import BytesIO
 from pathlib import Path
+from textwrap import dedent
 from traceback import format_exc
 from typing import Optional, Union
 
@@ -28,17 +29,19 @@ import geojson
 import geojson_pydantic
 import requests
 from asgiref.sync import async_to_sync
-from fastapi import HTTPException
+from fastapi import HTTPException, Request
 from loguru import logger as log
 from osm_fieldwork.basemapper import create_basemap_file
+from osm_login_python.core import Auth
 from osm_rawdata.postgres import PostgresClient
 from psycopg import Connection
 from psycopg.rows import class_row
 
+from app.auth.providers.osm import get_osm_token, send_osm_message
 from app.central import central_crud, central_schemas
 from app.config import settings
 from app.db.enums import BackgroundTaskStatus, HTTPStatus, XLSFormType
-from app.db.models import DbBackgroundTask, DbBasemap, DbProject, DbTask
+from app.db.models import DbBackgroundTask, DbBasemap, DbProject, DbTask, DbUser
 from app.db.postgis_utils import (
     check_crs,
     featcol_keep_single_geom_type,
@@ -932,3 +935,35 @@ async def get_project_users_plus_contributions(db: Connection, project_id: int):
     ) as cur:
         await cur.execute(query, {"project_id": project_id})
         return await cur.fetchall()
+
+
+async def send_project_manager_message(
+    request: Request,
+    project: DbProject,
+    new_manager: DbUser,
+    osm_auth: Auth,
+):
+    """Send message to the new project manager after assigned."""
+    log.info(f"Sending message to new project manager ({new_manager.username}).")
+
+    osm_token = get_osm_token(request, osm_auth)
+    project_url = f"{settings.FMTM_DOMAIN}/project/{project.id}"
+    if not project_url.startswith("http"):
+        project_url = f"http://{project_url}"
+
+    message_content = dedent(f"""
+        You have been assigned to the project **{project.name}** as a
+        manager. You can now manage the project and its tasks.
+
+        [Click here to view the project]({project_url})
+
+        Thank you for being a part of our platform!
+    """)
+
+    send_osm_message(
+        osm_token=osm_token,
+        osm_id=new_manager.id,
+        title=f"You have been assigned to project {project.name} as a manager",
+        body=message_content,
+    )
+    log.info(f"Message sent to new project manager ({new_manager.username}).")

--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -32,6 +32,7 @@ from fastapi import (
     Form,
     HTTPException,
     Query,
+    Request,
     Response,
     UploadFile,
 )
@@ -47,6 +48,7 @@ from psycopg import Connection
 
 from app.auth.auth_deps import login_required, mapper_login_required
 from app.auth.auth_schemas import AuthUser, OrgUserDict, ProjectUserDict
+from app.auth.providers.osm import init_osm_auth
 from app.auth.roles import mapper, org_admin, project_manager
 from app.central import central_crud, central_deps, central_schemas
 from app.config import settings
@@ -62,6 +64,7 @@ from app.db.models import (
     DbOdkEntities,
     DbProject,
     DbTask,
+    DbUser,
     DbUserRole,
 )
 from app.db.postgis_utils import (
@@ -75,6 +78,7 @@ from app.db.postgis_utils import (
 from app.organisations import organisation_deps
 from app.projects import project_crud, project_deps, project_schemas
 from app.s3 import delete_all_objs_under_prefix
+from app.users.user_deps import get_user
 
 router = APIRouter(
     prefix="/projects",
@@ -727,18 +731,30 @@ async def upload_custom_extract(
 
 @router.post("/add-manager")
 async def add_new_project_manager(
+    request: Request,
     db: Annotated[Connection, Depends(db_conn)],
-    project_user_dict: Annotated[ProjectUserDict, Depends(project_manager)],
+    background_tasks: BackgroundTasks,
+    new_manager: Annotated[DbUser, Depends(get_user)],
+    org_user_dict: Annotated[OrgUserDict, Depends(org_admin)],
+    osm_auth=Depends(init_osm_auth),
 ):
     """Add a new project manager.
 
-    The logged in user must be either the admin of the organisation or a super admin.
+    The logged in user must be the admin of the organisation.
     """
     await DbUserRole.create(
         db,
-        project_user_dict["project"].id,
-        project_user_dict["user"].id,
+        org_user_dict["project"].id,
+        new_manager.id,
         ProjectRole.PROJECT_MANAGER,
+    )
+
+    background_tasks.add_task(
+        project_crud.send_project_manager_message,
+        request=request,
+        project=org_user_dict["project"],
+        new_manager=new_manager,
+        osm_auth=osm_auth,
     )
     return Response(status_code=HTTPStatus.OK)
 

--- a/src/backend/tests/test_projects_routes.py
+++ b/src/backend/tests/test_projects_routes.py
@@ -431,7 +431,7 @@ async def test_project_summaries(client, project):
 
     assert first_project["id"] == project.id
     assert first_project["name"] == project.name
-    assert first_project["description"] == project.description
+    assert first_project["short_description"] == project.short_description
     assert first_project["hashtags"] == project.hashtags
     assert first_project["organisation_id"] == project.organisation_id
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- Resolves: #1573 

## Describe this PR

Refactored add manager endpoint to only allow organisation admins to assign managers
added code to send osm message and email to the new manager upon assignment

## Screenshots

![image](https://github.com/user-attachments/assets/b238a16d-a1c7-4044-ae71-7387e8584a45)

![image](https://github.com/user-attachments/assets/99ccfc2b-661b-41de-a4d4-43325cdbd9e1)

## Review Guide

Verify project url would work on production.

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
