### PR TITLE
Add endpoint to upload form media such as images, videos, audio

### DIFF
--- a/src/backend/app/central/central_deps.py
+++ b/src/backend/app/central/central_deps.py
@@ -21,6 +21,7 @@
 from contextlib import asynccontextmanager
 from io import BytesIO
 from pathlib import Path
+from typing import Optional
 
 from fastapi import UploadFile
 from fastapi.exceptions import HTTPException
@@ -79,3 +80,13 @@ async def validate_xlsform_extension(xlsform: UploadFile):
 async def read_xlsform(xlsform: UploadFile) -> BytesIO:
     """Read an XLSForm, validate extension, return wrapped in BytesIO."""
     return await validate_xlsform_extension(xlsform)
+
+
+async def read_form_media(
+    media_uploads: list[UploadFile],
+) -> Optional[dict[str, BytesIO]]:
+    """Read all uploaded form media for upload to ODK Central."""
+    file_data_dict = {
+        file.filename: BytesIO(await file.read()) for file in media_uploads
+    }
+    return file_data_dict


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Work towards #2075

## Describe this PR

- Endpoint to upload media attachments for a form.
- They must be **predefined** in the form beforehand.
- Perhaps this can be refactored to work the same was as additional datasets code (where we receive the additional datasets from the user during project creation, then we inject the fields in the XLSForm automatically).
  - This would be pretty tricky to implement though without knowing for which field the media is associated, what data type is it (image, video, audio), etc. Perhaps best left for when we have an interactive form builder?
- Example
  - MDP form with `mdp.png` attachment defined on category selection field: [mdp_xlsform.xlsx](https://github.com/user-attachments/files/19234317/mdp_xlsform.xlsx)
  - The png file to upload via this endpoint: [mdp.png](https://github.com/user-attachments/assets/de1e234e-7a60-4a7d-9438-17ef76b802ce)
  - The first question should have icons in ODK Collect, and in the future web-forms too.

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
