### PR TITLE
Initialize project stats materialized view

### DIFF
--- a/src/backend/app-entrypoint.sh
+++ b/src/backend/app-entrypoint.sh
@@ -45,11 +45,19 @@ create_s3_buckets() {
     python /opt/app/s3.py
 }
 
+init_project_stats() {
+    echo "Initializing project stats materialized view..."
+    python /opt/scheduler/project_stats.py
+}
+
 # Start wait in background with tmp log files
 wait_for_db &
 wait_for_s3 &
 # Wait until checks complete
 wait
+
+# Initialize project stats materialized view when the service starts
+init_project_stats
 
 # Skip init S3 if env var present
 if [ "${S3_SKIP_BUCKET_INIT}" != true ]; then

--- a/src/backend/migrations/init/fmtm_base_schema.sql
+++ b/src/backend/migrations/init/fmtm_base_schema.sql
@@ -656,52 +656,6 @@ BEFORE INSERT ON public.task_events
 FOR EACH ROW
 EXECUTE FUNCTION public.set_task_state();
 
--- Materialized Views
-
-CREATE MATERIALIZED VIEW IF NOT EXISTS public.mv_project_stats AS
-WITH latest_task_events AS (
-    SELECT DISTINCT ON (ev.project_id, ev.task_id)
-        ev.project_id,
-        ev.task_id,
-        ev.event_id,
-        ev.event
-    FROM public.task_events AS ev
-    ORDER BY ev.project_id ASC, ev.task_id ASC, ev.created_at DESC
-)
-
-SELECT
-    p.id AS project_id,
-    count(DISTINCT ev.user_sub) AS num_contributors,
-    count(
-        DISTINCT CASE
-            WHEN et.status = 'SURVEY_SUBMITTED'
-                THEN et.entity_id
-        END
-    ) AS total_submissions,
-    count(
-        DISTINCT CASE
-            WHEN lte.event = 'FINISH'
-                THEN lte.event_id
-        END
-    ) AS tasks_mapped,
-    count(
-        DISTINCT CASE
-            WHEN lte.event = 'BAD'
-                THEN lte.event_id
-        END
-    ) AS tasks_bad,
-    count(
-        DISTINCT CASE
-            WHEN lte.event = 'GOOD'
-                THEN lte.event_id
-        END
-    ) AS tasks_validated
-FROM public.projects AS p
-LEFT JOIN public.task_events AS ev ON p.id = ev.project_id
-LEFT JOIN public.odk_entities AS et ON p.id = et.project_id
-LEFT JOIN latest_task_events AS lte ON p.id = lte.project_id
-GROUP BY p.id;
-
 -- Finalise
 
 REVOKE USAGE ON SCHEMA public FROM public;


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- Project stats materialised view is not created in the first place; you have to wait for 10 minutes to initialise it. It should be created whenever service starts.

## Describe this PR

- Added command in entrypoint to initialise the project stats mv.


## Review Guide

- Can you confirm if it works periodically every 10 minutes?

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
