### PR TITLE
add manual_geopoint to submission geojson download

### DIFF
--- a/src/backend/app/central/central_crud.py
+++ b/src/backend/app/central/central_crud.py
@@ -448,6 +448,30 @@ async def convert_odk_submission_json_to_geojson(
         data = {}
         flatten_json(submission, data)
 
+        try:
+            manual_geopoint = submission["survery_questions"]["group_1"]["manual_geopoint"]
+        except (KeyError, IndexError) as e:
+            log.warning(e)
+            manual_geopoint = None
+
+        if manual_geopoint:
+            manual_geopoint_geom = {
+                "type": manual_geopoint["type"],
+                "coordinates": manual_geopoint["coordinates"][:2],  # Use only [lon, lat]
+            }
+            # Add manual_geopoint as a separate feature
+            manual_geopoint_feature = geojson.Feature(
+                id="manual_geopoint",
+                geometry=manual_geopoint_geom,
+                properties={
+                    "is_manual_geopoint": True,
+                    "description": "Manually placed gate point",
+                    "accuracy": manual_geopoint["properties"]["accuracy"],
+                    "xid": data["xid"] if "xid" in data else None,  # Link to submission
+                },
+            )
+            all_features.append(manual_geopoint_feature)
+
         # Process primary geometry
         geojson_geom = await javarosa_to_geojson_geom(data.pop("xlocation", {}))
 

--- a/src/backend/app/central/central_crud.py
+++ b/src/backend/app/central/central_crud.py
@@ -449,7 +449,9 @@ async def convert_odk_submission_json_to_geojson(
         flatten_json(submission, data)
 
         try:
-            manual_geopoint = submission["survery_questions"]["group_1"]["manual_geopoint"]
+            manual_geopoint = submission["survery_questions"]["group_1"][
+                "manual_geopoint"
+            ]
         except (KeyError, IndexError) as e:
             log.warning(e)
             manual_geopoint = None
@@ -457,7 +459,9 @@ async def convert_odk_submission_json_to_geojson(
         if manual_geopoint:
             manual_geopoint_geom = {
                 "type": manual_geopoint["type"],
-                "coordinates": manual_geopoint["coordinates"][:2],  # Use only [lon, lat]
+                "coordinates": manual_geopoint["coordinates"][
+                    :2
+                ],  # Use only [lon, lat]
             }
             # Add manual_geopoint as a separate feature
             manual_geopoint_feature = geojson.Feature(


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

When filtering through submissions, we should be able to download in .GeoJSON format which should also contain manual geopoint in it

## Describe this PR

submission geojson download will now also contain manual geopoints in it as features alongside the submission polygons
