### PR TITLE
Handle repeat group questions response on submission table.

### DIFF
--- a/src/backend/app/submissions/submission_routes.py
+++ b/src/backend/app/submissions/submission_routes.py
@@ -367,7 +367,9 @@ async def submission_table(
     if filter_clauses:
         filters["$filter"] = " and ".join(filter_clauses)
 
-    data = await submission_crud.get_submission_by_project(project, filters)
+    data = await submission_crud.get_submission_by_project(
+        project, filters, expand=False
+    )
 
     submissions = data.get("value", [])
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- #2883 

## Describe this PR

This PR fixes the issue where the submission table page failed to render data for fields inside repeat group questions (e.g., hhmemb_repeat).

The problem occurred because repeat groups are returned as arrays, and the table API previously fetched submissions without expanding repeats.

The PR updates the data fetch logic to include the $expand=* parameter when retrieving submissions, ensuring repeat group data is properly expanded and accessible for rendering on the submission table.

## Screenshots

<img width="1437" height="360" alt="image" src="https://github.com/user-attachments/assets/e1d5a016-d76e-4d7a-b4a4-09b04fe34486" />

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the Field-TM Contributing Guide: <https://github.com/hotosm/field-tm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
