### PR TITLE
Redirect to Qfield cloud dashboard on redirect response

### DIFF
--- a/src/frontend/src/views/CreateProject.tsx
+++ b/src/frontend/src/views/CreateProject.tsx
@@ -224,6 +224,7 @@ const CreateProject = () => {
       new_geom_type: data.new_geom_type ? data.new_geom_type : data.primary_geom_type,
       task_split_type: data.task_split_type,
       status: 'PUBLISHED',
+      field_mapping_app: data.field_mapping_app,
     };
 
     if (data.task_split_type === task_split_type.TASK_SPLITTING_ALGORITHM) {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [x] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue
- Related to #2834

## Describe this PR
- If the field mapping app is QField, then using the redirect response via `/generate-project-data,` redirect user to the QField cloud dashboard

## Screenshots