### PR TITLE
Generate data extracts based on the geom type (POINT, LINE, POLYGON) selected.

### DIFF
--- a/src/backend/app/projects/project_crud.py
+++ b/src/backend/app/projects/project_crud.py
@@ -125,6 +125,7 @@ async def get_projects_featcol(
 async def generate_data_extract(
     aoi: geojson.FeatureCollection | geojson.Feature | dict,
     extract_config: Optional[BytesIO] = None,
+    centroid: bool= False,
 ) -> str:
     """Request a new data extract in flatgeobuf format.
 
@@ -167,6 +168,7 @@ async def generate_data_extract(
             "outputType": "geojson",
             "bind_zip": False,
             "useStWithin": False,
+            "centroid": centroid,
         },
     )
 

--- a/src/backend/packages/osm-fieldwork/osm_fieldwork/data_models/buildings/centroid.yaml
+++ b/src/backend/packages/osm-fieldwork/osm_fieldwork/data_models/buildings/centroid.yaml
@@ -1,0 +1,26 @@
+select:
+  - osm_id: id
+  - version
+from:
+  - ways_poly
+  - nodes
+where:
+  tags:
+    - building: not null
+      amenity: not null
+      tourism: not null
+
+keep:
+  - building
+  - building:levels
+  - building:material
+  - roof:material
+  - roof:shape
+  - roof:levels
+  - cuisine
+  - amenity
+  - convenience
+  - diesel
+  - version
+  - name
+  - name:en

--- a/src/backend/packages/osm-fieldwork/osm_fieldwork/data_models/buildings/point.yaml
+++ b/src/backend/packages/osm-fieldwork/osm_fieldwork/data_models/buildings/point.yaml
@@ -1,0 +1,25 @@
+select:
+  - osm_id: id
+  - version
+from:
+  - nodes
+where:
+  tags:
+    - building: not null
+      amenity: not null
+      tourism: not null
+
+keep:
+  - building
+  - building:levels
+  - building:material
+  - roof:material
+  - roof:shape
+  - roof:levels
+  - cuisine
+  - amenity
+  - convenience
+  - diesel
+  - version
+  - name
+  - name:en

--- a/src/backend/packages/osm-fieldwork/osm_fieldwork/data_models/buildings/polygon.yaml
+++ b/src/backend/packages/osm-fieldwork/osm_fieldwork/data_models/buildings/polygon.yaml
@@ -1,0 +1,25 @@
+select:
+  - osm_id: id
+  - version
+from:
+  - ways_poly
+where:
+  tags:
+    - building: not null
+      amenity: not null
+      tourism: not null
+
+keep:
+  - building
+  - building:levels
+  - building:material
+  - roof:material
+  - roof:shape
+  - roof:levels
+  - cuisine
+  - amenity
+  - convenience
+  - diesel
+  - version
+  - name
+  - name:en

--- a/src/frontend/src/components/createnewproject/DataExtract.tsx
+++ b/src/frontend/src/components/createnewproject/DataExtract.tsx
@@ -135,7 +135,12 @@ const DataExtract = ({
     if (projectDetails.osmFormSelectionName) {
       dataExtractRequestFormData.append('osm_category', projectDetails.osmFormSelectionName);
     }
-
+    dataExtractRequestFormData.append("geom_type", formValues.primaryGeomType)
+    // Check if geom_type is POINT, then append centroid = true by default
+    // TODO later on advanced mode, allow toggle on and off for centroid
+    if (formValues.primaryGeomType === 'POINT') {
+      dataExtractRequestFormData.append('centroid', 'true');
+    }
     // Set flatgeobuf as loading
     dispatch(CreateProjectActions.SetFgbFetchingStatus(true));
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Issues: 
- #2302
- #2159

## Describe this PR

- Specify geom type to generate data extracts. 
```python
geom_type = DbGeomType.Polygon
```
as a default parameter in the backend.
- If `osm_buildings` category is selected, then we allow `Polygons`, `Points` and `Points along with the building centroids`
- If `osm_buildings` is selected as a category, the option to select Lines as a primary geom type needs to be hidden, I guess? @spwoodcock , @NSUWAL123 
- By default, the frontend passes centroid: true if point data is selected. Later on the advanced option, we will allow the toggle option for the centroid.

## Screenshots

![image](https://github.com/user-attachments/assets/98854837-5854-4768-a4d4-338d3717ef51)

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
