### PR TITLE
fix broken web forms appearance

### DIFF
--- a/src/mapper/src/lib/components/forms/wrapper.svelte
+++ b/src/mapper/src/lib/components/forms/wrapper.svelte
@@ -238,6 +238,7 @@
 						{#key entityId}
 							<iframe
 								class="iframe"
+								style:height="100%"
 								use:handleIframe
 								title="odk-web-forms-wrapper"
 								src={`./web-forms.html?projectId=${projectId}&entityId=${entityId}&formXml=${formXml}&language=${commonStore.locale}&odkWebFormUrl=${odkWebFormUrl}&formMedia=${encodeURIComponent(JSON.stringify(formMedia))}`}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixed broken web forms appearance.

## Describe this PR

Basically hard-code the height of the web forms popup to 100%.  I don't think there's a need to make this height something someone can over-ride in a custom css variables file (css module).  However, this is meant just as a quick fix, so definitely open to better fixes in the future.

## Screenshots
see below


## Alternative Approaches Considered

Looked at over-riding --at-apply in css or adding it as a custom variable; however, being short on time, this was the most direct approach.

## Review Guide

Try to submit a web form

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
