### PR TITLE
prepend fmtm.hotosm.org: to deviceid

### DIFF
--- a/src/mapper/src/lib/components/forms/wrapper.svelte
+++ b/src/mapper/src/lib/components/forms/wrapper.svelte
@@ -81,7 +81,7 @@
 			submissionXml = submissionXml.replace('<warmup/>', `<warmup>${latitude} ${longitude} 0.0 0.0</warmup>`);
 		}
 
-		submissionXml = submissionXml.replace('<deviceid/>', `<deviceid>${getDeviceId()}</deviceid>`);
+		submissionXml = submissionXml.replace('<deviceid/>', `<deviceid>fmtm.hotosm.org:${getDeviceId()}</deviceid>`);
 
 		return submissionXml;
 	}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [X] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Addresses request to prepend `fmtm.hotosm.org:` to deviceid: https://github.com/hotosm/fmtm/issues/2433

## Describe this PR

Basically just adds to the string

## Screenshots

<img width="769" alt="Screenshot 2025-06-04 at 10 27 03 AM" src="https://github.com/user-attachments/assets/d1ac1fc6-eff4-42e7-b78a-cebc88a126e9" />


## Alternative Approaches Considered

I considered storing `fmtm.hotosm.org:` as a part of the device id in localstorage.

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the Field-TM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
