### PR TITLE
fix: Fix area splitter issue when splitting by buildings=1

### DIFF
--- a/src/backend/packages/area-splitter/area_splitter/algorithms/common/3-cluster-buildings.sql
+++ b/src/backend/packages/area-splitter/area_splitter/algorithms/common/3-cluster-buildings.sql
@@ -34,7 +34,8 @@ CREATE TABLE clusteredbuildings AS (
             *,
             ST_CLUSTERKMEANS(
                 geom,
-                CAST((numfeatures / %(num_buildings)s) + 1 AS integer)
+                CAST(CEIL(numfeatures / CAST(%(num_buildings)s AS float))
+                     AS integer)
             )
                 OVER (PARTITION BY polyid)
             AS cid


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixes [fmtm-splitter issue#33](https://github.com/hotosm/fmtm-splitter/issues/33)

## PR Description

When area-splitter is run by specifying "area-splitter -n 1" (i.e. a single building), it returns an error of the form:
K (345) must be smaller than the number of rows in the group (344)

$ uv run area-splitter -b ~/bugs/hotosm/kathmandu.geojson -n 1 -db "postgresql://ami:xxxxxx@localhost:59000/postgres" -e ~/bugs/hotosm/kathmandu_extract.geojson
 File "/home/ami/src/hotosm/field-tm/src/backend/packages/area-splitter/area_splitter/splitter.py", line 712, in split_by_sql
    split_features = splitter.splitBySQL(
        db, num_buildings, osm_extract=extract_geojson
    )
....
psycopg.errors.InternalError_: K (604) must be smaller than the number of rows in the group (603)

Probably, with sparse features, field-tm ends up running area-splitter with num_buildings=1, that might be the reason it was reproduced only with sparse features. Also the screenshot in the issue shows that the number of buildings were 1. But as shown above, it is easily reproducible on command-line, with any geojson file. Just give buildings=1.

This error message is emitted by the PostGIS function ST_ClusterKMeans(geom, number_of_clusters) when 'number_of_clusters' is greater than the number of rows in the group partition.

Below query from 3-cluster-buildings.sql give this error when %(num_buildings)=1.
``
SELECT
    *,
    ST_CLUSTERKMEANS(
        geom,
        CAST((numfeatures / %(num_buildings)s) + 1 AS integer)
    )
        OVER (PARTITION BY polyid)
    AS cid
FROM buildingstocluster;
``

buildingstocluster.numfeatures is the number of buildings contained in a polygon. So it is always equal to the number of rows with a given polyid. So when num_buildings=1, the number_of_clusters value becomes numfeatures+1 while the number of rows in the polygon partition is numfeatures which is less than number_of_clusters by 1, which would return the error shown above.

Fix:

Rather than unconditionally adding 1 to the number_of_clusters, it can be CEIL()ed to the next integer value. So CEIL(23/2) will be 12, but CEIL(23/1) will remain 23. The PR has this fix.


## Screenshots

None

## Alternative Approaches Considered

None