### PR TITLE
Update submission retrieval to use pyodk except in submission detail page

### DIFF
--- a/src/backend/app/submissions/submission_routes.py
+++ b/src/backend/app/submissions/submission_routes.py
@@ -352,7 +352,9 @@ async def submission_table(
             else review_filter
         )
 
-    data = await submission_crud.get_submission_by_project(project, filters)
+    data = await submission_crud.get_submission_by_project(
+        project, filters, use_osm_fieldwork=True
+    )
     total_count = data.get("@odata.count", 0)
     submissions = data.get("value", [])
     if review_state == "received":

--- a/src/backend/app/submissions/submission_routes.py
+++ b/src/backend/app/submissions/submission_routes.py
@@ -337,31 +337,29 @@ async def submission_table(
         "$wkt": True,
     }
 
+    filter_clauses = []
+
     if submitted_date_range:
         start_date, end_date = submitted_date_range.split(",")
-        filters["$filter"] = (
-            "__system/submissionDate ge {}T00:00:00+00:00 "
-            "and __system/submissionDate le {}T23:59:59.999+00:00"
-        ).format(start_date, end_date)
-
-    if review_state and review_state != "received":
-        review_filter = f"__system/reviewState eq '{review_state}'"
-        filters["$filter"] = (
-            f"{filters['$filter']} and {review_filter}"
-            if "$filter" in filters
-            else review_filter
+        filter_clauses.append(
+            f"__system/submissionDate ge {start_date}T00:00:00+00:00 "
+            f"and __system/submissionDate le {end_date}T23:59:59.999+00:00"
         )
 
-    data = await submission_crud.get_submission_by_project(
-        project, filters, use_osm_fieldwork=True
-    )
-    total_count = data.get("@odata.count", 0)
+    if review_state and review_state != "received":
+        filter_clauses.append(f"__system/reviewState eq '{review_state}'")
+
+    if filter_clauses:
+        filters["$filter"] = " and ".join(filter_clauses)
+
+    data = await submission_crud.get_submission_by_project(project, filters)
+
     submissions = data.get("value", [])
+
     if review_state == "received":
         submissions = [
             sub for sub in submissions if sub["__system"].get("reviewState") is None
         ]
-        total_count = len(submissions)
 
     if task_id:
         submissions = [sub for sub in submissions if sub.get("task_id") == str(task_id)]
@@ -371,6 +369,7 @@ async def submission_table(
             sub for sub in submissions if sub.get("username") == submitted_by
         ]
 
+    total_count = len(submissions)
     start_index = (page - 1) * results_per_page
     end_index = start_index + results_per_page
     paginated_submissions = submissions[start_index:end_index]
@@ -378,12 +377,11 @@ async def submission_table(
     pagination = await project_crud.get_pagination(
         page, len(submissions), results_per_page, total_count
     )
-    response = submission_schemas.PaginatedSubmissions(
+
+    return submission_schemas.PaginatedSubmissions(
         results=paginated_submissions,
         pagination=submission_schemas.PaginationInfo(**pagination.model_dump()),
     )
-
-    return response
 
 
 @router.post(


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [x] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- Related to: #2550

## Describe this PR

Include data from repeat groups by using pyodk in list submissions, submission table, submission json and geojson download.
Pyodk was found to be faster by at least 10 seconds on average on some rough local load testing.
We still need to work on repeat group on submission detail page as it is also not supported by pyodk.

## Screenshots

Please provide screenshots of the change.

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the Field-TM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
