### PR TITLE
make sure route /{project_id}/form-xml returns plain xml string

### DIFF
--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -946,12 +946,14 @@ async def get_project_form_xml_route(
     odkid = project.odkid
     odk_form_id = project.odk_form_id
     # Run separate thread in event loop to avoid blocking with sync code
-    return await run_in_threadpool(
+    form_xml = await run_in_threadpool(
         central_crud.get_project_form_xml,
         odk_creds,
         odkid,
         odk_form_id,
     )
+    return Response(content=form_xml, media_type="application/xml")
+
 
 
 @router.post("/{project_id}/generate-project-data")

--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -955,7 +955,6 @@ async def get_project_form_xml_route(
     return Response(content=form_xml, media_type="application/xml")
 
 
-
 @router.post("/{project_id}/generate-project-data")
 async def generate_files(
     db: Annotated[Connection, Depends(db_conn)],


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue
Fast API was assuming the return for the `/{project_id}/form-xml` endpoint was JSON, so it stringified/quoted the xml string like it was a JSON string.

## Describe this PR

Force Fast API to recognize that the output isn't JSON and doesn't need to be quoted.

Please see this reference page: https://fastapi.tiangolo.com/advanced/custom-response/
And search for "application/xml" on the reference page:
<img width="803" alt="Screenshot 2025-02-16 at 6 28 42 PM" src="https://github.com/user-attachments/assets/96831cc6-f208-4f4a-bf5c-b43e4807434c" />


## Screenshots

N/A

## Alternative Approaches Considered

N/A

## Review Guide

Notes for the reviewer. How to test this change?
Go to http://api.fmtm.localhost:7050/projects/1/form-xml and see that the return doesn't have any `\"` anymore

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
