### PR TITLE
fix: wrap xlsx_bytes in BytesIO for streaming response

### DIFF
--- a/src/backend/app/helpers/helper_routes.py
+++ b/src/backend/app/helpers/helper_routes.py
@@ -84,7 +84,7 @@ async def download_template(
     xlsx_bytes = convert_to_xlsform(str(xlsform_path))
     if xlsx_bytes:
         return StreamingResponse(
-            xlsx_bytes,
+            BytesIO(xlsx_bytes),
             media_type=(
                 "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
             ),


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- #2880 
- #2656 

## Describe this PR

This PR fixed the issue where the XLS sample form download failed during project creation after the XLS form conversion (Issue #2865). The bug was preventing users from accessing the sample form, and this fix restores the download functionality covering OSM Buildings, OSM Highways, OSM Healthcare.

## Screenshots

<img width="313" height="97" alt="image" src="https://github.com/user-attachments/assets/3b2dcccf-f330-46c2-ab88-9c69c24a7e3d" />


## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the Field-TM Contributing Guide: <https://github.com/hotosm/field-tm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
