### PR TITLE
Mapper Navigation: Limit routing API call 

### DIFF
--- a/src/mapper/src/lib/components/dialog-entities-actions.svelte
+++ b/src/mapper/src/lib/components/dialog-entities-actions.svelte
@@ -48,7 +48,8 @@
 
 	const navigateToEntity = () => {
 		if (!entitiesStore.toggleGeolocation) {
-			entitiesStore.setToggleGeolocation(true);
+			alertStore.setAlert({ message: 'Please enable geolocation to navigate to the entity.', variant: 'warning' });
+			return;
 		}
 		entitiesStore.setEntityToNavigate(selectedEntityCoordinate);
 	};

--- a/src/mapper/src/lib/components/map/geolocation.svelte
+++ b/src/mapper/src/lib/components/map/geolocation.svelte
@@ -9,6 +9,7 @@
 	import { getCommonStore } from '$store/common.svelte.ts';
 	import { layers } from '$assets/maplibre-directions.ts';
 	import locationUrl from '$assets/images/location.png';
+	import { untrack } from 'svelte';
 
 	interface Props {
 		map: maplibregl.Map | undefined;
@@ -69,9 +70,17 @@
 	}
 
 	$effect(() => {
-		if (entitiesStore.userLocationCoord && entityToNavigate) {
-			setWaypoints(entitiesStore.userLocationCoord as [number, number], entityToNavigate?.coordinate);
-		}
+		if (!untrack(() => entitiesStore.userLocationCoord) && !entityToNavigate) return;
+		entityToNavigate?.coordinate &&
+			setWaypoints(untrack(() => entitiesStore.userLocationCoord) as [number, number], entityToNavigate?.coordinate);
+		const interval = setInterval(() => {
+			entityToNavigate?.coordinate &&
+				setWaypoints(untrack(() => entitiesStore.userLocationCoord) as [number, number], entityToNavigate?.coordinate);
+		}, 10000);
+
+		return () => {
+			clearInterval(interval);
+		};
 	});
 
 	// if navigation mode on, tilt map by 50 degrees

--- a/src/mapper/src/lib/components/map/geolocation.svelte
+++ b/src/mapper/src/lib/components/map/geolocation.svelte
@@ -69,6 +69,8 @@
 		}
 	}
 
+	// set waypoints for navigation on every 10 seconds if navigation mode is on i.e. entityToNavigate is not null
+	// don't track user geolocation
 	$effect(() => {
 		if (!untrack(() => entitiesStore.userLocationCoord) && !entityToNavigate) return;
 		entityToNavigate?.coordinate &&


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue
- Related to #1888

## Describe this PR
- When navigation mode is enabled, fetch directions API in every 10 seconds rather than fetching on every user geolocation coordinate change (as geolocation coordinates change in every milliseconds)

## Screenshots
N/A