### PR TITLE
Set osm_id property to negative value if the geom is not from OSM

### DIFF
--- a/src/backend/app/db/postgis_utils.py
+++ b/src/backend/app/db/postgis_utils.py
@@ -325,13 +325,21 @@ def add_required_geojson_properties(
             properties["osm_id"] = feature_id
         else:
             osm_id = (
-                properties.get("osm_id")
+                properties.get(
+                    "osm_id"
+                )  # osm_id property takes priority (i.e. it's from OSM)
                 or properties.get("id")
-                or properties.get("fid")
+                or properties.get("fid")  # fid is typical from tools like QGIS
                 # Random id
                 # NOTE 32-bit int is max supported by standard postgres Integer
                 or getrandbits(30)
             )
+
+            # Ensure negative osm_id if it's derived
+            # NOTE this is important to denote the geom is not from OSM
+            if not properties.get("osm_id"):
+                osm_id = -abs(int(osm_id))
+
             feature["id"] = str(osm_id)
             properties["osm_id"] = osm_id
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixes https://github.com/hotosm/osm-fieldwork/issues/344, as we no longer will create entities via XLSForm (moved to entity creation via API)

## Describe this PR

- Rob suggested this is a convention: negative numbers for geoms that come from outside OSM.
- Updated the mandatory fields check to reflect that.
- Hopefully doesn't break anywhere we use the `osm_id` in the code 🤞 

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
