### PR TITLE
auto-open web forms when entity created

### DIFF
--- a/src/mapper/src/lib/odk/collect.ts
+++ b/src/mapper/src/lib/odk/collect.ts
@@ -1,6 +1,5 @@
-import { getAlertStore, getCommonStore } from '$store/common.svelte.ts';
+import { getAlertStore } from '$store/common.svelte.ts';
 
-const commonStore = getCommonStore();
 const alertStore = getAlertStore();
 
 export function openOdkCollectNewFeature(xFormId: string, entityId: string) {
@@ -10,10 +9,7 @@ export function openOdkCollectNewFeature(xFormId: string, entityId: string) {
 
 	const isMobile = /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent);
 
-	if (commonStore.enableWebforms) {
-		// TODO can we open the webform directly, instead of needing to click
-		// TODO the 'Collect Data' button?
-	} else if (!isMobile) {
+	if (!isMobile) {
 		alertStore.setAlert({
 			variant: 'warning',
 			message: 'Requires a mobile phone with ODK Collect.',

--- a/src/mapper/src/routes/[projectId]/+page.svelte
+++ b/src/mapper/src/routes/[projectId]/+page.svelte
@@ -205,7 +205,19 @@
 			});
 			entitiesStore.syncEntityStatus(data.projectId);
 			cancelMapNewFeatureInODK();
-			openOdkCollectNewFeature(data?.project?.odk_form_id, entity.uuid);
+
+			if (commonStore.enableWebforms) {
+				await entitiesStore.setSelectedEntity(entity.uuid);
+				openedActionModal = null;
+				entitiesStore.updateEntityStatus(data.projectId, {
+					entity_id: entity.uuid,
+					status: 1,
+					label: entity?.currentVersion?.label,
+				});
+				displayWebFormsDrawer = true;
+			} else {
+				openOdkCollectNewFeature(data?.project?.odk_form_id, entity.uuid);
+			}
 		} catch (error) {
 			alertStore.setAlert({ message: 'Unable to create entity', variant: 'danger' });
 		} finally {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Example: Fixes #2393

## Describe this PR

Basically do the same things after you create an entity as you would do if you select an entity and click "Collect Data".  The main difference is we have to first select the entity, because the entity creation workflow doesn't automatically "select" an entity in the entities store before creation (because it doesn't exist yet).

## Screenshots


## Alternative Approaches Considered

Strongly considered adding the logic into openOdkCollectNewFeature function inside of src/mapper/src/lib/odk/collect.ts.  However, this functionality requires a lot of variables set up in +page.svelete and it would require passing in a lot of variables.

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the Field-TM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
