### PR TITLE
Fix satellite imagery zoom error

### DIFF
--- a/src/frontend/src/components/MapComponent/OpenLayersComponent/LayerSwitcher/index.js
+++ b/src/frontend/src/components/MapComponent/OpenLayersComponent/LayerSwitcher/index.js
@@ -40,15 +40,9 @@ const bingMaps = (visible) =>
     visible: visible === 'satellite',
     source: new XYZ({
       url: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+      minZoom: 0,
+      maxZoom: 18, // still only request tiles up to 18
     }),
-    // source: new BingMaps({
-    //   key: 'AoTlmaazzog43ImdKts9HVztFzUI4PEOT0lmo2V4q7f20rfVorJGAgDREKmfQAgd',
-    //   imagerySet: 'Aerial',
-    //   // use maxZoom 19 to see stretched tiles instead of the BingMaps
-    //   // "no photos at this zoom level" tiles
-    //   maxZoom: 19,
-    //   crossOrigin: 'Anonymous',
-    // }),
   });
 
 const mapboxMap = (visible) =>

--- a/src/mapper/src/constants/baseLayers.ts
+++ b/src/mapper/src/constants/baseLayers.ts
@@ -92,7 +92,7 @@ let satellite = {
 			type: 'raster',
 			tiles: ['https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'],
 			minzoom: 0,
-			maxzoom: 19,
+			maxzoom: 18,
 			tileSize: 256,
 			attribution: 'ArcGIS',
 		},

--- a/src/mapper/src/routes/project/[projectId]/+page.svelte
+++ b/src/mapper/src/routes/project/[projectId]/+page.svelte
@@ -501,9 +501,11 @@
 			<sl-tab slot="nav" panel="offline">
 				<hot-icon name="wifi-off"></hot-icon>
 			</sl-tab>
-			<sl-tab slot="nav" panel="qrcode">
-				<hot-icon name="qr-code"></hot-icon>
-			</sl-tab>
+			{#if !commonStore.enableWebforms}
+				<sl-tab slot="nav" panel="qrcode">
+					<hot-icon name="qr-code"></hot-icon>
+				</sl-tab>
+			{/if}
 			<sl-tab slot="nav" panel="events">
 				<hot-icon name="three-dots"></hot-icon>
 			</sl-tab>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue
- Satellite imagery, when zoomed in, displays an error on the tile showing `Map data not available`
- QR tab on the mapper is visible when webforms enabled

## Describe this PR
- Fix tile error by setting the max zoom level of satellite imagery to 18 
- Hide QR tab if webforms enabled. (Forgot that I mistakenly made the QR tab visible while making the offline tab visible yesterday)

## Screenshots
Before:
![image](https://github.com/user-attachments/assets/06e27032-6193-4aad-856d-5c0a8b0270c4)

After:
![image](https://github.com/user-attachments/assets/ebd2fe81-27f9-490c-8acf-f330e8a69012)