### PR TITLE
Add column to store qfield project id to generate qrcode.

### DIFF
--- a/src/backend/app/projects/project_schemas.py
+++ b/src/backend/app/projects/project_schemas.py
@@ -254,6 +254,7 @@ class ProjectSummary(BaseModel):
     location_str: Optional[str] = None
     short_description: Optional[str] = None
     project_url: Optional[str] = None
+    qfield_project_id: Optional[str] = None
     status: Optional[ProjectStatus] = None
     visibility: Optional[ProjectVisibility] = None
     field_mapping_app: Optional[FieldMappingApp] = None

--- a/src/backend/app/qfield/qfield_crud.py
+++ b/src/backend/app/qfield/qfield_crud.py
@@ -250,7 +250,11 @@ async def create_qfield_project(
 
     # Store QField URL in project_external_urls
     await DbProjectExternalURL.create_or_update(
-        db=db, project_id=project.id, source=FieldMappingApp.QFIELD, url=qfield_url
+        db=db,
+        project_id=project.id,
+        source=FieldMappingApp.QFIELD,
+        url=qfield_url,
+        qfield_project_id=api_project_id,
     )
     await db.commit()
 

--- a/src/migrations/002-add-qfield-project-id.sql
+++ b/src/migrations/002-add-qfield-project-id.sql
@@ -1,0 +1,8 @@
+BEGIN;
+
+-- Add qfield_project_id to project_external_urls
+
+ALTER TABLE ONLY public.project_external_urls
+ADD COLUMN IF NOT EXISTS qfield_project_id VARCHAR;
+
+COMMIT;

--- a/src/migrations/init/2-tables.sql
+++ b/src/migrations/init/2-tables.sql
@@ -283,5 +283,6 @@ CREATE TABLE IF NOT EXISTS project_external_urls (
     url TEXT NOT NULL,
     created_at TIMESTAMPTZ DEFAULT now(),
     updated_at TIMESTAMPTZ DEFAULT now(),
+    qfield_project_id VARCHAR,
     UNIQUE (project_id, source)
 );


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- #2875 

## Describe this PR

Adds a new qfield_project_id column to store the QField project ID in the database. This allows QR code generation by keeping the project reference persistently linked to each record.

## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the Field-TM Contributing Guide: <https://github.com/hotosm/field-tm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
