### PR TITLE
Allow verification questions for every geom type

### DIFF
--- a/src/backend/packages/osm-fieldwork/osm_fieldwork/update_xlsform.py
+++ b/src/backend/packages/osm-fieldwork/osm_fieldwork/update_xlsform.py
@@ -345,9 +345,6 @@ def _get_form_components(
         need_verification_fields: bool
     ) -> dict:
     """Select appropriate form components based on target platform."""
-    # only add verification questions if new feature type is Polygon
-    need_verification_fields = new_geom_type == DbGeomType.POLYGON and need_verification_fields
-
     if use_odk_collect:
         # Here we modify digitisation_df to include the `new_feature` field
         # NOTE we set digitisation_correct to 'yes' if the user is drawing a new geometry


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [X] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- Issue: By default `new_geom_type` is set `POINT`, and allowing `verification fields` results in invalid xlsform
- pytest failure

## Describe this PR

- Simply allows verification fields based on `need_verification_fields` bool

## Screenshots

N/A

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the Field-TM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
