### PR TITLE
fixed running gen-env.sh on MacOS

### DIFF
--- a/scripts/1-environment/gen-env.sh
+++ b/scripts/1-environment/gen-env.sh
@@ -324,7 +324,7 @@ set_osm_credentials() {
 
     export OSM_CLIENT_ID=${OSM_CLIENT_ID}
     export OSM_CLIENT_SECRET=${OSM_CLIENT_SECRET}
-    secret_key=$(tr -dc 'a-zA-Z0-9' </dev/urandom | head -c 50)
+    secret_key=$(base64 </dev/urandom | tr -dc 'a-zA-Z0-9' | head -c 50)
     export OSM_SECRET_KEY=${secret_key}
 }
 


### PR DESCRIPTION
enables running gen-env.sh on MacOS

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

None

## Describe this PR

Converts random bytes from /dev/urandom to base64 to avoid passing non-ascii characters to tr and avoiding this error being thrown by tr `tr: Illegal byte sequence`


## Screenshots
<img width="576" alt="Screenshot 2025-01-12 at 9 37 28 PM" src="https://github.com/user-attachments/assets/03a4ec1a-cb4a-403f-96cc-d1282772cf90" />



## Alternative Approaches Considered
I considered looking for a native uuid or crypto library that could generate random characters, but I think the way proposed most directly fixes the issue.

## Review Guide

Notes for the reviewer. How to test this change?

Follow instructions here: https://docs.fmtm.dev/INSTALL/#2-create-an-env-file

If you are on MacOS, this will test if the bug is fixed.
If you are on Linux, this will test to make sure we don't introduce a regression.

If you already have a .env file created, you'll have to rename it while you test this PR.

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
🐢 steady progress