### PR TITLE
Sync multiple submission id's

### DIFF
--- a/src/backend/app/central/central_schemas.py
+++ b/src/backend/app/central/central_schemas.py
@@ -329,3 +329,4 @@ class OdkEntitiesUpdate(BaseModel):
     """A small base model to update the OdkEntity status field only."""
 
     status: str  # this must be the str representation of the db enum
+    submission_ids: Optional[str] = None

--- a/src/backend/app/integrations/integration_crud.py
+++ b/src/backend/app/integrations/integration_crud.py
@@ -78,6 +78,7 @@ async def update_entity_status_in_fmtm(
 
     # Insert state into db
     new_state = odk_event.data.get("status")
+    submission_ids = odk_event.data.get("submission_ids", "")
 
     if new_state is None:
         log.warning(f"Missing entity state in webhook event: {odk_event.data}")
@@ -106,7 +107,7 @@ async def update_entity_status_in_fmtm(
     update_success = await DbOdkEntities.update(
         db,
         str(odk_event.id),
-        OdkEntitiesUpdate(status=new_entity_state),
+        OdkEntitiesUpdate(status=new_entity_state, submission_ids=submission_ids),
     )
     if not update_success:
         raise HTTPException(

--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -52,12 +52,9 @@ from app.auth.auth_schemas import AuthUser, OrgUserDict, ProjectUserDict
 from app.auth.providers.osm import init_osm_auth
 from app.auth.roles import Mapper, ProjectManager, org_admin
 from app.central import central_crud, central_deps, central_schemas
-from app.central.central_schemas import (
-    OdkEntitiesUpdate,
-)
 from app.config import settings
 from app.db.database import db_conn
-from app.db.enums import DbGeomType, EntityState, HTTPStatus, ProjectRole, XLSFormType
+from app.db.enums import DbGeomType, HTTPStatus, ProjectRole, XLSFormType
 from app.db.languages_and_countries import countries
 from app.db.models import (
     DbBackgroundTask,

--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -284,12 +284,6 @@ async def set_odk_entities_mapping_status(
     }
     """
     project = project_user.get("project")
-    new_status = EntityState(int(entity_details.status)).name
-    await DbOdkEntities.update(
-        db,
-        entity_details.entity_id,
-        OdkEntitiesUpdate(status=new_status),
-    )
     return await central_crud.update_entity_mapping_status(
         project.odk_credentials,
         project.odkid,

--- a/src/mapper/src/lib/db/entities.ts
+++ b/src/mapper/src/lib/db/entities.ts
@@ -8,9 +8,9 @@ import { javarosaToGeojsonGeom } from '$lib/odk/javarosa';
 async function update(db: PGlite, entity: Partial<DbEntityType>) {
 	await db.query(
 		`UPDATE odk_entities
-         SET status = $2
+         SET status = $2, submission_ids = $3
          WHERE entity_id = $1`,
-		[entity.entity_id, entity.status],
+		[entity.entity_id, entity.status, entity.submission_ids],
 	);
 }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue
- Related to #2620

## Describe this PR
- add submission_ids to OdkEntitiesUpdate for webhook processing
- update submission_ids also when updating local db
- remove redundant status update on backend (status update is already handled during webhook processing)
- implement entity processing queue for efficient updates (the reason for implementing this is: 
```
for (const entity of rows) {
    const updatedEntity = {
        ...entityMapClone.get(entity.entity_id), // fallback to existing data
        ...entity, // overwrite with new status
    };
    entityMapClone.set(entity.entity_id, updatedEntity);
    // Store value in local db for persistence across restarts
    await DbEntity.update(db, entity);
    }
)
```
The await was here was making stale submission_ids data to be concatenated with the new submission_id, causing the final submission_ids value to be incorrect. And since we want the asynchronous behaviour while making updates in the DB, `processQueue `workflow is used so that it would asynchronously update on each electric shape and its rows.

## Screenshots
![image](https://github.com/user-attachments/assets/3f518d29-07d7-4ef2-87f7-0ee5fdfe88ab)