### PR TITLE
Refactor yxf library to most recent release

### DIFF
--- a/src/backend/packages/osm-fieldwork/osm_fieldwork/conversion_to_xlsform.py
+++ b/src/backend/packages/osm-fieldwork/osm_fieldwork/conversion_to_xlsform.py
@@ -1,23 +1,30 @@
-import os 
+import io
 import logging
 
-from yxf import yaml_string_to_xlsform_bytes
+from yxf.yaml import read_yaml
+from yxf.excel import write_xlsform
 
 logger = logging.getLogger(__name__)
 
 def convert_to_xlsform(yaml_file):
     """
-    Reads a YAML file and converts in-memory to XLSForm bytes using yxf's yaml_string_to_xlsform_bytes.
+    Reads a YAML file and converts in-memory to XLSForm bytes using the yxf library.
     """
     try:
         with open(yaml_file, encoding="utf-8") as file:
             yaml_content = file.read()
         
-        xlsx_bytes = yaml_string_to_xlsform_bytes(yaml_content, source_name=os.path.basename(yaml_file))
+        form_dictionary = read_yaml(yaml_content)
+
+        output_buffer = io.BytesIO()
+
+        write_xlsform(form_dictionary, output_buffer)
+        xlsx_bytes = output_buffer.getvalue()
 
         logger.info(f'Successfully converted YAML file: {yaml_file} to XLSForm bytes.')
 
+        return xlsx_bytes
+
     except Exception as e: 
         logger.exception(f'An error occurred during in-memory conversion for YAML file: {yaml_file}')
-
-    return xlsx_bytes
+        raise

--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
     "osm-fieldwork",
     "area-splitter",
     "pyodk",
-    "yxf",
+    "yxf>=1.0.0",
 ]
 readme = "../../README.md"
 license = {text = "AGPL-3.0-only"}
@@ -157,7 +157,6 @@ write-changes = true
 osm-fieldwork = { workspace = true }
 area-splitter = { workspace = true }
 pyodk = { git = "https://github.com/hotosm/pyodk", rev = "feat/env-var-config" }
-yxf = { git = "https://github.com/spwoodcock/yxf.git", rev = "feat/in-memory-processing"}
 
 [tool.uv.workspace]
 members = ["packages/*"]

--- a/src/backend/uv.lock
+++ b/src/backend/uv.lock
@@ -612,7 +612,7 @@ requires-dist = [
     { name = "tldextract", specifier = "==5.3.0" },
     { name = "uvicorn", specifier = "==0.34.2" },
     { name = "uvloop", specifier = "==0.21.0" },
-    { name = "yxf", git = "https://github.com/spwoodcock/yxf.git?rev=feat%2Fin-memory-processing" },
+    { name = "yxf", specifier = ">=1.0.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -2498,11 +2498,15 @@ wheels = [
 [[package]]
 name = "yxf"
 version = "1.0.0"
-source = { git = "https://github.com/spwoodcock/yxf.git?rev=feat%2Fin-memory-processing#9d2892cecc5230535193e5acd44f7f55eeb89b58" }
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown-it-py" },
     { name = "openpyxl" },
     { name = "strictyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1e/22/c746dc487cf4fe53832658f85dbb17e9b54bebc08f1d94d1d9b8e33f7bf3/yxf-1.0.0.tar.gz", hash = "sha256:e33b77a6a0ca79c69e2917beb7e32424c8d754cb13b3c1bd2690338df7616df5", size = 149941, upload-time = "2025-10-28T22:35:26.06Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/98/4e4dbc571f3c44028198f05d72a0b6d745c72eef3bf4e0f8f1159380062a/yxf-1.0.0-py3-none-any.whl", hash = "sha256:eab0b3121dbaf970799cd192d223254c1029a5c6fe5390006dfabdfe0b90da6a", size = 13556, upload-time = "2025-10-28T22:35:24.391Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [X] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Updates: Update usage of yzf XLSForms library to the most recent API release #2939

## Describe this PR
This PR updates the conversion process from YAML -> XLSForms that aligns with the recent release of the yxf library. 

I have: 
- Updated pyproject.toml to use yxf>=1.0.0 (most recent release) and updated uv.lock
- Updated convert_to_xlsform to reflect yxf's most recent release:
            - Uses the official read_yaml and write_xlsform functions from the yxf library.
            - Uses io.BytesIO streams for in-memory conversion.

Important Note on the newest yxf release and future YAML Files:
The recent release for the yxf library is stricter than the previous fork used and requires a yxf: metadata block at the end of YAML files to define column headers. I have verified that the current version-controlled YAML files already contain this block, so no changes to the source YAML files were necessary.

For any new YAML files added to the repository, it is recommended to keep generating them using the yxf CLI tools to ensure the metadata block is created automatically.
## Alternative Approaches Considered

I initially implemented a fallback function that would detect files missing the yxf metadata. However, since the current version-controlled YAML files already contain the metadata block, I removed it. 

Can revisit to add this fallback function to handle cases where a YAML file, that was not converted with yxf library, does not contain the metadata block and raises a ValueError: YAML file must have a "yxf" entry.

Edit: It'd actually be a lot easier to use yxf's ensure_yxf_comment function for this to ensure all files have that metadata; however, this function is not in the public API. 

## Review Guide

- Verified the convert_to_xlsform logic via a local script using sample data matching our schema.
-  I was unable to run the backend Docker suite locally because the project's AMD64 containers cause Segmentation Faults (Exit Code 139) on my Apple Silicon (M1/M2) environment due to emulation issues, so I am relying on the CI/CD tests. 

## Checklist before requesting a review

- 📖 Read the Field-TM Contributing Guide: <https://github.com/hotosm/field-tm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
