### PR TITLE
Remove custom ValidationError handler on backend responses

### DIFF
--- a/src/backend/app/main.py
+++ b/src/backend/app/main.py
@@ -24,8 +24,7 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Annotated, AsyncIterator
 
-from fastapi import Depends, FastAPI, Request
-from fastapi.exceptions import RequestValidationError
+from fastapi import Depends, FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse, RedirectResponse, Response
 from loguru import logger as log
@@ -208,30 +207,6 @@ def get_logger():
 
 
 api = get_api()
-
-
-@api.exception_handler(RequestValidationError)
-async def validation_exception_handler(
-    request: Request,  # dead: disable
-    exc: RequestValidationError,
-):
-    """Exception handler for more descriptive logging and traces."""
-    status_code = 500
-    errors = []
-    for error in exc.errors():
-        # TODO Handle this properly
-        if error["msg"] in ["Invalid input", "field required"]:
-            status_code = HTTPStatus.UNPROCESSABLE_ENTITY
-        else:
-            status_code = HTTPStatus.BAD_REQUEST
-        errors.append(
-            {
-                "loc": error["loc"],
-                "msg": error["msg"],
-                "error": error["msg"] + str([x for x in error["loc"]]),
-            }
-        )
-    return JSONResponse(status_code=status_code, content={"errors": errors})
 
 
 @api.get("/")


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixes #2139

## Describe this PR

- Two years ago we added a custom validation error handler to the API.
- Ideally we want a standard response on all endpoints, with `detail` being the first key (this is standard in FastAPI and makes error handling easier).
- This PR reverts the change / removes the handler.
- I couldn't find the references in the frontend on first search, for if this impacts any toast / error notifications to the users on failed endpoint submit.
- I'm assuming we might change `CreateProjectService` after this, updating code:

```js
      if (!hasAPISuccess) {
        const msg = `Request failed with status ${projectCreateResp.status}`;
        console.error(msg);
        throw new Error(msg);
      }
```

to

```js
      if (!hasAPISuccess) {
        const msg = `Request failed with status ${projectCreateResp.status}`;
        console.error(msg);
        throw new Error(msg);
        // get the fields from the response and display list of errors to user
      }
```

## Checklist before requesting a review

- 📖 Read the FMTM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
