### PR TITLE
Delete project in qfield cloud while deleting qfield project from field-tm

### DIFF
--- a/src/backend/app/db/models.py
+++ b/src/backend/app/db/models.py
@@ -2260,6 +2260,28 @@ class DbProjectExternalURL(BaseModel):
             )
             return await cur.fetchone()
 
+    @classmethod
+    async def one(cls, db: Connection, project_id: int) -> Self:
+        """Fetch a single external URL record for a project."""
+        async with db.cursor(row_factory=class_row(cls)) as cur:
+            await cur.execute(
+                """
+                SELECT *
+                FROM project_external_urls
+                WHERE project_id = %(project_id)s
+                LIMIT 1;
+                """,
+                {"project_id": project_id},
+            )
+            rec = await cur.fetchone()
+
+        if rec is None:
+            raise KeyError(
+                f"Project external URL for project ({project_id}) not found."
+            )
+
+        return rec
+
 
 class DbOdkEntities(BaseModel):
     """Table odk_entities.

--- a/src/backend/app/qfield/qfield_routes.py
+++ b/src/backend/app/qfield/qfield_routes.py
@@ -31,7 +31,11 @@ from app.auth.roles import ProjectManager
 from app.db.database import db_conn
 from app.db.enums import HTTPStatus
 from app.qfield import qfield_schemas
-from app.qfield.qfield_crud import create_qfield_project, qfc_credentials_test
+from app.qfield.qfield_crud import (
+    create_qfield_project,
+    delete_qfield_project,
+    qfc_credentials_test,
+)
 from app.qfield.qfield_deps import qfield_client
 
 router = APIRouter(
@@ -73,3 +77,14 @@ async def qfc_creds_test(
     """Test QFieldCloud credentials by attempting to open a session."""
     await qfc_credentials_test(qfc_creds)
     return Response(status_code=HTTPStatus.OK)
+
+
+@router.delete("/{project_id}")
+async def trigger_delete_qfield_project(
+    project_id: int,
+    db: Annotated[Connection, Depends(db_conn)],
+    project_user_dict: Annotated[ProjectUserDict, Depends(ProjectManager())],
+):
+    """Delete a project from QFieldCloud."""
+    await delete_qfield_project(db, project_id)
+    return Response(status_code=HTTPStatus.NO_CONTENT)


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

- #2937 

## Describe this PR

This PR ensures that when a project is removed from Field-TM, the corresponding project on QFieldCloud is also deleted. Previously, the local deletion did not trigger a remote cleanup, leaving orphaned projects on QFieldCloud.

The update adds the necessary API call and handling logic to keep both systems in sync.


## Review Guide

Notes for the reviewer. How to test this change?

## Checklist before requesting a review

- 📖 Read the Field-TM Contributing Guide: <https://github.com/hotosm/field-tm/blob/main/CONTRIBUTING.md>
- 📖 Read the HOT Code of Conduct: <https://docs.hotosm.org/code-of-conduct>
- 👷‍♀️ Create small PRs. In most cases, this will be possible.
- ✅ Provide tests for your changes.
- 📝 Use descriptive commit messages.
- 📗 Update any related documentation and include any relevant screenshots.

## [optional] What gif best describes this PR or how it makes you feel?
