### PR TITLE
Delete organisation only if there are no projects within it

### DIFF
--- a/src/backend/app/db/models.py
+++ b/src/backend/app/db/models.py
@@ -620,12 +620,12 @@ class DbOrganisation(BaseModel):
                 )
                 return True
         
-        except psycopg.errors.ForeignKeyViolation:
+        except psycopg.errors.ForeignKeyViolation as e:
             raise HTTPException(
                 status_code=HTTPStatus.CONFLICT,
                 detail="""Cannot delete organization with existing projects.
                 Delete all projects first."""
-            )
+            ) from e
         except Exception as e:
             raise HTTPException(
                 status_code = HTTPStatus.BAD_REQUEST,

--- a/src/backend/app/db/models.py
+++ b/src/backend/app/db/models.py
@@ -29,9 +29,9 @@ from typing import TYPE_CHECKING, Annotated, List, Optional, Self
 from uuid import UUID
 
 import geojson
+import psycopg
 from fastapi import HTTPException, UploadFile
 from loguru import logger as log
-import psycopg
 from psycopg import Connection
 from psycopg.errors import UniqueViolation
 from psycopg.rows import class_row
@@ -619,17 +619,17 @@ class DbOrganisation(BaseModel):
                     f"/{org_id}/",
                 )
                 return True
-        
+
         except psycopg.errors.ForeignKeyViolation as e:
             raise HTTPException(
                 status_code=HTTPStatus.CONFLICT,
                 detail="""Cannot delete organization with existing projects.
-                Delete all projects first."""
+                Delete all projects first.""",
             ) from e
         except Exception as e:
             raise HTTPException(
-                status_code = HTTPStatus.BAD_REQUEST,
-                detail = f"Failed to delete organization: {e}"
+                status_code=HTTPStatus.BAD_REQUEST,
+                detail=f"Failed to delete organization: {e}",
             ) from e
 
     @classmethod
@@ -716,15 +716,15 @@ class DbOrganisationManagers(BaseModel):
             sql += ";"
             await cur.execute(sql, params)
             return await cur.fetchall()
-    
+
     @classmethod
     async def delete(cls, db: Connection, user_sub: str):
         """Delete an organization manager.
-        
+
         Args:
             db: Database connection
             user_sub: The subject ID of the user to remove
-            
+
         Returns:
             None
         """
@@ -733,6 +733,7 @@ class DbOrganisationManagers(BaseModel):
                 "DELETE FROM organisation_managers WHERE user_sub = %(user_sub)s;",
                 {"user_sub": user_sub},
             )
+
 
 class DbXLSForm(BaseModel):
     """Table xlsforms.

--- a/src/backend/app/organisations/organisation_routes.py
+++ b/src/backend/app/organisations/organisation_routes.py
@@ -263,8 +263,8 @@ async def remove_organisation_admin(
     if current_user.sub == user_sub:
         raise HTTPException(
             status_code=HTTPStatus.BAD_REQUEST,
-            detail="You cannot remove your own admin role."
+            detail="You cannot remove your own admin role.",
         )
-    
+
     await DbOrganisationManagers.delete(db, user_sub)
     return Response(status_code=HTTPStatus.NO_CONTENT)

--- a/src/frontend/src/api/OrganisationService.ts
+++ b/src/frontend/src/api/OrganisationService.ts
@@ -255,9 +255,12 @@ export const DeleteOrganizationService = (url: string, navigate: NavigateFunctio
           }),
         );
       } catch (error) {
+        const message =
+          error?.response?.data?.detail || "Failed to delete organisation";
         dispatch(
           CommonActions.SetSnackBar({
-            message: 'Failed to delete organization',
+            message,
+            variant: 'error',
           }),
         );
       } finally {

--- a/src/frontend/src/api/OrganisationService.ts
+++ b/src/frontend/src/api/OrganisationService.ts
@@ -255,8 +255,7 @@ export const DeleteOrganizationService = (url: string, navigate: NavigateFunctio
           }),
         );
       } catch (error) {
-        const message =
-          error?.response?.data?.detail || "Failed to delete organisation";
+        const message = error?.response?.data?.detail || 'Failed to delete organisation';
         dispatch(
           CommonActions.SetSnackBar({
             message,


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- Issue: #1572 

## Describe this PR

- Update organisation delete function:-
   - Only allow users to delete organisation if no projects are present within organisation
- Create delete organisation admin api
   -  Do not allow user or org admin to delete their own role
   - They can remove other admins if they are organisation admin of same organisation

## Screenshots

![image](https://github.com/user-attachments/assets/2381c2b9-514a-417e-9e35-76dbad0d47ee)

## Response

`/organisation/org-admin/{user_sub}?org_id=1`

```json
{
  "detail": "You cannot remove your own admin role."
}
```

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
