### PR TITLE
Allow users to select default odk credentials irrespective of organisation

### DIFF
--- a/src/frontend/src/components/createnewproject/ProjectDetailsForm.tsx
+++ b/src/frontend/src/components/createnewproject/ProjectDetailsForm.tsx
@@ -113,8 +113,7 @@ const ProjectDetailsForm = ({ flag }) => {
   }, [organisationList]);
 
   const shouldShowCustomODKFields = () => {
-    const currentOrg = getSelectedOrganization();
-    return !values.useDefaultODKCredentials || !currentOrg?.hasODKCredentials;
+    return !values.useDefaultODKCredentials;
   };
 
   return (


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- Issue: #2140 

## Describe this PR

Whenever users select an organisation without any default ODK credentials, they are suggested to provide credentials input. But if they wish to use default ODK credentials, they should be allowed to use the default from HOTOSM. So there was an issue when they checked the box to use default ODK credentials; the custom ODK fields input was still shown.

So I removed the logic tied with the organisation in order to show custom ODK fields; this PR only checks if the user has checked the box or not. Based on that, the custom fields to provide credentials are shown.

## Screenshots

I. When no org is selected:
![image](https://github.com/user-attachments/assets/f06052ce-7aa0-40a5-afb3-08256804ca79)

II. When org without default odk creds is selected:
![image](https://github.com/user-attachments/assets/91c472d6-b02c-4846-b312-d4129bd7610f)

III. When user checks to box to use default creds:
![image](https://github.com/user-attachments/assets/b3c848ce-f56d-446b-b1f5-5aef2473c9c8)

IV. When org with default odk creds is selected:
check box is auto checked
![image](https://github.com/user-attachments/assets/c44861d9-11bc-4e80-a11e-891773338af6)

V. When user checks to box to use default creds even though org has its own creds:
![image](https://github.com/user-attachments/assets/d80ee703-ff02-4578-b2de-4b5a0c75a607)


## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
