### PR TITLE
Add option to set primary ODK server during approval

### DIFF
--- a/src/backend/app/config.py
+++ b/src/backend/app/config.py
@@ -161,7 +161,7 @@ class Settings(BaseSettings):
 
     DEFAULT_ORG_NAME: Optional[str] = "HOTOSM"
     DEFAULT_ORG_URL: Optional[str] = "https://hotosm.org"
-    DEFAULT_ORG_EMAIL: Optional[str] = "syadmin@hotosm.org"
+    DEFAULT_ORG_EMAIL: Optional[str] = "sysadmin@hotosm.org"
     DEFAULT_ORG_LOGO_URL: Optional[str] = (
         "https://raw.githubusercontent.com/hotosm/fmtm/refs/heads/development/src/frontend/public/hot-org-logo.png"
     )

--- a/src/backend/app/db/models.py
+++ b/src/backend/app/db/models.py
@@ -254,6 +254,7 @@ class DbUser(BaseModel):
         search: Optional[str] = None,
         username: Optional[str] = None,
         signin_type: Optional[str] = None,
+        role: Optional[UserRole] = None,
     ) -> Optional[list[Self]]:
         """Fetch all users."""
         filters = []
@@ -270,6 +271,10 @@ class DbUser(BaseModel):
         if signin_type:
             filters.append("sub LIKE %(signin_type)s")
             params["signin_type"] = f"{signin_type}|%"
+
+        if role:
+            filters.append("role = %(role)s")
+            params["role"] = role
 
         sql = f"""
             SELECT * FROM users

--- a/src/backend/app/organisations/organisation_crud.py
+++ b/src/backend/app/organisations/organisation_crud.py
@@ -154,6 +154,7 @@ async def send_approval_message(
     creator_sub: str,
     organisation_name: str,
     osm_auth: Auth,
+    set_primary_org_odk_server: bool = False,
 ):
     """Send message to the organisation creator after approval."""
     log.info(f"Sending approval message to organisation creator ({creator_sub}).")
@@ -164,8 +165,13 @@ async def send_approval_message(
         Your organisation **{organisation_name}** has been approved.
 
         You can now manage your organisation freely.
-
-        Thank you for being a part of our platform!
+    """)
+    if set_primary_org_odk_server:
+        message_content += dedent("""
+            It has also been granted access to the ODK server.
+        """)
+    message_content += dedent("""
+        \nThank you for being a part of our platform!
     """)
     send_osm_message(
         osm_token=osm_token,
@@ -184,7 +190,7 @@ async def send_organisation_approval_request(
 ):
     """Notify primary organisation about new organisation's creation."""
     if settings.DEBUG:
-        organisation_url = f"http://{settings.FMTM_DOMAIN}:{settings.FMTM_DEV_PORT}/organization/{organisation.id}"
+        organisation_url = f"http://{settings.FMTM_DOMAIN}:{settings.FMTM_DEV_PORT}/organization/approve/{organisation.id}"
     else:
         organisation_url = (
             f"https://{settings.FMTM_DOMAIN}/organization/{organisation.id}"
@@ -209,7 +215,7 @@ async def send_organisation_approval_request(
             f"\nThe organisation creator has requested access to the "
             f"{primary_organisation.name} ODK server at "
             f"{primary_organisation.odk_central_url}. "
-            "Please arrange setup.\n"
+            "The access can be granted during the organisation's approval.\n"
         )
 
     await send_mail(

--- a/src/backend/app/organisations/organisation_routes.py
+++ b/src/backend/app/organisations/organisation_routes.py
@@ -182,7 +182,6 @@ async def approve_organisation(
     )
     # Set organisation requester as organisation manager
     if approved_org.created_by:
-        print("here")
         await DbOrganisationManagers.create(
             db, approved_org.id, approved_org.created_by
         )

--- a/src/backend/app/users/user_crud.py
+++ b/src/backend/app/users/user_crud.py
@@ -21,7 +21,7 @@ import os
 from datetime import datetime, timedelta, timezone
 from email.message import EmailMessage
 from textwrap import dedent
-from typing import Literal, Optional
+from typing import List, Literal, Optional
 
 import aiosmtplib
 import markdown
@@ -221,7 +221,7 @@ async def send_warning_email_or_osm(
 
 
 async def send_mail(
-    user_email: str,
+    user_emails: List[str],
     title: str,
     message_content: str,
 ):
@@ -235,10 +235,11 @@ async def send_mail(
     html_content = markdown.markdown(message_content)
     message.add_alternative(html_content, subtype="html")
 
+    log.debug(f"Sending email to {', '.join(user_emails)}")
     await aiosmtplib.send(
         message,
         sender=settings.SMTP_USER,
-        recipients=[user_email],
+        recipients=user_emails,
         hostname=settings.SMTP_HOST,
         port=settings.SMTP_PORT,
         username=settings.SMTP_USER,
@@ -287,7 +288,7 @@ async def send_invitation_message(
 
     elif signin_type == "google":
         await send_mail(
-            user_email=user_email,
+            user_emails=[user_email],
             title=title,
             message_content=message_content,
         )

--- a/src/backend/app/users/user_crud.py
+++ b/src/backend/app/users/user_crud.py
@@ -21,7 +21,7 @@ import os
 from datetime import datetime, timedelta, timezone
 from email.message import EmailMessage
 from textwrap import dedent
-from typing import List, Literal, Optional
+from typing import Literal, Optional
 
 import aiosmtplib
 import markdown
@@ -221,7 +221,7 @@ async def send_warning_email_or_osm(
 
 
 async def send_mail(
-    user_emails: List[str],
+    user_emails: list[str],
     title: str,
     message_content: str,
 ):

--- a/src/backend/tests/test_organisation_routes.py
+++ b/src/backend/tests/test_organisation_routes.py
@@ -27,11 +27,15 @@ from app.db.models import DbOrganisationManagers
 
 async def test_create_organisation(client, organisation_data, organisation_logo):
     """Test creating an organisation."""
-    response = await client.post(
-        "/organisation",
-        data=organisation_data,
-        files={"logo": organisation_logo},
-    )
+    with patch(
+        "app.organisations.organisation_crud.send_organisation_approval_request",
+        return_value=None,
+    ):
+        response = await client.post(
+            "/organisation",
+            data=organisation_data,
+            files={"logo": organisation_logo},
+        )
     assert response.status_code == HTTPStatus.OK
     data = response.json()
     assert data["name"] == organisation_data["name"]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- Related to: #2563 #2300 

## Describe this PR

Allow admins and primary organizations to assign an ODK server during organization approval, instead of manual-assigning it on request. Updated the organization approval request message to include an approval URL. Also added a role filter to the DbUser.all() method.

## Screenshots

Please provide screenshots of the change.

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the Field-TM Contributing Guide: <https://github.com/hotosm/fmtm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
