### PR TITLE
cache form xml and ODK Web Forms js library

### DIFF
--- a/src/mapper/src/lib/components/forms/wrapper.svelte
+++ b/src/mapper/src/lib/components/forms/wrapper.svelte
@@ -4,6 +4,7 @@
 	import { getCommonStore } from '$store/common.svelte.ts';
 	import { getLoginStore } from '$store/login.svelte.ts';
 	import { getEntitiesStatusStore } from '$store/entities.svelte.ts';
+	import { fetchBlobUrl } from '$lib/utils/fetch.ts';
 
 	const CUSTOM_UPLOAD_ELEMENT_ID = '95c6807c-82b4-4208-b5df-5a3e795227b0';
 
@@ -30,6 +31,10 @@
 	let startDate: string | undefined;
 
 	let pic: any;
+
+	const formXmlPromise = fetchBlobUrl(`${API_URL}/projects/${projectId}/form-xml`);
+
+	const odkWebFormPromise = fetchBlobUrl('https://hotosm.github.io/web-forms/odk-web-form.js');
 
 	function handleMutation() {
 		if (!iframeRef) return;
@@ -210,19 +215,22 @@
 	class="drawer-contained drawer-placement-start drawer-overview"
 	style="--size: 100vw; --header-spacing: 0px"
 >
-	{#if entityId}
-		{#key projectId}
-			{#key entityId}
-				<iframe
-					bind:this={iframeRef}
-					title="odk-web-forms-wrapper"
-					src={`./web-forms.html?projectId=${projectId}&entityId=${entityId}&api_url=${API_URL}&language=${commonStore.locale}`}
-					style="height: 100%; width: 100%; z-index: 11;"
-				>
-				</iframe>
+	{#await odkWebFormPromise then odkWebFormUrl}
+		{#if entityId}
+			{#key projectId}
+				{#await formXmlPromise then formXml}
+					{#key entityId}
+						<iframe
+							bind:this={iframeRef}
+							title="odk-web-forms-wrapper"
+							src={`./web-forms.html?projectId=${projectId}&entityId=${entityId}&formXml=${formXml}&language=${commonStore.locale}&odkWebFormUrl=${odkWebFormUrl}`}
+							style="height: 100%; width: 100%; z-index: 11;"
+						></iframe>
+					{/key}
+				{/await}
 			{/key}
-		{/key}
-	{/if}
+		{/if}
+	{/await}
 </hot-drawer>
 
 <style>

--- a/src/mapper/src/lib/utils/fetch.ts
+++ b/src/mapper/src/lib/utils/fetch.ts
@@ -4,7 +4,7 @@
  * @returns {string} object url to the cached fetch response
  */
 export async function fetchBlobUrl(url: string): Promise<string> {
-  const response = await fetch(url);
-  const blob = await response.blob();
-  return URL.createObjectURL(blob);
+	const response = await fetch(url);
+	const blob = await response.blob();
+	return URL.createObjectURL(blob);
 }

--- a/src/mapper/src/lib/utils/fetch.ts
+++ b/src/mapper/src/lib/utils/fetch.ts
@@ -1,0 +1,10 @@
+/**
+ * @name fetchBlobUrl
+ * @param url - url to a web resource like a script or xml file
+ * @returns {string} object url to the cached fetch response
+ */
+export async function fetchBlobUrl(url: string): Promise<string> {
+  const response = await fetch(url);
+  const blob = await response.blob();
+  return URL.createObjectURL(blob);
+}

--- a/src/mapper/static/web-forms.html
+++ b/src/mapper/static/web-forms.html
@@ -2,7 +2,8 @@
 <html>
 	<body style="height: 100vh; overflow-y: scroll; position: relative">
 		<script type="module">
-			import OdkWebForm from 'https://hotosm.github.io/web-forms/odk-web-form.js';
+			const odkWebFormUrl = new URL(window.location.href).searchParams.get("odkWebFormUrl");
+			const OdkWebForm = (await import(odkWebFormUrl)).default;
 
 			// we created this static html file for a few reasons:
 			// 1) we were running into issues where the css styles imported in the main layout page
@@ -11,7 +12,7 @@
 
 			const entityId = new URL(window.location.href).searchParams.get('entityId');
 			const projectId = new URL(window.location.href).searchParams.get('projectId');
-			const api_url = new URL(window.location.href).searchParams.get('api_url');
+			const formXml = new URL(window.location.href).searchParams.get('formXml');
 			const language = new URL(window.location.href).searchParams.get('language');
 
 			// we are creating an instance of a web component programmatically
@@ -19,7 +20,7 @@
 			// because we need to pass a function as fetchFormAttachment
 			// (and you can't pass a function as a tag attribute in HTML)
 			const odkWebForm = new OdkWebForm({
-				formXml: `${api_url}/projects/${projectId}/form-xml`,
+				formXml: formXml,
 				header: false,
 				missingResourceBehavior: 'BLANK',
 				fetchFormAttachment: function (url) {

--- a/src/mapper/static/web-forms.html
+++ b/src/mapper/static/web-forms.html
@@ -2,7 +2,7 @@
 <html>
 	<body style="height: 100vh; overflow-y: scroll; position: relative">
 		<script type="module">
-			const odkWebFormUrl = new URL(window.location.href).searchParams.get("odkWebFormUrl");
+			const odkWebFormUrl = new URL(window.location.href).searchParams.get('odkWebFormUrl');
 			const OdkWebForm = (await import(odkWebFormUrl)).default;
 
 			// we created this static html file for a few reasons:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [X] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixes [#123](https://github.com/hotosm/fmtm/issues/2327)

## Describe this PR

Basically cache/proxy the ODK Web Forms library and forms xml by fetching and then passing along the response blob url.

## Screenshots

no appearance changes

## Alternative Approaches Considered

I tried a couple alternatives before finding this one.  I tried loading the OdkWebForm library in an isolated iframe and then injecting the OdkWebForm Web Component into the rendered iframe.  Technically, I successfully inject the web component into the iframe, but the issue is that the odk-web-forms.js (web component build without shadow dom) library presumes that  it will be used in the same frame as its loaded.  Unfortunately, this means that if you pass in the OdkWebForm object from another iframe (in the same origin) it won't carry with it the css styles that it loaded as a part of script initialization.

## Review Guide

Nothing should change.  I would recommend checking a couple projects and making sure its not caching form xml between projects.

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
