### PR TITLE
tweak iframe height

### DIFF
--- a/src/mapper/src/lib/components/forms/wrapper.svelte
+++ b/src/mapper/src/lib/components/forms/wrapper.svelte
@@ -268,8 +268,7 @@
 									{/if}
 									<iframe
 										class="iframe"
-										style:border="none"
-										style:height="100%"
+										style="border: none; height: 100%; height: -webkit-fill-available;"
 										use:handleIframe
 										title="odk-web-forms-wrapper"
 										id={WEB_FORMS_IFRAME_ID}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [X] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Example: Fixes #2477 

## Describe this PR

This might solve the issue of the form not resizing when the mobile keyboard is closed.  If the -webkit-fill-available is not available, then it'll fallback to the existing height: 100% rule.

## Screenshots

N/A

## Alternative Approaches Considered

I considered editing the css file, but that would require changing @hotosm/ui and I'm not sure this will fix it.

If the approach in the PR doesn't work, we might have to look at adding a [ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) and some JavaScript logic to resize the iframe whenever the container size changes.  My hunch is that this is actually a bug in the Chrome mobile app and we may have to develop a workaround.

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the Field-TM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
