### PR TITLE
added warmup latitude/longitude into form submission

### DIFF
--- a/src/mapper/src/lib/components/forms/wrapper.svelte
+++ b/src/mapper/src/lib/components/forms/wrapper.svelte
@@ -102,6 +102,12 @@
 				submission_xml = submission_xml.replace('<image/>', `<image>${pic?.name}</image>`);
 			}
 
+			if (entitiesStore.userLocationCoord) {
+				const [longitude, latitude] = entitiesStore.userLocationCoord as [number, number];
+				// add 0.0 for altitude and 10.0 for accuracy as defaults
+				submission_xml = submission_xml.replace('<warmup/>', `<warmup>${latitude} ${longitude} 0.0 10.0</warmup>`);
+			}
+
 			const url = `${API_URL}/submission?project_id=${projectId}`;
 			var data = new FormData();
 			data.append('submission_xml', submission_xml);


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

N/A

## Describe this PR

Basically take the geolocation if available and adds it to the submission xml.

## Screenshots

No visible change, but here's an example output from submissions download from manager:
<img width="811" alt="Screenshot 2025-04-12 at 5 07 26 PM" src="https://github.com/user-attachments/assets/b2b69ce1-6173-4b9d-a590-0bc66e6a7865" />


## Alternative Approaches Considered

Tried to see if enabling geolocation in the iframe would have getodk/web-forms automatically inject the warmup/start-geopoint value, but that didn't seem to work.  My understanding is that this information will be added to odk in the future, at which point we can remove the lines added in this PR.

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
