### PR TITLE
Support big integer osm ids

### DIFF
--- a/src/backend/app/db/postgis_utils.py
+++ b/src/backend/app/db/postgis_utils.py
@@ -84,7 +84,7 @@ async def featcol_to_flatgeobuf(
             -- Wrap geometries in GeometryCollection
             CREATE TEMP TABLE IF NOT EXISTS temp_features(
                 geom geometry(GeometryCollection, 4326),
-                osm_id integer,
+                osm_id bigint,
                 tags text,
                 version integer,
                 changeset integer,
@@ -101,7 +101,7 @@ async def featcol_to_flatgeobuf(
                 ST_ForceCollection(ST_GeomFromGeoJSON(feat->>'geometry')) AS geom,
                 regexp_replace(
                     (feat->'properties'->>'osm_id')::text, '[^0-9]', '', 'g'
-                )::integer as osm_id,
+                )::BIGINT as osm_id,
                 (feat->'properties'->>'tags')::text as tags,
                 (feat->'properties'->>'version')::integer as version,
                 (feat->'properties'->>'changeset')::integer as changeset,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- I encountered some issue while uploading custom data extracts which has big integer values in osm id

## Describe this PR

This PR fixes a minor issue where big integers are not supported for OSM IDs while uploading custom data extracts; it may occur while generating OSM extracts too. The issue was during creating temporary table to convert featcol to flatgeobuf.

## Screenshots

N/A

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
