### PR TITLE
fixing issue 2403

### DIFF
--- a/src/mapper/static/web-forms.html
+++ b/src/mapper/static/web-forms.html
@@ -46,14 +46,14 @@
 	</head>
 	<body style="height: 100vh; overflow-y: scroll; position: relative">
 		<script type="module">
-			URL.canParse = function(string) {
+			URL.canParse = function (string) {
 				try {
 					new URL(string);
 					return true;
 				} catch (err) {
 					return false;
 				}
-			}
+			};
 
 			const odkWebFormUrl = new URL(window.location.href).searchParams.get('odkWebFormUrl');
 			const OdkWebForm = (await import(odkWebFormUrl)).default;

--- a/src/mapper/static/web-forms.html
+++ b/src/mapper/static/web-forms.html
@@ -18,10 +18,43 @@
 			.columns-pack .label-text {
 				display: none;
 			}
+
+			/* css polyfilling for old browsers */
+			[popover] {
+				display: none;
+			}
+			[popover]:popover-open {
+				display: block;
+			}
+
+			[popover] {
+				position: fixed;
+				width: fit-content;
+				height: fit-content;
+				color: canvastext;
+				background-color: canvas;
+				inset: 0px;
+				margin: auto;
+				border-width: initial;
+				border-style: solid;
+				border-color: initial;
+				border-image: initial;
+				padding: 0.25em;
+				overflow: auto;
+			}
 		</style>
 	</head>
 	<body style="height: 100vh; overflow-y: scroll; position: relative">
 		<script type="module">
+			URL.canParse = function(string) {
+				try {
+					new URL(string);
+					return true;
+				} catch (err) {
+					return false;
+				}
+			}
+
 			const odkWebFormUrl = new URL(window.location.href).searchParams.get('odkWebFormUrl');
 			const OdkWebForm = (await import(odkWebFormUrl)).default;
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Example: Fixes #2403 

## Describe this PR

Added code that adds canParse to URL object.  This is contained within the iframe.  [popover] is also not supported in older browsers, so basically hide it.  Unfortunately odk web-forms doesn't seem to have any other attributes it updates when error popover is updated, so css rules rely on pesudo-classes.  What this means in practice is that certain errors might not appear; however, in my testing the relevant errors (like not filling in a required field) still appear correctly.

URL.prototype.canParse didn't work for me, so that's why I use URL.canParse

## Screenshots

## Alternative Approaches Considered

adding support directly into xforms-engine or web-forms.  However, I want to minimize merge conflicts with upstream.

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the Field-TM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
