### PR TITLE
Pass centroid param only if primary geom type is point

### DIFF
--- a/src/frontend/src/components/createnewproject/DataExtract.tsx
+++ b/src/frontend/src/components/createnewproject/DataExtract.tsx
@@ -136,10 +136,10 @@ const DataExtract = ({
       dataExtractRequestFormData.append('osm_category', projectDetails.osmFormSelectionName);
     }
     dataExtractRequestFormData.append('geom_type', formValues.primaryGeomType);
-    
-    if (formValues.primaryGeomType == "POINT"){
-    dataExtractRequestFormData.append('centroid', formValues.includeCentroid)
-    };
+
+    if (formValues.primaryGeomType == 'POINT') {
+      dataExtractRequestFormData.append('centroid', formValues.includeCentroid);
+    }
 
     // Set flatgeobuf as loading
     dispatch(CreateProjectActions.SetFgbFetchingStatus(true));

--- a/src/frontend/src/components/createnewproject/DataExtract.tsx
+++ b/src/frontend/src/components/createnewproject/DataExtract.tsx
@@ -136,7 +136,10 @@ const DataExtract = ({
       dataExtractRequestFormData.append('osm_category', projectDetails.osmFormSelectionName);
     }
     dataExtractRequestFormData.append('geom_type', formValues.primaryGeomType);
-    dataExtractRequestFormData.append('centroid', formValues.includeCentroid);
+    
+    if (formValues.primaryGeomType == "POINT"){
+    dataExtractRequestFormData.append('centroid', formValues.includeCentroid)
+    };
 
     // Set flatgeobuf as loading
     dispatch(CreateProjectActions.SetFgbFetchingStatus(true));


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- Generating polygon data extracts was failing

## Describe this PR

- Fixed the issue, only pass centroid param if primary geom type is "POINT"

## Screenshots

N/A

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
