### PR TITLE
Refactor: Skip polygon selection confirmation step

### DIFF
--- a/src/frontend/src/components/ProjectDetails/ProjectDetailsMap.tsx
+++ b/src/frontend/src/components/ProjectDetails/ProjectDetailsMap.tsx
@@ -386,39 +386,16 @@ const ProjectDetailsMap = ({ setSelectedTaskArea, setSelectedTaskFeature, setMap
                 <p className="fmtm-font-semibold fmtm-mb-1">
                   {i + 1}. {id}
                 </p>
-                {selectedEntityId === id ? (
-                  <div className="fmtm-flex fmtm-gap-2 fmtm-w-full">
-                    <Button
-                      className="!fmtm-w-1/2"
-                      variant="primary-grey"
-                      onClick={() => {
-                        dispatch(ProjectActions.SetSelectedEntityId(null));
-                      }}
-                    >
-                      Cancel
-                    </Button>
-                    <Button
-                      className="!fmtm-w-1/2"
-                      variant="primary-red"
-                      onClick={() => {
-                        handleFeatureClick(featureProperties, feature);
-                        setOverlappingEntityFeatures([]);
-                      }}
-                    >
-                      Map this feature
-                    </Button>
-                  </div>
-                ) : (
-                  <Button
-                    className="!fmtm-w-full"
-                    variant="primary-red"
-                    onClick={() => {
-                      dispatch(ProjectActions.SetSelectedEntityId(id));
-                    }}
-                  >
-                    Select this feature
-                  </Button>
-                )}
+                <Button
+                  className="!fmtm-w-full"
+                  variant="primary-red"
+                  onClick={() => {
+                    handleFeatureClick(featureProperties, feature);
+                    setOverlappingEntityFeatures([]);
+                  }}
+                >
+                  Select this feature
+                </Button>
               </div>
             );
           })}

--- a/src/mapper/src/lib/components/dialog-entities-actions.svelte
+++ b/src/mapper/src/lib/components/dialog-entities-actions.svelte
@@ -11,7 +11,6 @@
 	import { getTaskStore } from '$store/tasks.svelte.ts';
 	import { mapTask } from '$lib/db/events';
 
-	type statusType = 'READY' | 'OPENED_IN_ODK' | 'SURVEY_SUBMITTED' | 'MARKED_BAD' | 'VALIDATED';
 	type Props = {
 		isTaskActionModalOpen: boolean;
 		toggleTaskActionModal: (value: boolean) => void;
@@ -146,10 +145,16 @@
 			<div class="icon">
 				<hot-icon
 					name="close"
-					onclick={() => toggleTaskActionModal(false)}
+					onclick={() => {
+						toggleTaskActionModal(false);
+						entitiesStore.setSelectedEntity(null);
+						entitiesStore.setSelectedEntityCoordinate(null);
+					}}
 					onkeydown={(e: KeyboardEvent) => {
 						if (e.key === 'Enter') {
 							toggleTaskActionModal(false);
+							entitiesStore.setSelectedEntity(null);
+							entitiesStore.setSelectedEntityCoordinate(null);
 						}
 					}}
 					role="button"

--- a/src/mapper/src/lib/components/map/main.svelte
+++ b/src/mapper/src/lib/components/map/main.svelte
@@ -877,56 +877,26 @@
 							<p class={`status ${feature.properties.status}`}>{m[`entity_states.${feature.properties.status}`]()}</p>
 						</div>
 						<div class="button-wrapper">
-							{#if entitiesStore.selectedEntity && entitiesStore.selectedEntity === feature.properties.entity_id}
-								<sl-button
-									variant="secondary"
-									size="small"
-									onclick={() => {
-										entitiesStore.setSelectedEntity(null);
-										entitiesStore.setSelectedEntityCoordinate(null);
-									}}
-									onkeydown={() => {}}
-									role="button"
-									tabindex="0"
-								>
-									{m['popup.cancel']()}
-								</sl-button>
-								<sl-button
-									variant="primary"
-									size="small"
-									onclick={() => {
-										selectedFeatures = [];
-										toggleActionModal('entity-modal');
-									}}
-									onkeydown={() => {
-										selectedFeatures = [];
-										toggleActionModal('entity-modal');
-									}}
-									role="button"
-									tabindex="0"
-								>
-									{m['popup.map_this_feature']()}
-								</sl-button>
-							{:else}
-								<sl-button
-									variant="primary"
-									size="small"
-									onclick={() => {
-										const entityCentroid = centroid(feature.geometry);
-										const clickedEntityId = feature?.properties?.entity_id;
-										entitiesStore.setSelectedEntity(clickedEntityId);
-										entitiesStore.setSelectedEntityCoordinate({
-											entityId: clickedEntityId,
-											coordinate: entityCentroid?.geometry?.coordinates,
-										});
-									}}
-									onkeydown={() => {}}
-									role="button"
-									tabindex="0"
-								>
-									{m['popup.select_this_feature']()}
-								</sl-button>
-							{/if}
+							<sl-button
+								variant="primary"
+								size="small"
+								onclick={() => {
+									const entityCentroid = centroid(feature.geometry);
+									const clickedEntityId = feature?.properties?.entity_id;
+									entitiesStore.setSelectedEntity(clickedEntityId);
+									entitiesStore.setSelectedEntityCoordinate({
+										entityId: clickedEntityId,
+										coordinate: entityCentroid?.geometry?.coordinates,
+									});
+									selectedFeatures = [];
+									toggleActionModal('entity-modal');
+								}}
+								onkeydown={() => {}}
+								role="button"
+								tabindex="0"
+							>
+								{m['popup.select_this_feature']()}
+							</sl-button>
 						</div>
 					</div>
 				{/each}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [x] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue
- Related to #2352

## Describe this PR
After clicking on `Select this feature` button, directly show the `entity-modal` by skipping entity selection confirmation step

## Screenshots

https://github.com/user-attachments/assets/8c58c315-a56c-4585-be90-26dd7d0adade


https://github.com/user-attachments/assets/e6b008bf-f885-4622-a870-3a5bc0a82fd2

