### PR TITLE
fixed running docker compose up ui-mapper on MacOS by upgrading node version

### DIFF
--- a/src/Dockerfile.ui.debug
+++ b/src/Dockerfile.ui.debug
@@ -1,4 +1,4 @@
-FROM docker.io/node:20-slim
+FROM docker.io/node:23-slim
 RUN set -ex \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install \

--- a/src/Dockerfile.ui.debug
+++ b/src/Dockerfile.ui.debug
@@ -1,4 +1,4 @@
-FROM docker.io/node:23-slim
+FROM docker.io/node:22-slim
 RUN set -ex \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install \

--- a/src/Dockerfile.ui.prod
+++ b/src/Dockerfile.ui.prod
@@ -1,4 +1,4 @@
-FROM docker.io/node:20-slim AS base
+FROM docker.io/node:22-slim AS base
 ARG VITE_API_URL
 ARG VITE_SYNC_URL
 ENV VITE_API_URL=${VITE_API_URL} \


### PR DESCRIPTION

## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue
I was running into a Segmentation Fault issue when I was trying to run `docker compose up --build ui-mapper`.

## Describe this PR

Basically just upgrades from Node 20 to Node 23

## Screenshots

Screenshot of it working on a MacOS
<img width="740" alt="Screenshot 2025-01-22 at 10 23 24 PM" src="https://github.com/user-attachments/assets/b428bab8-0684-4ead-a8da-5d9a27fa52fc" />

## Alternative Approaches Considered

Tried installing pnpm with `npm install -g pnpm@version` which seemed to help a little but still ran into seg fault issues when running vite.  I think the issue is a fundamental issue with older versions of NodeJS. 

## Review Guide

Notes for the reviewer. How to test this change?
I ran the docker compose command and the application seemed to run.  I haven't done any further testing.

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
