### PR TITLE
pass fmtm domain to deviceid

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -218,6 +218,7 @@ services:
       # - ../ui:/app/node_modules/@hotosm/ui:ro
     environment:
       - TEST_PWA=${TEST_PWA:-false}
+      - VITE_FMTM_DOMAIN=${FMTM_DOMAIN}
       - VITE_API_URL=http://api.${FMTM_DOMAIN}:${FMTM_DEV_PORT:-7050}
       - VITE_SYNC_URL=http://sync.${FMTM_DOMAIN}:${FMTM_DEV_PORT:-7050}
       - VITE_S3_URL=http://s3.${FMTM_DOMAIN}:${FMTM_DEV_PORT:-7050}

--- a/contrib/just/start/Justfile
+++ b/contrib/just/start/Justfile
@@ -56,6 +56,7 @@ frontend-dev:
   cd {{justfile_directory()}}/src/frontend
 
   pnpm install
+  VITE_FMTM_DOMAIN=fmtm.hotosm.org \
   VITE_API_URL=https://api.stage.fmtm.hotosm.org \
   pnpm run dev
 
@@ -67,6 +68,7 @@ mapper-frontend-dev:
   cd {{justfile_directory()}}/src/mapper
 
   pnpm install
+  VITE_FMTM_DOMAIN=fmtm.hotosm.org \
   VITE_API_URL=https://api.stage.fmtm.hotosm.org \
   VITE_SYNC_URL=https://sync.stage.fmtm.hotosm.org \
   VITE_S3_URL=https://s3.stage.fmtm.hotosm.org \

--- a/contrib/just/test/Justfile
+++ b/contrib/just/test/Justfile
@@ -82,6 +82,7 @@ mapper-preview:
   cd {{justfile_directory()}}/src/mapper
   pnpm install
   VITE_API_URL=http://api.fmtm.localhost:7050 \
+    VITE_FMTM_DOMAIN=fmtm.localhost \
     VITE_SYNC_URL=http://sync.fmtm.localhost:7050 \
     VITE_S3_URL=http://s3.fmtm.localhost:7050 \
     pnpm run build

--- a/deploy/compose.development.yaml
+++ b/deploy/compose.development.yaml
@@ -178,6 +178,7 @@ services:
       dockerfile: Dockerfile.ui.prod
       args:
         APP_VERSION: ${GIT_BRANCH}
+        VITE_FMTM_DOMAIN: ${FMTM_DOMAIN}
         VITE_API_URL: https://${FMTM_API_DOMAIN:-api.${FMTM_DOMAIN}}
         VITE_SYNC_URL: https://${FMTM_SYNC_DOMAIN:-sync.${FMTM_DOMAIN}}
         VITE_S3_URL: https://${FMTM_SYNC_DOMAIN:-sync.${FMTM_DOMAIN}}

--- a/deploy/compose.sub.yaml
+++ b/deploy/compose.sub.yaml
@@ -178,6 +178,7 @@ services:
       dockerfile: Dockerfile.ui.prod
       args:
         APP_VERSION: ${GIT_BRANCH}
+        VITE_FMTM_DOMAIN: ${FMTM_DOMAIN}
         VITE_API_URL: https://${FMTM_API_DOMAIN:-api.${FMTM_DOMAIN}}
         VITE_SYNC_URL: https://${FMTM_SYNC_DOMAIN:-sync.${FMTM_DOMAIN}}
         VITE_S3_URL: https://${FMTM_S3_DOMAIN:-s3.${FMTM_DOMAIN}}

--- a/src/Dockerfile.ui.prod
+++ b/src/Dockerfile.ui.prod
@@ -1,10 +1,12 @@
 FROM docker.io/node:22-slim AS base
+ARG VITE_FMTM_DOMAIN
 ARG VITE_API_URL
 ARG VITE_SYNC_URL
 ARG VITE_S3_URL
 ENV VITE_API_URL=${VITE_API_URL} \
     VITE_SYNC_URL=${VITE_SYNC_URL} \
     VITE_S3_URL=${VITE_S3_URL} \
+    VITE_FMTM_DOMAIN=${VITE_FMTM_DOMAIN} \
     PNPM_HOME="/pnpm" \
     PATH="$PATH:/pnpm"
 # FIXME this npm install is a workaround due to https://github.com/nodejs/corepack/issues/627
@@ -40,6 +42,7 @@ RUN pnpm run build
 FROM docker.io/rclone/rclone:1 AS prod
 ARG APP_VERSION
 ARG COMMIT_REF
+ARG VITE_FMTM_DOMAIN
 ARG VITE_API_URL
 ARG VITE_SYNC_URL
 ARG VITE_S3_URL
@@ -47,6 +50,7 @@ LABEL org.hotosm.fmtm.app-name="frontend" \
       org.hotosm.fmtm.app-version="${APP_VERSION}" \
       org.hotosm.fmtm.git-commit-ref="${COMMIT_REF:-none}" \
       org.hotosm.fmtm.maintainer="sysadmin@hotosm.org" \
+      org.hotosm.fmtm.fmtm-domain="${VITE_FMTM_DOMAIN}" \
       org.hotosm.fmtm.api-url="${VITE_API_URL}" \
       org.hotosm.fmtm.sync-url="${VITE_SYNC_URL}" \
       org.hotosm.fmtm.s3-url="${VITE_S3_URL}"

--- a/src/mapper/src/lib/components/forms/wrapper.svelte
+++ b/src/mapper/src/lib/components/forms/wrapper.svelte
@@ -20,6 +20,9 @@
 		webFormsRef: HTMLElement | undefined;
 	};
 
+	// if VITE_FMTM_DOMAIN is not set, use hostname but with first subdomain removed (like mapper.fmtm.localhost to fmtm.localhost)
+	const FMTM_DOMAIN = import.meta.env.VITE_FMTM_DOMAIN || window.location.hostname.split(".").slice(1).join(".");
+
 	const WEB_FORMS_IFRAME_ID = "7f86f661-efd6-4cc6-b068-48dd7eb53dbb";
 
 	const commonStore = getCommonStore();
@@ -82,7 +85,7 @@
 			submissionXml = submissionXml.replace('<warmup/>', `<warmup>${latitude} ${longitude} 0.0 0.0</warmup>`);
 		}
 
-		submissionXml = submissionXml.replace('<deviceid/>', `<deviceid>${getDeviceId()}</deviceid>`);
+		submissionXml = submissionXml.replace('<deviceid/>', `<deviceid>${FMTM_DOMAIN}:${getDeviceId()}</deviceid>`);
 
 		return submissionXml;
 	}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [X] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

https://github.com/hotosm/fmtm/issues/2433

## Describe this PR

Supersedes https://github.com/hotosm/fmtm/pull/2584

Prepends VITE_FMTM_DOMAIN to device id.  Calculates it via page location if env var isn't available.

## Screenshots

<img width="522" alt="Screenshot 2025-06-05 at 10 12 19 PM" src="https://github.com/user-attachments/assets/7da8e49b-6b2a-4a9a-b62b-673eb68eab82" />

## Alternative Approaches Considered

Could store in localStorage, but that could get weird because I think two subdomain could access the same localStorage

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the Field-TM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
