### PR TITLE
fix: Submission details page crashing when trying to render null value

### DIFF
--- a/src/frontend/src/views/SubmissionDetails.tsx
+++ b/src/frontend/src/views/SubmissionDetails.tsx
@@ -62,7 +62,7 @@ const SubmissionDetails = () => {
           </p>
         </>
       );
-    } else if (typeof value === 'object' && Object.values(value).includes('Point')) {
+    } else if (typeof value === 'object' && value !== null && Object.values(value).includes('Point')) {
       return (
         <>
           {renderValue(
@@ -73,7 +73,7 @@ const SubmissionDetails = () => {
           {renderValue(value?.properties?.accuracy, 'accuracy')}
         </>
       );
-    } else if (typeof value === 'object') {
+    } else if (typeof value === 'object' && value !== null) {
       return (
         <ul className="fmtm-flex fmtm-flex-col fmtm-gap-1">
           <Accordion


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Submission details page will crash when it attempts to render a null value, because it will try to call Object.values(null), which throws an error.

## Describe this PR

I specifically encountered this issue when working on web forms photo upload.  I'm thinking we probably want to gracefully handle errors, so an error in one part doesn't crash the whole page.  In theory, there could be a network issue and not a code issue, too.

## Screenshots

N/A

## Alternative Approaches Considered

I've been trying to fix a local issue I'm having with web forms and photo upload, but I'm thinking it would be a good idea to have this page be more resilient to random issues.

## Review Guide
- go to a submission details page like http://fmtm.localhost:7050/project-submissions/1/tasks/3/submission/uuid:4b14699b-fd93-45b6-9aef-6a88ad217bb4

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
