### PR TITLE
Update list organisation admins permissions to allow authenticated users

### DIFF
--- a/src/backend/app/organisations/organisation_routes.py
+++ b/src/backend/app/organisations/organisation_routes.py
@@ -189,12 +189,13 @@ async def add_new_organisation_admin(
 @router.get("/org-admins", response_model=list[OrgManagersOut])
 async def get_organisation_admins(
     db: Annotated[Connection, Depends(db_conn)],
-    org_user_dict: Annotated[OrgUserDict, Depends(org_admin)],
+    organisation: Annotated[DbOrganisation, Depends(org_exists)],
+    current_user: Annotated[AuthUser, Depends(login_required)],
 ):
     """Get the list of organisation admins."""
     org_managers = await DbOrganisationManagers.get(
         db,
-        org_user_dict.get("org").id,
+        organisation.id,
     )
     return org_managers
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

The organisation detail page was giving a generic 403 error page when someone who is not an organisation admin would access it.

## Describe this PR

The organisation admins get api has been updated to allow any authenticated user to view it. It should be ok to do this.

## Screenshots

Please provide screenshots of the change.

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the Field-TM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
