### PR TITLE
Align task lock icon within task area

### DIFF
--- a/src/frontend/package.json
+++ b/src/frontend/package.json
@@ -74,6 +74,7 @@
     "@tiptap/pm": "^2.4.0",
     "@tiptap/react": "^2.4.0",
     "@tiptap/starter-kit": "^2.4.0",
+    "@turf/centroid": "^7.2.0",
     "axios": "^1.7.2",
     "clsx": "^2.1.1",
     "cmdk": "^1.0.4",

--- a/src/frontend/pnpm-lock.yaml
+++ b/src/frontend/pnpm-lock.yaml
@@ -95,6 +95,9 @@ importers:
       '@tiptap/starter-kit':
         specifier: ^2.4.0
         version: 2.4.0(@tiptap/pm@2.4.0)
+      '@turf/centroid':
+        specifier: ^7.2.0
+        version: 7.2.0
       axios:
         specifier: ^1.7.2
         version: 1.7.2
@@ -1633,6 +1636,15 @@ packages:
   '@tootallnate/once@2.0.0':
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
+
+  '@turf/centroid@7.2.0':
+    resolution: {integrity: sha512-yJqDSw25T7P48au5KjvYqbDVZ7qVnipziVfZ9aSo7P2/jTE7d4BP21w0/XLi3T/9bry/t9PR1GDDDQljN4KfDw==}
+
+  '@turf/helpers@7.2.0':
+    resolution: {integrity: sha512-cXo7bKNZoa7aC7ydLmUR02oB3IgDe7MxiPuRz3cCtYQHn+BJ6h1tihmamYDWWUlPHgSNF0i3ATc4WmDECZafKw==}
+
+  '@turf/meta@7.2.0':
+    resolution: {integrity: sha512-igzTdHsQc8TV1RhPuOLVo74Px/hyPrVgVOTgjWQZzt3J9BVseCdpfY/0cJBdlSRI4S/yTmmHl7gAqjhpYH5Yaw==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -3926,6 +3938,9 @@ packages:
   tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
 
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -5617,6 +5632,23 @@ snapshots:
 
   '@tootallnate/once@2.0.0':
     optional: true
+
+  '@turf/centroid@7.2.0':
+    dependencies:
+      '@turf/helpers': 7.2.0
+      '@turf/meta': 7.2.0
+      '@types/geojson': 7946.0.14
+      tslib: 2.8.1
+
+  '@turf/helpers@7.2.0':
+    dependencies:
+      '@types/geojson': 7946.0.14
+      tslib: 2.8.1
+
+  '@turf/meta@7.2.0':
+    dependencies:
+      '@turf/helpers': 7.2.0
+      '@types/geojson': 7946.0.14
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -8319,6 +8351,8 @@ snapshots:
   ts-interface-checker@0.1.13: {}
 
   tslib@2.6.2: {}
+
+  tslib@2.8.1: {}
 
   type-check@0.4.0:
     dependencies:

--- a/src/frontend/src/utilfunctions/getTaskStatusStyle.ts
+++ b/src/frontend/src/utilfunctions/getTaskStatusStyle.ts
@@ -1,9 +1,10 @@
 import { Fill, Icon, Stroke, Style } from 'ol/style';
-import { asArray, asString } from 'ol/color';
-import { getCenter } from 'ol/extent';
+import { asArray } from 'ol/color';
 import { Point } from 'ol/geom';
 import AssetModules from '@/shared/AssetModules';
 import { GeoGeomTypesEnum } from '@/types/enums';
+import { centroid } from '@turf/centroid';
+import getFeatureGeojson from '@/components/MapComponent/OpenLayersComponent/helpers/getFeatureGeojson';
 
 function createPolygonStyle(fillColor: string, strokeColor: string) {
   return new Style({
@@ -43,7 +44,8 @@ function createIconStyle(iconSrc: string, scale: number = 0.8, color: any = 'red
       opacity: 1,
     }),
     geometry: function (feature) {
-      const polygonCentroid = getCenter(feature.getGeometry().getExtent());
+      const polygonCoord = getFeatureGeojson(feature, {});
+      const polygonCentroid = centroid(polygonCoord)?.geometry?.coordinates;
       return new Point(polygonCentroid);
     },
   });


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue
- Related to #2235

## Describe this PR
- Use `turf/centroid` to calculate the centroid of the task area. Previously it was calculated using task extent center that made irregularly shaped tasks lock icon to fall outside its area.

## Screenshots
Before: 
![Screenshot from 2025-03-26 14-23-13](https://github.com/user-attachments/assets/9ecc927d-3ea7-47b7-ab2e-0c82ded278dd)

After:
![Screenshot from 2025-03-26 14-24-36](https://github.com/user-attachments/assets/3c2c0690-c059-4822-91ce-bca2776ce802)