### PR TITLE
Allow creating entity even without login using svcfmtm

### DIFF
--- a/src/mapper/src/routes/project/[projectId]/+page.svelte
+++ b/src/mapper/src/routes/project/[projectId]/+page.svelte
@@ -326,7 +326,8 @@
 							osm_id: newOsmId,
 							task_id: taskStore.selectedTaskIndex || '',
 							status: '0', // TODO update this to use the enum / mapping
-							created_by: loginStore.getAuthDetails?.sub,
+							// NOTE: 'osm|20386219' is the service user 'svcfmtm' (not a logged-in user).
+							created_by: loginStore.getAuthDetails?.sub || 'osm|20386219',
 						},
 					},
 				],


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- Issue #2602

## Describe this PR

In order to create an entity, we need to have a not-null created_by field in the `odk-entities` table; we are using the `created_by` field to track new entity geometries. Adding the `svcfmtm` user's sub `osm|20386219` while creating a new entity without login would allow users to create the entity but doesn't allow deleting it, which is what we wanted to have.

## Screenshots

N/A

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the Field-TM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
