### PR TITLE
Load entities after page load

### DIFF
--- a/src/mapper/src/lib/components/map/main.svelte
+++ b/src/mapper/src/lib/components/map/main.svelte
@@ -423,7 +423,7 @@
 					'#fae15f',
 					'SURVEY_SUBMITTED',
 					'#71bf86',
-					'#c5fbf5', // default color if no match is found
+					'#9c9a9a', // default color if no match is found
 				],
 				'fill-outline-color': [
 					'match',
@@ -434,7 +434,7 @@
 					'#ffd603',
 					'SURVEY_SUBMITTED',
 					'#32a852',
-					'#c5fbf5',
+					'#000000',
 				],
 			}}
 			beforeLayerType="symbol"

--- a/src/mapper/src/routes/[projectId]/+page.svelte
+++ b/src/mapper/src/routes/[projectId]/+page.svelte
@@ -25,6 +25,9 @@
 	import More from '$lib/components/more/index.svelte';
 	import { getProjectSetupStepStore, getCommonStore } from '$store/common.svelte.ts';
 	import { projectSetupStep as projectSetupStepEnum } from '$constants/enums.ts';
+	import { ShapeStream } from '@electric-sql/client';
+
+	const API_URL = import.meta.env.VITE_API_URL;
 
 	interface Props {
 		data: PageData;
@@ -44,7 +47,6 @@
 	const commonStore = getCommonStore();
 
 	const taskEventStream = getTaskEventStream(data.projectId);
-	const entityStatusStream = getEntityStatusStream(data.projectId);
 
 	// Update the geojson task states when a new event is added
 	$effect(() => {
@@ -98,9 +100,6 @@
 	}
 
 	onMount(async () => {
-		// In store/entities.ts
-		await entitiesStore.subscribeToEntityStatusUpdates(entityStatusStream, data.entityStatus);
-
 		// In store/tasks.svelte.ts
 		await taskStore.subscribeToEvents(taskEventStream);
 		await taskStore.appendTaskStatesToFeatcol(data.project.tasks);
@@ -108,9 +107,25 @@
 
 	onDestroy(() => {
 		taskEventStream?.unsubscribeAll();
-		entityStatusStream?.unsubscribeAll();
 	});
 
+	$effect(() => {
+		let entityStatusStream: ShapeStream | undefined;
+
+		async function getEntityStatus() {
+			const entityStatusResponse = await fetch(`${API_URL}/projects/${data.projectId}/entities/statuses`, {
+				credentials: 'include',
+			});
+			const response = await entityStatusResponse.json();
+			entityStatusStream = getEntityStatusStream(data.projectId);
+			await entitiesStore.subscribeToEntityStatusUpdates(entityStatusStream, response);
+		}
+
+		getEntityStatus();
+		return () => {
+			entityStatusStream?.unsubscribeAll();
+		};
+	});
 	const projectSetupStepStore = getProjectSetupStepStore();
 
 	$effect(() => {

--- a/src/mapper/src/routes/[projectId]/+page.ts
+++ b/src/mapper/src/routes/[projectId]/+page.ts
@@ -36,15 +36,11 @@ export const load: PageLoad = async ({ parent, params, fetch }) => {
 	if (projectResponse.status === 404) {
 		throw error(404, { message: `Project with ID (${projectId}) not found` });
 	}
-	const entityStatusResponse = await fetch(`${API_URL}/projects/${projectId}/entities/statuses`, {
-		credentials: 'include',
-	});
 
 	return {
 		project: await projectResponse.json(),
 		projectId: parseInt(projectId),
 		userId: apiUser.id,
-		entityStatus: await entityStatusResponse.json(),
 		// db: db,
 	};
 };


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [x] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue
The initial mapper frontend page load is too slow due to the `/entities/statuses` API call which leads to a blank white screen for some time. 
The slow API is blocking the UI from being rendered.

## Describe this PR
The /entities/statuses API is called after the UI load rather than before which speeds up the UI load. 

## Screenshots
[Screencast from 2-1-25 09:42:48 पूर्वाह्न +0545.webm](https://github.com/user-attachments/assets/ec0727dc-ef77-43c2-be36-d325dda6d51c)