### PR TITLE
Add async method to retrieve submission XML content

### DIFF
--- a/src/backend/packages/osm-fieldwork/osm_fieldwork/OdkCentralAsync.py
+++ b/src/backend/packages/osm-fieldwork/osm_fieldwork/OdkCentralAsync.py
@@ -347,6 +347,31 @@ class OdkForm(OdkCentral):
             log.error(msg)
             raise aiohttp.ClientError(msg) from e
 
+    async def getSubmissionXml(
+        self,
+        projectId: int,
+        xform: str,
+        submissionUuid: str,
+    ):
+        """Retrieve the XML content of a submission.
+
+        Args:
+            projectId (int): The ID of the project on ODK Central.
+            xform (str): The XForm ID on ODK Central.
+            submissionUuid (str): The UUID of the submission.
+
+        Returns:
+            Optional[str]: The XML content as a string.
+        """
+        url = f"{self.base}projects/{projectId}/forms/{xform}/submissions/{submissionUuid}.xml"
+
+        try:
+            async with self.session.get(url, ssl=self.verify) as response:
+                return await response.text()
+        except Exception as e:
+            log.error(f"Failed to fetch submission XML for {submissionUuid}: {e}")
+            return None
+
     async def listSubmissionAttachments(self, projectId: int, xform: str, submissionUuid: str):
         """Fetch a list of attachments listed for upload on a given submission.
 

--- a/src/frontend/src/components/ProjectSubmissions/SubmissionsTable.tsx
+++ b/src/frontend/src/components/ProjectSubmissions/SubmissionsTable.tsx
@@ -448,7 +448,7 @@ const SubmissionsTable = ({ toggleView }) => {
               const taskUid = taskList?.find((task) => task?.index == row?.task_id)?.id;
               return (
                 <div className="fmtm-w-[5rem] fmtm-overflow-hidden fmtm-truncate fmtm-text-center">
-                  <Link to={`/project-submissions/${projectId}/tasks/${taskUid}/submission/${row?.meta?.instanceID}`}>
+                  <Link to={`/project-submissions/${projectId}/tasks/${taskUid}/submission/${row?.__id}`}>
                     <Tooltip arrow placement="bottom" title="Validate Submission">
                       <AssetModules.VisibilityOutlinedIcon className="fmtm-text-[#545454] hover:fmtm-text-primaryRed" />
                     </Tooltip>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Describe this PR

Added a method in osm-fieldwork package to get the xml content of a submission.
If submission is edited manually through API. It's instanceID is changed causing the submission detail page to crash. So, switching to __id.

## Screenshots

Please provide screenshots of the change.

## Alternative Approaches Considered

Did you attempt any other approaches that are not documented in code?

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the Field-TM Contributing Guide: <https://github.com/hotosm/field-tm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
