### PR TITLE
Clear tiles from disk after generation

### DIFF
--- a/src/backend/app/projects/project_crud.py
+++ b/src/backend/app/projects/project_crud.py
@@ -18,6 +18,7 @@
 """Logic for FMTM project routes."""
 
 import json
+import shutil
 import uuid
 from io import BytesIO
 from pathlib import Path
@@ -801,8 +802,6 @@ def generate_project_basemap(
             f"{settings.S3_DOWNLOAD_ROOT}/{settings.S3_BUCKET_NAME}/{basemap_s3_path}"
         )
         log.info(f"Upload of basemap to S3 complete: {basemap_external_s3_url}")
-        # Delete file on disk
-        Path(outfile).unlink(missing_ok=True)
 
         update_basemap_sync = async_to_sync(DbBasemap.update)
         update_basemap_sync(
@@ -845,6 +844,10 @@ def generate_project_basemap(
                 message=str(e),
             ),
         )
+    finally:
+        log.info(f"Cleaned up tiles directory: {tiles_dir}")
+        Path(outfile).unlink(missing_ok=True)
+        shutil.rmtree(tiles_dir)
 
 
 # async def convert_geojson_to_osm(geojson_file: str):


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- Issue: #2152

## Describe this PR

There was issue of tiles not being cleared from disk after successfully generating tiles, consequently consuming larger volume. This PR adds a line of code that removes the tile directory from disk `/opt/tiles` after generating it.

## Screenshots

N/A

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
