### PR TITLE
Change user role to org admin in user list endpoint

### DIFF
--- a/src/backend/app/users/user_routes.py
+++ b/src/backend/app/users/user_routes.py
@@ -23,7 +23,7 @@ from fastapi import APIRouter, Depends, Query, Response
 from loguru import logger as log
 from psycopg import Connection
 
-from app.auth.roles import mapper, project_manager, super_admin
+from app.auth.roles import mapper, org_admin, super_admin
 from app.db.database import db_conn
 from app.db.enums import HTTPStatus
 from app.db.enums import UserRole as UserRoleEnum
@@ -42,7 +42,7 @@ router = APIRouter(
 @router.get("", response_model=user_schemas.PaginatedUsers)
 async def get_users(
     db: Annotated[Connection, Depends(db_conn)],
-    current_user: Annotated[DbUser, Depends(project_manager)],
+    current_user: Annotated[DbUser, Depends(org_admin)],
     page: int = Query(1, ge=1),
     results_per_page: int = Query(13, le=100),
     search: str = None,

--- a/src/frontend/src/api/User.ts
+++ b/src/frontend/src/api/User.ts
@@ -55,7 +55,7 @@ export const UpdateUserRole = (url: string, payload: { role: 'READ_ONLY' | 'ADMI
 
 export const GetUserListForSelect = (
   url: string,
-  params: { page: number; results_per_page: number; search: string },
+  params: { page: number; org_id: number; results_per_page: number; search: string },
 ) => {
   return async (dispatch: AppDispatch) => {
     dispatch(UserActions.SetUserListForSelectLoading(true));

--- a/src/frontend/src/components/createnewproject/ProjectDetailsForm.tsx
+++ b/src/frontend/src/components/createnewproject/ProjectDetailsForm.tsx
@@ -46,6 +46,7 @@ const ProjectDetailsForm = ({ flag }) => {
     hasODKCredentials: item?.odk_central_url ? true : false,
   }));
   const [hasODKCredentials, setHasODKCredentials] = useState(false);
+  const [userSearchText, setUserSearchText] = useState('');
 
   const submission = () => {
     dispatch(CreateProjectActions.SetIndividualProjectDetailsData(values));
@@ -105,6 +106,23 @@ const ProjectDetailsForm = ({ flag }) => {
       handleCustomChange('odk_central_password', '');
     }
   }, [values.useDefaultODKCredentials]);
+
+  useEffect(() => {
+    if (!userSearchText) return;
+    if (!values.organisation_id && userSearchText) {
+      dispatch(CommonActions.SetSnackBar({ message: 'Please select an organization', variant: 'warning' }));
+      return;
+    }
+
+    dispatch(
+      GetUserListForSelect(`${VITE_API_URL}/users`, {
+        search: userSearchText,
+        page: 1,
+        results_per_page: 30,
+        org_id: values.organisation_id,
+      }),
+    );
+  }, [userSearchText]);
 
   useEffect(() => {
     if (isEmpty(organisationList)) return;
@@ -223,9 +241,7 @@ const ProjectDetailsForm = ({ flag }) => {
               isLoading={userListLoading}
               handleApiSearch={(value) => {
                 if (value) {
-                  dispatch(
-                    GetUserListForSelect(`${VITE_API_URL}/users`, { search: value, page: 1, results_per_page: 30 }),
-                  );
+                  setUserSearchText(value);
                 } else {
                   dispatch(UserActions.SetUserListForSelect([]));
                 }


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- Previously, the project admin role was used to fetch the users list, thinking that one project admin can add another project admin but during project creation we won't have project id to check if the user is project admin or not since to create project they need to be org admin

## Describe this PR

- Update role dependency to `org_admin` in backend to fetch users list
- Passed org id as a query param from frontend

## Screenshots

N/A

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
