### PR TITLE
Allow for download of form media/attachments as list of URLs pt1

### DIFF
--- a/src/backend/app/central/central_crud.py
+++ b/src/backend/app/central/central_crud.py
@@ -1004,3 +1004,4 @@ async def get_form_media(
             xform_id,
         )
         return form_attachments
+    # TODO continue from here

--- a/src/backend/app/central/central_crud.py
+++ b/src/backend/app/central/central_crud.py
@@ -990,3 +990,17 @@ async def upload_form_media(
                 form_id=xform_id,
                 attachments=attachment_filepaths,
             )
+
+
+async def get_form_media(
+    xform_id: str,
+    project_odk_id: int,
+    odk_credentials: central_schemas.ODKCentralDecrypted,
+):
+    """Get a list of form media attachments."""
+    async with central_deps.get_async_odk_form(odk_credentials) as async_odk_form:
+        form_attachments = await async_odk_form.listFormAttachments(
+            project_odk_id,
+            xform_id,
+        )
+        return form_attachments

--- a/src/backend/app/central/central_routes.py
+++ b/src/backend/app/central/central_routes.py
@@ -137,6 +137,8 @@ async def upload_form_media(
             project_odk_creds,
             media_attachments,
         )
+        # FIXME this doesn't publish the form after??
+        # FIXME is the form still in draft?
 
         return Response(status_code=HTTPStatus.OK)
 
@@ -144,6 +146,37 @@ async def upload_form_media(
         log.exception(f"Error: {e}")
         msg = (
             f"Failed to upload form media for FMTM project ({project_id}) "
+            f"ODK project ({project_odk_id}) form ID ({project_xform_id})"
+        )
+        log.error(msg)
+        raise HTTPException(
+            status_code=HTTPStatus.UNPROCESSABLE_ENTITY,
+            detail=msg,
+        ) from e
+
+
+@router.post("/get-form-media")
+async def get_form_media(
+    current_user: Annotated[AuthUser, Depends(project_manager)],
+):
+    """Return the project form attachments as a list of files."""
+    project = current_user.get("project")
+    project_id = project.id
+    project_odk_id = project.odkid
+    project_xform_id = project.odk_form_id
+    project_odk_creds = project.odk_credentials
+
+    try:
+        return await central_crud.get_form_media(
+            project_xform_id,
+            project_odk_id,
+            project_odk_creds,
+        )
+
+    except Exception as e:
+        log.exception(f"Error: {e}")
+        msg = (
+            f"Failed to get form media for FMTM project ({project_id}) "
             f"ODK project ({project_odk_id}) form ID ({project_xform_id})"
         )
         log.error(msg)

--- a/src/backend/app/central/central_routes.py
+++ b/src/backend/app/central/central_routes.py
@@ -164,14 +164,16 @@ async def get_form_media(
     project_id = project.id
     project_odk_id = project.odkid
     project_xform_id = project.odk_form_id
-    project_odk_creds = project.odk_credentials
+    # project_odk_creds = project.odk_credentials
 
     try:
-        return await central_crud.get_form_media(
-            project_xform_id,
-            project_odk_id,
-            project_odk_creds,
-        )
+        # FIXME we hardcode here to test with, but should swap to code below eventually
+        return {"mdp.png": "https://s3.mdp.fmtm.hotosm.org/fmtm-data/frontend/mdp.png"}
+        # return await central_crud.get_form_media(
+        #     project_xform_id,
+        #     project_odk_id,
+        #     project_odk_creds,
+        # )
 
     except Exception as e:
         log.exception(f"Error: {e}")

--- a/src/backend/packages/osm-fieldwork/osm_fieldwork/OdkCentralAsync.py
+++ b/src/backend/packages/osm-fieldwork/osm_fieldwork/OdkCentralAsync.py
@@ -227,61 +227,30 @@ class OdkForm(OdkCentral):
         """
         super().__init__(url, user, passwd)
 
-    # NOTE this does not work and has been abandoned for now
-    # Probably best to use pyodk instead
-    # async def createSubmission(
-    #     self,
-    #     projectId: int,
-    #     appuser_token: str,
-    #     submission_xml: str,
-    #     submission_media_name: Optional[str] = None,
-    #     submission_media_bytes: Optional[bytes] = None,
-    # ):
-    #     """Create a new form submission via ODK OpenRosa API.
+    async def listFormAttachments(self, projectId: int, xform: str):
+        """Fetch a list of attachments listed for upload on a given form.
 
-    #     Args:
-    #         projectId (int): The ODK project ID.
-    #         appuser_token (str): An appuser token with access permissions on the form.
-    #         submission_xml (str): The XML submission, created by JavaRosa,
-    #             web-forms, or similar.
-    #         submission_media_name (str, optional): The name of the media file.
-    #         submission_media_bytes (bytes, optional): Bytes of media (e.g. photo)
-    #             file to upload with the submission.
+        Returns data in format:
 
-    #     Returns:
-    #         dict: The submission response metadata.
-    #     """
-    #     url = f"{self.base}key/{appuser_token}/projects/{projectId}/submission"
-    #     headers = {
-    #         "X-OpenRosa-Version": "1.0",
-    #     }
+        [
+            {'name': '1731673738156.jpg', 'exists': False},
+        ]
 
-    #     # Prepare multipart form data
-    #     form_data = FormData()
-    #     form_data.add_field(
-    #         "xml_submission_file",
-    #         submission_xml.encode(encoding="utf-8"),
-    #         content_type="text/xml",
-    #     )
-    #     if submission_media_bytes and submission_media_name:
-    #         form_data.add_field(
-    #             submission_media_name,
-    #             submission_media_bytes,
-    #             filename=submission_media_name,
-    #             content_type="image/jpeg",
-    #         )
+        Args:
+            projectId (int): The ID of the project on ODK Central
+            xform (str): The XForm to get the details of from ODK Central
 
-    #     try:
-    #         async with self.session.post(url, data=form_data, headers=headers, ssl=self.verify) as response:
-    #             if response.status != 201:
-    #                 msg = f"Unexpected response {response.status}: {await response.text()}"
-    #                 log.error(msg)
-    #                 response.raise_for_status()
-    #             return await response.text()
-    #     except aiohttp.ClientError as e:
-    #         msg = f"Error creating submission: {e}"
-    #         log.error(msg)
-    #         raise aiohttp.ClientError(msg) from e
+        Returns:
+            (list[dict]): The list of form attachments.
+        """
+        url = f"{self.base}projects/{projectId}/forms/{xform}/attachments"
+        try:
+            async with self.session.get(url, ssl=self.verify) as response:
+                return await response.json()
+        except aiohttp.ClientError as e:
+            msg = f"Error fetching submissions: {e}"
+            log.error(msg)
+            raise aiohttp.ClientError(msg) from e
 
     async def listSubmissions(self, projectId: int, xform: str):
         """Fetch a list of submission instances for a given form.


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Related #2337

## Describe this PR

Work in progress. @Anuj-Gupta4 could you look into this please 🙏 

- As described in the issue, we need a way to get the form attachments from ODK --> mapper frontend (display in web forms).
- There is a test implementation in this PR for osm-fieldwork, but what we probably actually need is a wrapper for these two endpoints:
  - https://docs.getodk.org/central-api-form-management/#listing-form-version-attachments
    - First, we need the version of the form.
    - Next we call this API to get a list of attachments.
    - We filter out the image attachments: JPG, PNG
  - https://docs.getodk.org/central-api-form-management/#downloading-a-form-version-attachment
    - Then for each attachment we are interested in, we get the data. HOWEVER, the docs state this is the blob data.
    - After the S3 update to ODK Central, if the blob is synced to S3, I actually think this will return a pre-signed URL.
    - We should forward a list of pre-signed URLs as an API response (the same as for photo attachments).

TODO:

- [ ] Below OdkCentralAsync.listFormAttachments, add OdkCentralAsync.getFormAttachmentUrls. This method will be similar to getSubmissionAttachmentUrls, but for uploaded and synced **form attachments**.
- [ ] Add a snippet like this to the `/central/upload-form-media` endpoint, to ensure the attachment blobs are synced db --> S3:
    ```python
        # Ensure S3 form attachments are uploaded to S3
        async with OdkCentral(
            url=project.odk_credentials.odk_central_url,
            user=project.odk_credentials.odk_central_user,
            passwd=project.odk_credentials.odk_central_password,
        ) as odk_central:
            await odk_central.s3_sync()
    ```
- [ ] Then when the user calls the `/central/get-form-media` endpoint (when a project is loaded), we can simply call the OdkCentralAysnc.getFormAttachmentUrls method to get a list of URLs. The images will be downloaded by the frontend and embedded via CSS for usage.

## Review Guide

- Use this test form to create a project: [mdp_xlsform.xlsx](https://github.com/user-attachments/files/19623877/mdp_xlsform.xlsx)
- Upload this image for the form via API: ![mdp](https://github.com/user-attachments/assets/8d60e496-698c-4beb-ad12-a73e630d5742)
- The endpoints is `/central/upload-form-media`.
- Then continue to test using the `/central/get-form-media` endpoint.

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
