### PR TITLE
Disable osm extract fetch above 200 sq.km.

### DIFF
--- a/src/frontend/src/components/CreateProject/04-MapData.tsx
+++ b/src/frontend/src/components/CreateProject/04-MapData.tsx
@@ -40,7 +40,7 @@ const MapData = () => {
       value: data_extract_type.OSM,
       label: 'Fetch data from OSM',
       disabled:
-        values.outlineArea && +values.outlineArea?.split(' ')?.[0] && values.outlineArea?.split(' ')[1] === 'km²',
+        values.outlineArea && +values.outlineArea?.split(' ')?.[0] > 200 && values.outlineArea?.split(' ')[1] === 'km²',
     },
     { name: 'data_extract', value: data_extract_type.CUSTOM, label: 'Upload custom map data' },
     { name: 'data_extract', value: data_extract_type.NONE, label: 'No existing data' },


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue
- Unable to fetch the OSM data extract after recent merge on dev
- Related to #2866

## Describe this PR
Disable osm extract fetch above 200 sq.km.