### PR TITLE
Add capability to create new users via API key

### DIFF
--- a/src/backend/app/auth/auth_routes.py
+++ b/src/backend/app/auth/auth_routes.py
@@ -25,7 +25,6 @@ from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi.responses import JSONResponse
 from loguru import logger as log
 from psycopg import Connection
-from psycopg.rows import class_row
 
 from app.auth.auth_deps import login_required, public_endpoint
 from app.auth.auth_logic import (
@@ -43,8 +42,8 @@ from app.auth.providers.osm import (
 )
 from app.config import settings
 from app.db.database import db_conn
-from app.db.enums import HTTPStatus, UserRole
-from app.db.models import DbUser
+from app.db.enums import HTTPStatus
+from app.users.user_crud import get_or_create_user
 
 router = APIRouter(
     prefix="/auth",
@@ -178,93 +177,6 @@ async def logout():
 
     response = await expire_cookies(response, cookie_names)
     return response
-
-
-async def get_or_create_user(
-    db: Connection,
-    user_data: AuthUser,
-):
-    """Get user from User table if exists, else create."""
-    try:
-        upsert_sql = """
-            WITH upserted_user AS (
-                INSERT INTO users (
-                    sub,
-                    username,
-                    email_address,
-                    profile_img,
-                    role,
-                    registered_at
-                )
-                VALUES (
-                    %(user_sub)s,
-                    %(username)s,
-                    %(email_address)s,
-                    %(profile_img)s,
-                    %(role)s,
-                    NOW()
-                )
-                ON CONFLICT (sub)
-                DO UPDATE SET
-                    profile_img = EXCLUDED.profile_img,
-                    last_login_at = NOW()
-                RETURNING sub, username, email_address, profile_img, role
-            )
-
-            SELECT
-                u.sub,
-                u.username,
-                u.email_address,
-                u.profile_img,
-                u.role,
-
-                -- Aggregate the organisation IDs managed by the user
-                array_agg(
-                    DISTINCT om.organisation_id
-                ) FILTER (WHERE om.organisation_id IS NOT NULL) AS orgs_managed,
-
-                -- Aggregate project roles for the user, as project:role pairs
-                jsonb_object_agg(
-                    ur.project_id,
-                    COALESCE(ur.role, 'MAPPER')
-                ) FILTER (WHERE ur.project_id IS NOT NULL) AS project_roles
-
-            FROM upserted_user u
-            LEFT JOIN user_roles ur ON u.sub = ur.user_sub
-            LEFT JOIN organisation_managers om ON u.sub = om.user_sub
-            GROUP BY
-                u.sub,
-                u.username,
-                u.email_address,
-                u.profile_img,
-                u.role;
-        """
-
-        async with db.cursor(row_factory=class_row(DbUser)) as cur:
-            await cur.execute(
-                upsert_sql,
-                {
-                    "user_sub": user_data.sub,
-                    "username": user_data.username,
-                    "email_address": user_data.email,
-                    "profile_img": user_data.profile_img or "",
-                    "role": UserRole(user_data.role).name,
-                },
-            )
-            db_user_details = await cur.fetchone()
-
-        if not db_user_details:
-            raise HTTPException(
-                status_code=HTTPStatus.NOT_FOUND,
-                detail=f"User ({user_data.sub}) could not be inserted in db",
-            )
-
-        return db_user_details
-
-    except Exception as e:
-        await db.rollback()
-        log.exception(f"Exception occurred: {e}", stack_info=True)
-        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail=str(e)) from e
 
 
 @router.get("/me", response_model=FMTMUser)

--- a/src/backend/app/auth/auth_schemas.py
+++ b/src/backend/app/auth/auth_schemas.py
@@ -102,3 +102,13 @@ class FMTMUser(BaseUser):
         if self.profile_img:
             self.picture = self.profile_img
             self.profile_img = None
+
+
+class ExternalUserIn(BaseModel):
+    """Create a FieldTM user from an external platform."""
+
+    id: str
+    platform: str  # the name of the platform, used for sub `platform|id`
+    username: str
+    email: Optional[str] = None
+    picture: Optional[str] = None

--- a/src/backend/app/integrations/integration_routes.py
+++ b/src/backend/app/integrations/integration_routes.py
@@ -23,6 +23,7 @@ possible from misused API keys (so the entire API is not accessible).
 API keys are inherently not as secure as OAuth flow / JWT token combo.
 """
 
+from time import time
 from typing import Annotated
 
 from fastapi import (
@@ -30,23 +31,30 @@ from fastapi import (
     Depends,
 )
 from fastapi.exceptions import HTTPException
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
 from loguru import logger as log
 from psycopg import Connection
 
 from app.auth.auth_deps import login_required
-from app.auth.roles import super_admin
+from app.auth.auth_logic import (
+    create_jwt_tokens,
+    set_cookies,
+)
+from app.auth.auth_schemas import AuthUser, ExternalUserIn, OrgUserDict
+from app.auth.roles import org_admin, super_admin
 from app.central.central_schemas import (
     OdkCentralWebhookRequest,
 )
+from app.config import settings
 from app.db.database import db_conn
-from app.db.enums import HTTPStatus, OdkWebhookEvents
+from app.db.enums import HTTPStatus, OdkWebhookEvents, UserRole
 from app.db.models import DbUser
 from app.integrations.integration_crud import (
     generate_api_token,
     update_entity_status_in_fmtm,
     # update_entity_status_in_odk,
 )
+from app.users.user_crud import get_or_create_user
 
 router = APIRouter(
     prefix="/integrations",
@@ -121,3 +129,46 @@ async def update_entity_status_from_webhook(
         )
         log.warning(msg)
         raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail=msg)
+
+
+@router.post("/new-user")
+async def create_new_user_from_external_platform(
+    user_data: ExternalUserIn,
+    org_user_dict: Annotated[OrgUserDict, Depends(org_admin)],
+    db: Annotated[Connection, Depends(db_conn)],
+):
+    """Create a new user and generate a login token / cookie.
+
+    This endpoint is used by managers, likely via API Key to generate
+    users from an external system in FieldTM, and authenticate the user
+    in advance for easy access to FieldTM.
+
+    NOTE if the provider & ID combination already exists, the user
+    details will be overwritten (allowing for updates for profile
+    picture, username, etc).
+    """
+    # Create user
+    user_sub = f"{user_data.platform}|{user_data.id}"
+    user_in = AuthUser(
+        sub=user_sub,
+        **user_data.model_dump(exclude=["id", "platform"]),
+    )
+    await get_or_create_user(db, user_in)
+
+    # Create cookies / auth
+    jwt_payload = {
+        "sub": user_in.sub,
+        "aud": settings.FMTM_DOMAIN,
+        "iat": int(time()),
+        "exp": int(time()) + 86400,
+        "username": user_data.username,
+        "email": user_data.email,
+        "picture": user_data.picture,
+        "role": UserRole.MAPPER.name,
+    }
+
+    fmtm_token, refresh_token = create_jwt_tokens(jwt_payload)
+    response = Response(status_code=HTTPStatus.OK)
+    response_plus_cookies = set_cookies(response, fmtm_token, refresh_token)
+
+    return response_plus_cookies

--- a/src/backend/app/organisations/organisation_routes.py
+++ b/src/backend/app/organisations/organisation_routes.py
@@ -113,7 +113,7 @@ async def delete_unapproved_org(
     """Delete an unapproved organisation.
 
     NOTE this endpoint is required as
-        org_user_dict: Annotated[AuthUser, Depends(org_admin)]
+        org_user_dict: Annotated[OrgUserDict, Depends(org_admin)]
     will also check if the organisation is approved and error if it's not.
     This is an ADMIN-only endpoint for deleting unapproved orgs.
     """
@@ -212,7 +212,7 @@ async def get_organisation_detail(
 @router.patch("/{org_id}", response_model=OrganisationOut)
 async def update_organisation(
     db: Annotated[Connection, Depends(db_conn)],
-    org_user_dict: Annotated[AuthUser, Depends(org_admin)],
+    org_user_dict: Annotated[OrgUserDict, Depends(org_admin)],
     new_values: OrganisationUpdate = Depends(parse_organisation_input),
     logo: UploadFile = File(None),
 ):
@@ -224,7 +224,7 @@ async def update_organisation(
 @router.delete("/{org_id}")
 async def delete_org(
     db: Annotated[Connection, Depends(db_conn)],
-    org_user_dict: Annotated[AuthUser, Depends(org_admin)],
+    org_user_dict: Annotated[OrgUserDict, Depends(org_admin)],
 ):
     """Delete an organisation."""
     org = org_user_dict.get("org")

--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -1001,7 +1001,7 @@ async def upload_project_task_boundaries(
 @router.post("", response_model=project_schemas.ProjectOut)
 async def create_project(
     project_info: project_schemas.ProjectIn,
-    org_user_dict: Annotated[AuthUser, Depends(org_admin)],
+    org_user_dict: Annotated[OrgUserDict, Depends(org_admin)],
     db: Annotated[Connection, Depends(db_conn)],
 ):
     """Create a project in ODK Central and the local database.

--- a/src/backend/app/users/user_crud.py
+++ b/src/backend/app/users/user_crud.py
@@ -23,19 +23,109 @@ from textwrap import dedent
 from typing import Optional
 
 from fastapi import Request
+from fastapi.exceptions import HTTPException
 from loguru import logger as log
 from osm_login_python.core import Auth
 from psycopg import Connection
 from psycopg.rows import class_row
 
+from app.auth.auth_schemas import AuthUser
 from app.auth.providers.osm import get_osm_token, send_osm_message
 from app.config import settings
+from app.db.enums import HTTPStatus, UserRole
 from app.db.models import DbProject, DbUser
 from app.projects.project_crud import get_pagination
 
 SVC_OSM_TOKEN = os.getenv("SVC_OSM_TOKEN", None)
 WARNING_INTERVALS = [21, 14, 7]  # Days before deletion
 INACTIVITY_THRESHOLD = 2 * 365  # 2 years approx
+
+
+async def get_or_create_user(
+    db: Connection,
+    user_data: AuthUser,
+) -> DbUser:
+    """Get user from User table if exists, else create."""
+    try:
+        upsert_sql = """
+            WITH upserted_user AS (
+                INSERT INTO users (
+                    sub,
+                    username,
+                    email_address,
+                    profile_img,
+                    role,
+                    registered_at
+                )
+                VALUES (
+                    %(user_sub)s,
+                    %(username)s,
+                    %(email_address)s,
+                    %(profile_img)s,
+                    %(role)s,
+                    NOW()
+                )
+                ON CONFLICT (sub)
+                DO UPDATE SET
+                    profile_img = EXCLUDED.profile_img,
+                    last_login_at = NOW()
+                RETURNING sub, username, email_address, profile_img, role
+            )
+
+            SELECT
+                u.sub,
+                u.username,
+                u.email_address,
+                u.profile_img,
+                u.role,
+
+                -- Aggregate the organisation IDs managed by the user
+                array_agg(
+                    DISTINCT om.organisation_id
+                ) FILTER (WHERE om.organisation_id IS NOT NULL) AS orgs_managed,
+
+                -- Aggregate project roles for the user, as project:role pairs
+                jsonb_object_agg(
+                    ur.project_id,
+                    COALESCE(ur.role, 'MAPPER')
+                ) FILTER (WHERE ur.project_id IS NOT NULL) AS project_roles
+
+            FROM upserted_user u
+            LEFT JOIN user_roles ur ON u.sub = ur.user_sub
+            LEFT JOIN organisation_managers om ON u.sub = om.user_sub
+            GROUP BY
+                u.sub,
+                u.username,
+                u.email_address,
+                u.profile_img,
+                u.role;
+        """
+
+        async with db.cursor(row_factory=class_row(DbUser)) as cur:
+            await cur.execute(
+                upsert_sql,
+                {
+                    "user_sub": user_data.sub,
+                    "username": user_data.username,
+                    "email_address": user_data.email,
+                    "profile_img": user_data.profile_img or "",
+                    "role": UserRole(user_data.role).name,
+                },
+            )
+            db_user_details = await cur.fetchone()
+
+        if not db_user_details:
+            raise HTTPException(
+                status_code=HTTPStatus.NOT_FOUND,
+                detail=f"User ({user_data.sub}) could not be inserted in db",
+            )
+
+        return db_user_details
+
+    except Exception as e:
+        await db.rollback()
+        log.exception(f"Exception occurred: {e}", stack_info=True)
+        raise HTTPException(status_code=HTTPStatus.BAD_REQUEST, detail=str(e)) from e
 
 
 async def process_inactive_users(

--- a/src/backend/tests/conftest.py
+++ b/src/backend/tests/conftest.py
@@ -34,7 +34,6 @@ from httpx import ASGITransport, AsyncClient
 from loguru import logger as log
 from psycopg import AsyncConnection
 
-from app.auth.auth_routes import get_or_create_user
 from app.auth.auth_schemas import AuthUser, FMTMUser
 from app.central import central_crud, central_schemas
 from app.central.central_schemas import ODKCentralDecrypted, ODKCentralIn
@@ -57,6 +56,7 @@ from app.organisations.organisation_schemas import OrganisationIn
 from app.projects import project_crud
 from app.projects.project_schemas import GeometryLogIn, ProjectIn, ProjectTeamIn
 from app.tasks.task_schemas import TaskEventIn
+from app.users.user_crud import get_or_create_user
 from app.users.user_deps import get_user
 from tests.test_data import test_data_path
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Describe this PR

- New route `/integrations/new-user` to:
  1. Create a new user.
  2. Provide an auth cookie set in the users browser.

- If an external application has an org_admin API key, then can do this.
- Create the user and provide the cookie.
- When the user visits FieldTM mapper frontend, they will be automatically logged in.

## Checklist before requesting a review

- 📖 Read the Field-TM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
