### PR TITLE
Add signin type filter to user list retrieval

### DIFF
--- a/src/backend/app/users/user_routes.py
+++ b/src/backend/app/users/user_routes.py
@@ -18,7 +18,7 @@
 """Endpoints for users and role."""
 
 from datetime import datetime, timezone
-from typing import Annotated
+from typing import Annotated, Literal
 
 from fastapi import (
     APIRouter,
@@ -79,9 +79,12 @@ async def get_userlist(
     db: Annotated[Connection, Depends(db_conn)],
     _: Annotated[DbUser, Depends(validator)],
     search: str = "",
+    signin_type: Literal["osm", "google"] = Query(
+        "osm", description="Filter by signin type (osm or google)"
+    ),
 ):
     """Get all user list with info such as id and username."""
-    users = await DbUser.all(db, search=search)
+    users = await DbUser.all(db, search=search, signin_type=signin_type)
     if not users:
         return []
     return [


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

The usernames api will be used to assign organisation admins. But non OSM users can't be an organisation admin. In that case, we should only list osm users to choose an organisation admin from that list.

## Describe this PR

Added a filter to usernames to retrieve only osm or google users as needed.