### PR TITLE
Delete submission photos while deleting project to avoid foreign key constraint

### DIFF
--- a/src/backend/app/db/models.py
+++ b/src/backend/app/db/models.py
@@ -1359,6 +1359,12 @@ class DbProject(BaseModel):
         async with db.cursor() as cur:
             await cur.execute(
                 """
+                DELETE FROM submission_photos WHERE project_id = %(project_id)s;
+            """,
+                {"project_id": project_id},
+            )
+            await cur.execute(
+                """
                 DELETE FROM background_tasks WHERE project_id = %(project_id)s;
             """,
                 {"project_id": project_id},


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- There was an issue while deleting projects that have photos in the submissions, throwing an error of foreignkey constraint, as we do have a separate table to store image urls linking with projects. 

## Describe this PR

This PR adds a sql to delete submission photos linked to that particular project from table before deleting project.

## Screenshots

N/A

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
