### PR TITLE
Implement organisation approval request notification along with odk server request when applicable

### DIFF
--- a/src/backend/app/db/models.py
+++ b/src/backend/app/db/models.py
@@ -595,6 +595,16 @@ class DbOrganisation(BaseModel):
         return db_org
 
     @classmethod
+    async def primary_org(cls, db: Connection) -> Self:
+        """Fetch the first organisation (lowest ID)."""
+        async with db.cursor(row_factory=class_row(cls)) as cur:
+            await cur.execute("SELECT * FROM organisations ORDER BY id LIMIT 1;")
+            db_org = await cur.fetchone()
+            if db_org is None:
+                raise KeyError("No organisations found.")
+        return db_org
+
+    @classmethod
     async def all(
         cls, db: Connection, current_user_sub: str = ""
     ) -> Optional[list[Self]]:

--- a/src/backend/app/organisations/organisation_crud.py
+++ b/src/backend/app/organisations/organisation_crud.py
@@ -212,8 +212,6 @@ async def send_organisation_approval_request(
             "Please arrange setup.\n"
         )
 
-    message_content += "\nThank you for being a part of our platform!"
-
     await send_mail(
         user_email=primary_organisation.associated_email,
         title=title,

--- a/src/backend/app/organisations/organisation_crud.py
+++ b/src/backend/app/organisations/organisation_crud.py
@@ -36,6 +36,7 @@ from app.config import settings
 from app.db.enums import MappingLevel, UserRole
 from app.db.models import DbOrganisation, DbOrganisationManagers, DbUser
 from app.organisations.organisation_schemas import OrganisationIn, OrganisationOut
+from app.users.user_crud import send_mail
 from app.users.user_schemas import UserIn
 
 
@@ -173,3 +174,54 @@ async def send_approval_message(
         body=message_content,
     )
     log.info(f"Approval message sent to organisation creator ({creator_sub}).")
+
+
+async def send_organisation_approval_request(
+    organisation: DbOrganisation,
+    requester: str,
+    primary_organisation: DbOrganisation,
+    request_odk_server: bool,
+):
+    """Notify primary organisation about new organisation's creation."""
+    organisation_url = f"{settings.FMTM_DOMAIN}/organization/{organisation.id}"
+
+    if settings.DEBUG:
+        organisation_url = f"http://{settings.FMTM_DOMAIN}:{settings.FMTM_DEV_PORT}/organization/{organisation.id}"
+    else:
+        organisation_url = (
+            f"https://{settings.FMTM_DOMAIN}/organization/{organisation.id}"
+        )
+
+    title = f"Creation of a new organization {organisation.name} was requested"
+    message_content = dedent(f"""
+        A new organisation **{organisation.name}** has been created by **{requester}**.
+
+        You can view the organisation details here:
+        - [{organisation.name}]({organisation_url}).
+
+        The organisation is currently pending approval.
+        Please review the organisation details and approve or reject it as soon as
+        possible.
+        The organisation's associated email is: {organisation.associated_email} if you
+        need to contact them.
+    """)
+
+    if request_odk_server:
+        message_content += (
+            f"\nThe user has requested access to the "
+            f"{primary_organisation.name} ODK server at "
+            f"{primary_organisation.odk_central_url}. "
+            "Please arrange setup.\n"
+        )
+
+    message_content += "\nThank you for being a part of our platform!"
+
+    await send_mail(
+        user_email=primary_organisation.associated_email,
+        title=title,
+        message_content=message_content,
+    )
+    log.info(
+        "Notification about organisation creation sent at "
+        f"{primary_organisation.associated_email}."
+    )

--- a/src/backend/app/organisations/organisation_crud.py
+++ b/src/backend/app/organisations/organisation_crud.py
@@ -206,7 +206,7 @@ async def send_organisation_approval_request(
 
     if request_odk_server:
         message_content += (
-            f"\nThe user has requested access to the "
+            f"\nThe organisation creator has requested access to the "
             f"{primary_organisation.name} ODK server at "
             f"{primary_organisation.odk_central_url}. "
             "Please arrange setup.\n"

--- a/src/backend/app/organisations/organisation_crud.py
+++ b/src/backend/app/organisations/organisation_crud.py
@@ -183,8 +183,6 @@ async def send_organisation_approval_request(
     request_odk_server: bool,
 ):
     """Notify primary organisation about new organisation's creation."""
-    organisation_url = f"{settings.FMTM_DOMAIN}/organization/{organisation.id}"
-
     if settings.DEBUG:
         organisation_url = f"http://{settings.FMTM_DOMAIN}:{settings.FMTM_DEV_PORT}/organization/{organisation.id}"
     else:


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- Related to: #2563 

## Describe this PR

Sends an approval request email to the associated email of the primary organisation whenever a new organisation is created. The requesting user can also request odk server for usage.

## Screenshots

Please provide screenshots of the change.

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the Field-TM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
