### PR TITLE
hide conflicting footer when web forms drawer is open

### DIFF
--- a/src/mapper/src/lib/components/dialog-entities-actions.svelte
+++ b/src/mapper/src/lib/components/dialog-entities-actions.svelte
@@ -3,7 +3,7 @@
 	import type { Coord } from '@turf/helpers';
 	import type { SlDialog, SlDrawer } from '@shoelace-style/shoelace';
 
-	import { m } from "$translations/messages.js";
+	import { m } from '$translations/messages.js';
 	import { TaskStatusEnum, type ProjectData } from '$lib/types';
 	import { getEntitiesStatusStore } from '$store/entities.svelte.ts';
 	import { getAlertStore } from '$store/common.svelte.ts';
@@ -16,7 +16,7 @@
 		toggleTaskActionModal: (value: boolean) => void;
 		selectedTab: string;
 		projectData: ProjectData;
-		webFormsDrawerRef: SlDrawer | undefined;
+		displayWebFormsDrawer: Boolean;
 	};
 
 	function getStatusStyle(status: statusType) {
@@ -34,7 +34,13 @@
 		}
 	}
 
-	let { isTaskActionModalOpen, toggleTaskActionModal, selectedTab, projectData, webFormsDrawerRef }: Props = $props();
+	let {
+		isTaskActionModalOpen,
+		toggleTaskActionModal,
+		selectedTab,
+		projectData,
+		displayWebFormsDrawer = $bindable(false),
+	}: Props = $props();
 
 	let dialogRef: SlDialog | null = $state(null);
 	let toggleDistanceWarningDialog = $state(false);
@@ -279,12 +285,12 @@
 								class="primary flex-grow"
 								onclick={() => {
 									toggleTaskActionModal(false);
-									webFormsDrawerRef?.show();
+									displayWebFormsDrawer = true;
 								}}
 								onkeydown={(e: KeyboardEvent) => {
 									if (e.key === 'Enter') {
 										toggleTaskActionModal(false);
-										webFormsDrawerRef?.show();
+										displayWebFormsDrawer = true;
 									}
 								}}
 								role="button"

--- a/src/mapper/src/lib/components/forms/wrapper.svelte
+++ b/src/mapper/src/lib/components/forms/wrapper.svelte
@@ -5,13 +5,14 @@
 
 	const API_URL = import.meta.env.VITE_API_URL;
 	type Props = {
-		drawerRef: SlDrawer | undefined;
+		display: Boolean;
 		entityId: string | undefined;
 		projectId: number | undefined;
 		webFormsRef: HTMLElement | undefined;
 	};
 	const commonStore = getCommonStore();
-	let { drawerRef = $bindable(undefined), entityId, webFormsRef = $bindable(undefined), projectId }: Props = $props();
+	let { display = $bindable(false), entityId, webFormsRef = $bindable(undefined), projectId }: Props = $props();
+	let drawerRef: SlDrawer;
 	let iframeRef: HTMLIFrameElement;
 	let odkForm: any;
 	// to-do: hide drawer upon successful submission
@@ -25,7 +26,7 @@
 				method: 'POST',
 				body: data,
 			});
-			drawerRef?.hide();
+			display = false;
 		})();
 	}
 	function handleOdkForm(evt: any) {
@@ -63,7 +64,7 @@
 		entityId;
 		if (iframeRef) {
 			const intervalId = setInterval(() => {
-				webFormsRef = iframeRef.contentDocument?.querySelector('odk-web-form') || undefined;
+				webFormsRef = iframeRef?.contentDocument?.querySelector('odk-web-form') || undefined;
 				if (webFormsRef) {
 					clearInterval(intervalId);
 					webFormsRef.addEventListener('submit', handleSubmit);
@@ -76,12 +77,22 @@
 			};
 		}
 	});
+	$effect(() => {
+		if (drawerRef) {
+			drawerRef.addEventListener('sl-hide', function () {
+				if (display) {
+					display = false;
+				}
+			});
+		}
+	});
 </script>
 
 <hot-drawer
 	id="odk-web-forms-drawer"
 	bind:this={drawerRef}
 	contained
+	open={display}
 	placement="start"
 	class="drawer-contained drawer-placement-start drawer-overview"
 	style="--size: 100vw; --header-spacing: 0px"

--- a/src/mapper/src/routes/[projectId]/+page.svelte
+++ b/src/mapper/src/routes/[projectId]/+page.svelte
@@ -10,7 +10,7 @@
 	import type SlTabGroup from '@shoelace-style/shoelace/dist/components/tab-group/tab-group.component.js';
 	import type SlDialog from '@shoelace-style/shoelace/dist/components/dialog/dialog.component.js';
 
-	import { m } from "$translations/messages.js";
+	import { m } from '$translations/messages.js';
 	import ImportQrGif from '$assets/images/importQr.gif';
 	import BottomSheet from '$lib/components/bottom-sheet.svelte';
 	import MapComponent from '$lib/components/map/main.svelte';
@@ -35,8 +35,8 @@
 
 	let { data }: Props = $props();
 
-	let odkWebFormsWrapperRef: SlDrawer | undefined = $state();
 	let webFormsRef: HTMLElement | undefined = $state();
+	let displayWebFormsDrawer = $state(false);
 
 	let maplibreMap: maplibregl.Map | undefined = $state(undefined);
 	let tabGroup: SlTabGroup;
@@ -290,7 +290,7 @@
 		}}
 		selectedTab={commonStore.selectedTab}
 		projectData={data?.project}
-		webFormsDrawerRef={odkWebFormsWrapperRef}
+		bind:displayWebFormsDrawer
 	/>
 	{#if commonStore.selectedTab !== 'map'}
 		<BottomSheet onClose={() => tabGroup.show('map')}>
@@ -344,40 +344,42 @@
 		</hot-dialog>
 	{/if}
 
-	<sl-tab-group
-		class="z-9999 fixed bottom-0 left-0 right-0"
-		placement="bottom"
-		no-scroll-controls
-		onsl-tab-show={(e: CustomEvent<{ name: string }>) => {
-			commonStore.setSelectedTab(e.detail.name);
-			if (
-				e.detail.name !== 'qrcode' &&
-				+(projectSetupStepStore.projectSetupStep || 0) === projectSetupStepEnum['odk_project_load']
-			) {
-				localStorage.setItem(`project-${data.projectId}-setup`, projectSetupStepEnum['task_selection'].toString());
-				projectSetupStepStore.setProjectSetupStep(projectSetupStepEnum['task_selection']);
-			}
-		}}
-		style="--panel-display: none"
-		bind:this={tabGroup}
-	>
-		<sl-tab slot="nav" panel="map">
-			<hot-icon name="map" class="!text-[1.7rem] !sm:text-[2rem]"></hot-icon>
-		</sl-tab>
-		<sl-tab slot="nav" panel="offline">
-			<hot-icon name="wifi-off" class="!text-[1.7rem] !sm:text-[2rem]"></hot-icon>
-		</sl-tab>
-		<sl-tab slot="nav" panel="qrcode">
-			<hot-icon name="qr-code" class="!text-[1.7rem] !sm:text-[2rem]"></hot-icon>
-		</sl-tab>
-		<sl-tab slot="nav" panel="events">
-			<hot-icon name="three-dots" class="!text-[1.7rem] !sm:text-[2rem]"></hot-icon>
-		</sl-tab>
-	</sl-tab-group>
+	{#if displayWebFormsDrawer === false}
+		<sl-tab-group
+			class={'z-9999 fixed bottom-0 left-0 right-0'}
+			placement="bottom"
+			no-scroll-controls
+			onsl-tab-show={(e: CustomEvent<{ name: string }>) => {
+				commonStore.setSelectedTab(e.detail.name);
+				if (
+					e.detail.name !== 'qrcode' &&
+					+(projectSetupStepStore.projectSetupStep || 0) === projectSetupStepEnum['odk_project_load']
+				) {
+					localStorage.setItem(`project-${data.projectId}-setup`, projectSetupStepEnum['task_selection'].toString());
+					projectSetupStepStore.setProjectSetupStep(projectSetupStepEnum['task_selection']);
+				}
+			}}
+			style="--panel-display: none"
+			bind:this={tabGroup}
+		>
+			<sl-tab slot="nav" panel="map">
+				<hot-icon name="map" class="!text-[1.7rem] !sm:text-[2rem]"></hot-icon>
+			</sl-tab>
+			<sl-tab slot="nav" panel="offline">
+				<hot-icon name="wifi-off" class="!text-[1.7rem] !sm:text-[2rem]"></hot-icon>
+			</sl-tab>
+			<sl-tab slot="nav" panel="qrcode">
+				<hot-icon name="qr-code" class="!text-[1.7rem] !sm:text-[2rem]"></hot-icon>
+			</sl-tab>
+			<sl-tab slot="nav" panel="events">
+				<hot-icon name="three-dots" class="!text-[1.7rem] !sm:text-[2rem]"></hot-icon>
+			</sl-tab>
+		</sl-tab-group>
+	{/if}
 
 	<OdkWebFormsWrapper
-		bind:drawerRef={odkWebFormsWrapperRef}
 		bind:webFormsRef
+		bind:display={displayWebFormsDrawer}
 		projectId={data?.projectId}
 		entityId={selectedEntityId}
 	/>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation
- [x] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixes issue where bottom footer was appearing when the web forms panel was open

## Describe this PR

Basically creates a bindable display variable at the page level that is passed down to the entity action buttons and the web forms drawer.  When changes are made, this percolates up to the top level variable which is then used in an if statement to hide the footer.

## Screenshots
<img width="785" alt="Screenshot 2025-03-16 at 3 34 26 PM" src="https://github.com/user-attachments/assets/d305b5a3-a54e-4af4-a95f-05dedf6fe087" />



## Alternative Approaches Considered

We could have set display to none, turn off the z-999 class, or manually set the z-index to 0.  However, I felt a simple if statement was the most intuitive.

## Review Guide
- go to http://mapper.fmtm.localhost:7050/1?webforms=true
- click on an area
- click on a building
- click on "MAP IN ODK WEB FORMS"
- the web forms should slide in from the slide and the footer should disappear

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
