### PR TITLE
Remove user_roles join to avoid multiple projects result

### DIFF
--- a/src/backend/app/db/models.py
+++ b/src/backend/app/db/models.py
@@ -1661,9 +1661,7 @@ class DbProject(BaseModel):
         filters, params = cls._build_query_filters(
             skip, limit, org_id, user_sub, hashtags, search, access_info
         )
-        sql = cls._construct_sql_query(
-            filters, minimal, skip, limit
-        )
+        sql = cls._construct_sql_query(filters, minimal, skip, limit)
 
         # Execute query and return results
         async with db.cursor(row_factory=class_row(cls)) as cur:

--- a/src/backend/app/db/models.py
+++ b/src/backend/app/db/models.py
@@ -1658,11 +1658,11 @@ class DbProject(BaseModel):
     ) -> Optional[list[Self]]:
         """Fetch all projects with optional filters for user, hashtags, and search."""
         access_info = await cls._get_user_access_level(db, current_user)
-        filters, params, needs_user_roles_join = cls._build_query_filters(
+        filters, params = cls._build_query_filters(
             skip, limit, org_id, user_sub, hashtags, search, access_info
         )
         sql = cls._construct_sql_query(
-            filters, minimal, skip, limit, needs_user_roles_join
+            filters, minimal, skip, limit
         )
 
         # Execute query and return results
@@ -1711,9 +1711,7 @@ class DbProject(BaseModel):
 
         # Add visibility filter based on user authorization
         visibility_filter = cls._build_visibility_filter(access_info)
-        needs_user_roles_join = False
         if visibility_filter:
-            needs_user_roles_join = True
             filters.append(visibility_filter)
 
         params = {
@@ -1733,7 +1731,7 @@ class DbProject(BaseModel):
         if access_info["managed_org_ids"]:
             params["managed_org_ids"] = access_info["managed_org_ids"]
 
-        return filters, params, needs_user_roles_join
+        return filters, params
 
     @classmethod
     def _build_visibility_filter(cls, access_info: dict) -> Optional[str]:
@@ -1757,7 +1755,11 @@ class DbProject(BaseModel):
                 p.visibility = 'PUBLIC'
                 OR (
                     p.visibility = 'PRIVATE'
-                    AND ur.user_sub = %(current_user_sub)s
+                    AND EXISTS (
+                        SELECT 1 FROM user_roles ur
+                        WHERE ur.project_id = p.id
+                        AND ur.user_sub = %(current_user_sub)s
+                    )
                 )
             )
         """
@@ -1769,21 +1771,13 @@ class DbProject(BaseModel):
         minimal: bool,
         skip: Optional[int],
         limit: Optional[int],
-        needs_user_roles_join: Optional[bool] = False,
     ) -> str:
         """Construct SQL query based on filters and query type."""
         where_clause = f"WHERE {' AND '.join(filters)}" if filters else ""
 
-        # Only join user_roles if needed for private visibility check
-        if needs_user_roles_join:
-            user_roles_join = "LEFT JOIN user_roles ur ON ur.project_id = p.id"
-        else:
-            user_roles_join = ""
-
         sql = f"""
             WITH filtered_projects AS (
                 SELECT p.* FROM projects p
-                {user_roles_join}
                 {where_clause}
             )
         """


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- Issue:  #2453 

## Describe this PR

- `LEFT JOIN` always has been tricky for me; it resulted in multiple repetitions of projects if `user_roles` table has multiple rows for same project, as it creates a row for every matching pair
- Instead of join I have now just checked if any row for that project exists on the `user_roles` with that user which avoids row multiplication

So:
- If it's public → included
- If it's private → check if the current user has a role in user_roles
- If such a role exists → include the project

## Screenshots

N/A

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the Field-TM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
