### PR TITLE
Add a 'number of enumerators / buildings' task splitting workflow

### DIFF
--- a/cla.json
+++ b/cla.json
@@ -11,10 +11,10 @@
     {
       "name": "amitdkhan-pg",
       "id": 64206751,
-      "comment_id": 4106553003,
+      "comment_id": 4114320208,
       "created_at": "2026-03-22T16:31:30Z",
-      "repoId": 1090760561,
-      "pullRequestNo": 1
+      "repoId": 548162511,
+      "pullRequestNo": 3042
     }
   ]
 }

--- a/cla.json
+++ b/cla.json
@@ -7,6 +7,14 @@
       "created_at": "2026-02-25T17:50:31Z",
       "repoId": 548162511,
       "pullRequestNo": 3023
+    },
+    {
+      "name": "amitdkhan-pg",
+      "id": 64206751,
+      "comment_id": 4106553003,
+      "created_at": "2026-03-22T16:31:30Z",
+      "repoId": 1090760561,
+      "pullRequestNo": 1
     }
   ]
 }

--- a/src/backend/app/htmx/map_helpers.py
+++ b/src/backend/app/htmx/map_helpers.py
@@ -59,6 +59,7 @@ def render_leaflet_map(
             "weight": layer.get("weight", 2),
             "opacity": layer.get("opacity", 0.8),
             "fillOpacity": layer.get("fillOpacity", 0.3),
+            "popupOptions": layer.get("popup_options", {}),
         }
         escaped_layers.append(layer_config)
 
@@ -166,20 +167,43 @@ def render_leaflet_map(
                                 onEachFeature:
                                   function(f, layer) {{
                                     if (f.properties) {{
-                                        var ks = Object.keys(
+                                        var popupOptions =
+                                            cfg.popupOptions || {{}};
+                                        var propertyLabels =
+                                            popupOptions.propertyLabels || {{}};
+                                        var propertyOrder =
+                                            popupOptions.propertyOrder || [];
+                                        var showLayerName =
+                                            popupOptions.showLayerName !== false;
+                                        var orderedKeys = propertyOrder.filter(
+                                            function(k) {{
+                                                return Object.prototype
+                                                    .hasOwnProperty.call(
+                                                        f.properties, k);
+                                            }}
+                                        );
+                                        var extraKeys = Object.keys(
                                             f.properties
+                                        ).filter(function(k) {{
+                                            return !propertyOrder.includes(k);
+                                        }});
+                                        var ks = orderedKeys.concat(
+                                            extraKeys
                                         ).slice(0, 5);
                                         var ps = ks.map(
                                             function(k) {{
                                             return '<b>'
-                                                + k
+                                                + (propertyLabels[k] || k)
                                                 + ':</b> '
                                                 + f.properties[k];
                                         }}).join('<br>');
-                                        var h = '<b>'
-                                            + cfg.name
-                                            + '</b><br>'
-                                            + (ps || 'None');
+                                        var h = ps || 'None';
+                                        if (showLayerName) {{
+                                            h = '<b>'
+                                                + cfg.name
+                                                + '</b><br>'
+                                                + h;
+                                        }}
                                         layer.bindPopup(h);
                                     }}
                                 }}

--- a/src/backend/app/htmx/setup_step_routes.py
+++ b/src/backend/app/htmx/setup_step_routes.py
@@ -296,6 +296,7 @@ def _parse_split_form_options(data: dict | None) -> dict:
         "no_of_buildings": _parse_int_form_value(
             payload.get("no_of_buildings", 10), 10
         ),
+        "no_of_tasks": _parse_int_form_value(payload.get("no_of_tasks", 10), 10),
         "dimension_meters": _parse_int_form_value(
             payload.get("dimension_meters", 100), 100
         ),
@@ -355,6 +356,14 @@ def _task_boundaries_layer(task_boundaries: dict) -> dict:
         "weight": 3,
         "opacity": 1.0,
         "fillOpacity": 0.1,
+        "popup_options": {
+            "showLayerName": False,
+            "propertyLabels": {
+                "task_id": _("Task ID"),
+                "building_count": _("Building Count"),
+            },
+            "propertyOrder": ["task_id", "building_count"],
+        },
     }
 
 
@@ -1183,6 +1192,7 @@ async def split_aoi_htmx(
             "Split AOI parameters: "
             f"algorithm={algorithm}, "
             f"no_of_buildings={split_options['no_of_buildings']}, "
+            f"no_of_tasks={split_options['no_of_tasks']}, "
             f"dimension_meters={split_options['dimension_meters']}, "
             f"include_roads={split_options['include_roads']}, "
             f"include_rivers={split_options['include_rivers']}, "
@@ -1199,6 +1209,7 @@ async def split_aoi_htmx(
             options=SplitAoiOptions(
                 algorithm=algorithm,
                 no_of_buildings=split_options["no_of_buildings"],
+                no_of_tasks=split_options["no_of_tasks"],
                 dimension_meters=split_options["dimension_meters"],
                 include_roads=split_options["include_roads"],
                 include_rivers=split_options["include_rivers"],

--- a/src/backend/app/projects/project_routes.py
+++ b/src/backend/app/projects/project_routes.py
@@ -155,6 +155,7 @@ async def _split_project_if_requested(
         options=SplitAoiOptions(
             algorithm=data.algorithm.value,
             no_of_buildings=data.no_of_buildings,
+            no_of_tasks=data.no_of_tasks,
             dimension_meters=data.dimension_meters,
             include_roads=data.include_roads,
             include_rivers=data.include_rivers,

--- a/src/backend/app/projects/project_schemas.py
+++ b/src/backend/app/projects/project_schemas.py
@@ -76,6 +76,7 @@ class CreateProjectRequest(ODKCentral, QFieldCloud):
 
     algorithm: SplittingAlgorithm | None = None
     no_of_buildings: int = 10
+    no_of_tasks: int = 10
     dimension_meters: int = 100
     include_roads: bool = True
     include_rivers: bool = True

--- a/src/backend/app/projects/project_services.py
+++ b/src/backend/app/projects/project_services.py
@@ -134,6 +134,7 @@ class SplitAoiOptions:
 
     algorithm: str
     no_of_buildings: int = 10
+    no_of_tasks: int = 10
     dimension_meters: int = 100
     include_roads: bool = True
     include_rivers: bool = True
@@ -728,7 +729,7 @@ async def _split_with_building_algorithm(
     aoi_featcol: dict,
     parsed_extract: dict,
     algorithm_enum: SplittingAlgorithm,
-    no_of_buildings: int,
+    algorithm_params: dict,
     include_roads: bool,
     include_rivers: bool,
     include_railways: bool,
@@ -737,7 +738,7 @@ async def _split_with_building_algorithm(
     """Run one of the SQL-backed building-based split algorithms."""
     _validate_split_extract(parsed_extract)
     algorithm_params = {
-        "num_buildings": no_of_buildings,
+        **algorithm_params,
         "include_roads": "TRUE" if include_roads else "FALSE",
         "include_rivers": "TRUE" if include_rivers else "FALSE",
         "include_railways": "TRUE" if include_railways else "FALSE",
@@ -848,7 +849,7 @@ async def split_aoi(
             aoi_featcol,
             parsed_extract,
             algorithm_enum,
-            options.no_of_buildings,
+            {"num_buildings": options.no_of_buildings},
             options.include_roads,
             options.include_rivers,
             options.include_railways,
@@ -861,8 +862,15 @@ async def split_aoi(
             options.dimension_meters,
         )
     elif algorithm_enum == SplittingAlgorithm.TOTAL_TASKS:
-        raise ValidationError(
-            "Split by Specific Number of Tasks is not yet implemented."
+        features = await _split_with_building_algorithm(
+            aoi_featcol,
+            parsed_extract,
+            algorithm_enum,
+            {"num_enumerators": options.no_of_tasks},
+            options.include_roads,
+            options.include_rivers,
+            options.include_railways,
+            options.include_aeroways,
         )
     else:
         raise ValidationError(f"Algorithm {algorithm} not yet implemented.")

--- a/src/backend/app/templates/partials/project_details/setup_steps.html
+++ b/src/backend/app/templates/partials/project_details/setup_steps.html
@@ -468,9 +468,7 @@ project.task_areas_geojson is not none %} {% set is_no_splitting = project.task_
             <option value="AVG_BUILDING_SKELETON">
               {{ _("Average Buildings v2 (Straight Skeleton)") }}
             </option>
-            <option value="TOTAL_TASKS" disabled>
-              {{ _("Split by Specific Number of Tasks (Coming Soon)") }}
-            </option>
+            <option value="TOTAL_TASKS">{{ _("Split by Specific Number of Tasks") }}</option>
           </select>
         </div>
         <div id="algorithm-param-container">
@@ -483,6 +481,17 @@ project.task_areas_geojson is not none %} {% set is_no_splitting = project.task_
               type="number"
               id="no-of-buildings"
               name="no_of_buildings"
+              value="10"
+              min="1"
+              class="ftm-split-input"
+            />
+          </div>
+          <div id="param-tasks" style="display: none">
+            <label for="no-of-tasks" class="ftm-split-label">{{ _("Number of Tasks:") }}</label>
+            <input
+              type="number"
+              id="no-of-tasks"
+              name="no_of_tasks"
               value="10"
               min="1"
               class="ftm-split-input"

--- a/src/backend/app/templates/partials/project_details/style_and_scripts.html
+++ b/src/backend/app/templates/partials/project_details/style_and_scripts.html
@@ -468,8 +468,10 @@
   // Step 3: Split AOI - Handle algorithm selection and parameter visibility
   const splitAlgorithm = document.getElementById('split-algorithm');
   const paramBuildings = document.getElementById('param-buildings');
+  const paramTasks = document.getElementById('param-tasks');
   const paramDimension = document.getElementById('param-dimension');
   const noOfBuildingsInput = document.getElementById('no-of-buildings');
+  const noOfTasksInput = document.getElementById('no-of-tasks');
   const dimensionMetersInput = document.getElementById('dimension-meters');
   const splitAdvancedConfigToggle = document.getElementById('split-advanced-config-toggle');
   const splitAdvancedConfigPanel = document.getElementById('split-advanced-config-panel');
@@ -506,53 +508,35 @@
     });
   syncSplitLinearFeatureOptions();
 
-  if (splitAlgorithm) {
-    // Function to update parameter visibility
-    function updateParameterVisibility() {
-      const algorithm = splitAlgorithm.value;
-      if (algorithm === 'DIVIDE_BY_SQUARE') {
-        if (paramBuildings) paramBuildings.style.display = 'none';
-        if (paramDimension) paramDimension.style.display = 'block';
-        if (noOfBuildingsInput) {
-          noOfBuildingsInput.removeAttribute('required');
-          noOfBuildingsInput.disabled = true; // Disable so it's not sent
-        }
-        if (dimensionMetersInput) {
-          dimensionMetersInput.setAttribute('required', 'required');
-          dimensionMetersInput.disabled = false;
-        }
-      } else if (algorithm === 'AVG_BUILDING_VORONOI' || algorithm === 'AVG_BUILDING_SKELETON') {
-        if (paramBuildings) paramBuildings.style.display = 'block';
-        if (paramDimension) paramDimension.style.display = 'none';
-        if (noOfBuildingsInput) {
-          noOfBuildingsInput.setAttribute('required', 'required');
-          noOfBuildingsInput.disabled = false;
-        }
-        if (dimensionMetersInput) {
-          dimensionMetersInput.removeAttribute('required');
-          dimensionMetersInput.disabled = true; // Disable so it's not sent
-        }
-      } else {
-        // NO_SPLITTING, TOTAL_TASKS, or other options
-        if (paramBuildings) paramBuildings.style.display = 'none';
-        if (paramDimension) paramDimension.style.display = 'none';
-        if (noOfBuildingsInput) {
-          noOfBuildingsInput.removeAttribute('required');
-          noOfBuildingsInput.disabled = true; // Disable so it's not sent
-        }
-        if (dimensionMetersInput) {
-          dimensionMetersInput.removeAttribute('required');
-          dimensionMetersInput.disabled = true; // Disable so it's not sent
-        }
+  // Map each algorithm to which input group is active: buildings, tasks, or dimension
+  const splitParamGroups = {
+    buildings: { container: paramBuildings, input: noOfBuildingsInput },
+    tasks: { container: paramTasks, input: noOfTasksInput },
+    dimension: { container: paramDimension, input: dimensionMetersInput },
+  };
+  const algorithmActiveParam = {
+    'DIVIDE_BY_SQUARE': 'dimension',
+    'AVG_BUILDING_VORONOI': 'buildings',
+    'AVG_BUILDING_SKELETON': 'buildings',
+    'TOTAL_TASKS': 'tasks',
+  };
+
+  function updateSplitParamVisibility() {
+    if (!splitAlgorithm) return;
+    const active = algorithmActiveParam[splitAlgorithm.value] || null;
+    for (const [key, { container, input }] of Object.entries(splitParamGroups)) {
+      const isActive = key === active;
+      if (container) container.style.display = isActive ? 'block' : 'none';
+      if (input) {
+        input.disabled = !isActive;
+        if (isActive) input.setAttribute('required', 'required');
+        else input.removeAttribute('required');
       }
     }
-
-    // Initialize visibility on page load
-    updateParameterVisibility();
-
-    // Update on change
-    splitAlgorithm.addEventListener('change', updateParameterVisibility);
   }
+
+  // Initial param visibility (updateAlgorithmUI also calls this on change)
+  updateSplitParamVisibility();
 
   // Scroll to map after successful split
   document.body.addEventListener('htmx:afterSwap', function(event) {
@@ -584,28 +568,20 @@
       const splitBtn = splitAoiForm.querySelector('button[type="submit"]');
       const splitBtnText = document.getElementById('split-btn-text');
 
-      // Show/hide parameter container based on algorithm
       if (paramContainer) {
-        if (algorithm === 'NO_SPLITTING' || !algorithm) {
-          paramContainer.style.display = 'none';
-        } else {
-          paramContainer.style.display = 'block';
-        }
+        paramContainer.style.display = (algorithm && algorithm !== 'NO_SPLITTING') ? 'block' : 'none';
       }
 
-      // Update button text based on algorithm and current state
       if (splitBtnText) {
-        if (algorithm === 'NO_SPLITTING') {
-          splitBtnText.textContent = i18nStrings.confirmNoSplitting;
-        } else if (algorithm === 'DIVIDE_BY_SQUARE') {
-          splitBtnText.textContent = i18nStrings.splitBySquare;
-        } else if (algorithm === 'AVG_BUILDING_VORONOI' || algorithm === 'AVG_BUILDING_SKELETON') {
-          splitBtnText.textContent = i18nStrings.splitByBuildings;
-        } else if (algorithm && algorithm !== '') {
-          splitBtnText.textContent = i18nStrings.splitAoi;
-        } else {
-          splitBtnText.textContent = i18nStrings.selectOption;
-        }
+        const btnLabels = {
+          'NO_SPLITTING': i18nStrings.confirmNoSplitting,
+          'DIVIDE_BY_SQUARE': i18nStrings.splitBySquare,
+          'AVG_BUILDING_VORONOI': i18nStrings.splitByBuildings,
+          'AVG_BUILDING_SKELETON': i18nStrings.splitByBuildings,
+          'TOTAL_TASKS': i18nStrings.splitAoi,
+        };
+        splitBtnText.textContent = btnLabels[algorithm]
+          || (algorithm ? i18nStrings.splitAoi : i18nStrings.selectOption);
       }
 
       // Disable/enable button based on selection
@@ -613,35 +589,13 @@
         splitBtn.disabled = !algorithm || algorithm === '';
       }
 
-      // Disable the parameter that's not needed so it's not sent in form data
-      if (algorithm === 'DIVIDE_BY_SQUARE') {
-        if (noOfBuildingsInput) {
-          noOfBuildingsInput.disabled = true;
-        }
-        if (dimensionMetersInput) {
-          dimensionMetersInput.disabled = false;
-        }
-      } else if (algorithm === 'AVG_BUILDING_VORONOI' || algorithm === 'AVG_BUILDING_SKELETON') {
-        if (dimensionMetersInput) {
-          dimensionMetersInput.disabled = true;
-        }
-        if (noOfBuildingsInput) {
-          noOfBuildingsInput.disabled = false;
-        }
-      } else if (algorithm === 'NO_SPLITTING' || !algorithm) {
-        if (noOfBuildingsInput) {
-          noOfBuildingsInput.disabled = true;
-        }
-        if (dimensionMetersInput) {
-          dimensionMetersInput.disabled = true;
-        }
-      }
+      // Param visibility is handled by updateSplitParamVisibility
+      updateSplitParamVisibility();
     }
 
     // Update UI on algorithm change
     if (splitAlgorithm) {
       splitAlgorithm.addEventListener('change', updateAlgorithmUI);
-      // Initialize UI on page load
       updateAlgorithmUI();
     }
 

--- a/src/backend/packages/area-splitter/area_splitter/__init__.py
+++ b/src/backend/packages/area-splitter/area_splitter/__init__.py
@@ -13,7 +13,7 @@ class SplittingAlgorithm(StrEnum):
     DIVIDE_BY_SQUARE = "DIVIDE_BY_SQUARE"
     AVG_BUILDING_VORONOI = "AVG_BUILDING_VORONOI"
     AVG_BUILDING_SKELETON = "AVG_BUILDING_SKELETON"
-    TOTAL_TASKS = "TOTAL_TASKS"  # Not implemented yet
+    TOTAL_TASKS = "TOTAL_TASKS"
 
     @property
     def sql_path(self) -> Path | None:
@@ -21,12 +21,14 @@ class SplittingAlgorithm(StrEnum):
         if self in (
             SplittingAlgorithm.AVG_BUILDING_VORONOI,
             SplittingAlgorithm.AVG_BUILDING_SKELETON,
+            SplittingAlgorithm.TOTAL_TASKS,
         ):
             sql_file = {
                 SplittingAlgorithm.AVG_BUILDING_VORONOI: "avg_building_voronoi.sql",
                 SplittingAlgorithm.AVG_BUILDING_SKELETON: (
                     "avg_building_straight_skeleton.sql"
                 ),
+                SplittingAlgorithm.TOTAL_TASKS: "avg_building_straight_skeleton.sql",
             }[self]
             return algorithms_path / sql_file
         return None
@@ -52,5 +54,5 @@ class SplittingAlgorithm(StrEnum):
             SplittingAlgorithm.DIVIDE_BY_SQUARE: [],
             SplittingAlgorithm.AVG_BUILDING_VORONOI: ["num_buildings"],
             SplittingAlgorithm.AVG_BUILDING_SKELETON: ["num_buildings"],
-            SplittingAlgorithm.TOTAL_TASKS: [],  # Not implemented yet
+            SplittingAlgorithm.TOTAL_TASKS: ["num_enumerators"],
         }[self]

--- a/src/backend/packages/area-splitter/area_splitter/algorithms/common/2-group-buildings.sql
+++ b/src/backend/packages/area-splitter/area_splitter/algorithms/common/2-group-buildings.sql
@@ -55,7 +55,7 @@ DROP TABLE polygonsnocount;
 --         SELECT *
 --         FROM splitpolygons AS p
 --         -- TODO: feature count should not be hard-coded
---         WHERE p.numfeatures < %(num_buildings)s
+--         WHERE p.numfeatures < buildings_per_tasks
 --     ),
 
 --     -- Find the neighbors of the low-feature-count polygons

--- a/src/backend/packages/area-splitter/area_splitter/algorithms/common/3-cluster-buildings.sql
+++ b/src/backend/packages/area-splitter/area_splitter/algorithms/common/3-cluster-buildings.sql
@@ -19,7 +19,7 @@ BEGIN
     DROP TABLE IF EXISTS partition_tasks;
     create table partition_tasks as
         select polyid, numfeatures,
-        greatest(1,round(numfeatures/features_per_cluster))::int tasks
+        greatest(1,ceil(numfeatures/features_per_cluster))::int tasks
         from splitpolygons WHERE numfeatures > 0;
 
     -- Now adjust the tasks assigned to match the total tasks exactly with the

--- a/src/backend/packages/area-splitter/area_splitter/algorithms/common/3-cluster-buildings.sql
+++ b/src/backend/packages/area-splitter/area_splitter/algorithms/common/3-cluster-buildings.sql
@@ -1,4 +1,69 @@
 DROP TABLE IF EXISTS clusteredbuildings;
+
+DO $$
+DECLARE
+    features_per_cluster FLOAT := current_setting('area_splitter.num_buildings');
+    desired_tasks INTEGER := current_setting('area_splitter.num_enumerators');
+BEGIN
+
+    IF desired_tasks > 0 THEN
+    IF ROUND(features_per_cluster) != 0 THEN
+        RAISE EXCEPTION
+            'Only one out of buildings and enumerators should be set';
+    END IF;
+    features_per_cluster =
+        (SELECT SUM(numfeatures) FROM splitpolygons) / desired_tasks::float;
+    END IF;
+
+-- Calculate a tentative number of tasks per partition.
+    DROP TABLE IF EXISTS partition_tasks;
+    create table partition_tasks as
+        select polyid, numfeatures,
+        greatest(1,round(numfeatures/features_per_cluster))::int tasks
+        from splitpolygons WHERE numfeatures > 0;
+
+    -- Now adjust the tasks assigned to match the total tasks exactly with the
+    -- user-supplied desired number of enumerators.
+
+    -- If enumerators are less than the number of partitions formed by linear features (2),
+    -- then we failback to the task merging that is done in the end. Otherwise,
+    -- we adjust the per-partition tasks based on the feature density (features per partition)
+    -- So, if the actual tasks are more than the desired tasks, we decrement the
+    -- number of mappers in the partition that has the least feature density. Similarly if
+    -- the actual tasks are less, we increment the mappers in the most feature-dense
+    -- partition because those would be the ones with maximum work load. We keep on
+    -- doing this until enumerators matches the desired enumerators.
+    --
+    -- We do this only when area splitting is based on number of enumerators, not for
+    -- feature-based area splitting. (1)
+
+    IF desired_tasks > 0 AND -- (1)
+       desired_tasks >= (SELECT count(*) from partition_tasks) THEN -- (2)
+        DECLARE
+            total_tasks BIGINT =
+                (SELECT sum(tasks) from partition_tasks);
+            tasks_diff INT = ABS(total_tasks - desired_tasks);
+        BEGIN
+            FOR i IN 1..tasks_diff LOOP
+                IF total_tasks > desired_tasks THEN
+                    update partition_tasks set tasks = tasks - 1
+                    where polyid =
+                     (select polyid from partition_tasks where tasks > 1
+                      order by numfeatures::float/tasks limit 1);
+                ELSE
+                    update partition_tasks set tasks = tasks + 1
+                    where polyid =
+                     (select polyid from partition_tasks
+                      order by numfeatures::float/tasks desc limit 1);
+                END IF;
+            END LOOP;
+            IF desired_tasks != (SELECT sum(tasks) from partition_tasks) THEN
+                RAISE EXCEPTION 'Desired tasks: %. Created % tasks instead. Aborting...',
+                    desired_tasks, (SELECT sum(tasks) from partition_tasks);
+            END IF;
+        END;
+    END IF;
+
 CREATE TABLE clusteredbuildings AS (
     WITH splitpolygonswithcontents AS (
         SELECT *
@@ -34,8 +99,8 @@ CREATE TABLE clusteredbuildings AS (
             *,
             ST_CLUSTERKMEANS(
                 geom,
-                CAST(CEIL(numfeatures / CAST(%(num_buildings)s AS float))
-                     AS integer)
+                (select tasks::int from partition_tasks
+                 where partition_tasks.polyid = buildingstocluster.polyid)
             )
                 OVER (PARTITION BY polyid)
             AS cid
@@ -52,6 +117,8 @@ CREATE TABLE clusteredbuildings AS (
 
     SELECT * FROM clusteredbuildings
 );
+END $$;
+
 -- ALTER TABLE clusteredbuildings ADD PRIMARY KEY(osm_id);
 SELECT POPULATE_GEOMETRY_COLUMNS('clusteredbuildings'::regclass);
 CREATE INDEX clusteredbuildings_idx

--- a/src/backend/packages/area-splitter/area_splitter/algorithms/common/5-alignment.sql
+++ b/src/backend/packages/area-splitter/area_splitter/algorithms/common/5-alignment.sql
@@ -8,38 +8,59 @@ USING gist (geom);
 -- Merge least feature polygons with neighbouring polygons
 DO $$
 DECLARE
-    num_buildings INTEGER := %(num_buildings)s;
+    num_buildings INTEGER := current_setting('area_splitter.num_buildings');
+    num_enumerators INTEGER := current_setting('area_splitter.num_enumerators');
     min_area NUMERIC; -- Set the minimum area threshold
     mean_area NUMERIC;
     stddev_area NUMERIC; -- Set the standard deviation
     min_buildings INTEGER; -- Set the minimum number of buildings threshold
     small_polygon RECORD; -- set small_polygon and nearest_neighbor as record 
     nearest_neighbor RECORD; -- in order to use them in the loop
+    merges_remaining INTEGER = NULL;
 BEGIN
-    min_buildings := num_buildings * 0.5;
-
-    -- Find the mean and standard deviation of the area
-    SELECT 
-        AVG(ST_Area(geom)),
-        STDDEV_POP(ST_Area(geom))
-    INTO mean_area, stddev_area
-    FROM taskpolygons;
-
-    -- Set the threshold as mean - standard deviation
-    min_area := mean_area - stddev_area;
 
     DROP TABLE IF EXISTS leastfeaturepolygons;
-    CREATE TABLE leastfeaturepolygons AS
-    SELECT taskid, geom
-    FROM taskpolygons
-    WHERE ST_Area(geom) < min_area OR (
-        SELECT COUNT(b.id) FROM buildings b 
-        WHERE ST_Contains(taskpolygons.geom, b.geom)
-    ) < min_buildings; -- find least feature polygons based on the area and feature
+    IF num_enumerators > 0 THEN
+      merges_remaining = (SELECT COUNT(*) FROM taskpolygons) - num_enumerators;
+      IF merges_remaining < 0 THEN
+        merges_remaining = 0; -- Skip merging
+      END IF;
+      CREATE TABLE leastfeaturepolygons AS
+        SELECT taskid, geom,
+        (SELECT COUNT(b.id) FROM buildings b
+          WHERE ST_Intersects(taskpolygons.geom, b.geom)) numbuildings
+        FROM taskpolygons ORDER BY numbuildings ASC LIMIT merges_remaining;
+    ELSE
+      -- Find the mean and standard deviation of the area
+      SELECT
+          AVG(ST_Area(geom)),
+          STDDEV_POP(ST_Area(geom))
+      INTO mean_area, stddev_area
+      FROM taskpolygons;
+
+      -- Set the threshold as mean - standard deviation
+      min_area := min_area - stddev_area;
+      min_buildings := num_buildings * 0.5;
+
+      CREATE TABLE leastfeaturepolygons AS
+      SELECT taskid, geom
+      FROM taskpolygons
+      WHERE ST_Area(geom) < min_area OR
+        (
+          SELECT COUNT(b.id) FROM buildings b
+          WHERE ST_Contains(taskpolygons.geom, b.geom)
+        ) < min_buildings; -- find least feature polygons based on the area and feature
+
+    END IF;
 
     FOR small_polygon IN 
         SELECT * FROM leastfeaturepolygons
     LOOP
+        -- If the required # of polygons are merged, we are done.
+        IF merges_remaining = 0 THEN
+          EXIT;
+        END IF;
+
         -- Find the nearest neighbor to merge the small polygon with
         FOR nearest_neighbor IN
         SELECT taskid, geom, ST_LENGTH2D(ST_Intersection(small_polygon.geom, geom)) as shared_bound
@@ -56,11 +77,16 @@ BEGIN
             WHERE taskid = nearest_neighbor.taskid;
 
             DELETE FROM taskpolygons WHERE taskid = small_polygon.taskid;
+
+            IF merges_remaining IS NOT NULL THEN -- Fixed number of mappers
+              merges_remaining = merges_remaining - 1;
+            END IF;
+
             -- Exit the neighboring polygon loop after one successful merge
             EXIT;
         END LOOP;
     END LOOP;
 END $$;
 
-DROP TABLE IF EXISTS leastfeaturepolygons;
+-- DROP TABLE IF EXISTS leastfeaturepolygons;
 -- VACUUM ANALYZE taskpolygons;

--- a/src/backend/packages/area-splitter/area_splitter/algorithms/common/5-alignment.sql
+++ b/src/backend/packages/area-splitter/area_splitter/algorithms/common/5-alignment.sql
@@ -39,7 +39,7 @@ BEGIN
       FROM taskpolygons;
 
       -- Set the threshold as mean - standard deviation
-      min_area := min_area - stddev_area;
+      min_area := mean_area - stddev_area;
       min_buildings := num_buildings * 0.5;
 
       CREATE TABLE leastfeaturepolygons AS
@@ -88,5 +88,5 @@ BEGIN
     END LOOP;
 END $$;
 
--- DROP TABLE IF EXISTS leastfeaturepolygons;
+DROP TABLE IF EXISTS leastfeaturepolygons;
 -- VACUUM ANALYZE taskpolygons;

--- a/src/backend/packages/area-splitter/area_splitter/splitter.py
+++ b/src/backend/packages/area-splitter/area_splitter/splitter.py
@@ -767,12 +767,11 @@ class AreaSplitter:
 
         # Make the input parameters accessible to other sql files.
         cur.execute(
-            f"SET area_splitter.num_buildings = "
-            f"{params.get('num_buildings', 0)}"
+            f"SET area_splitter.num_buildings = {int(params.get('num_buildings', 0))}"
         )
         cur.execute(
             f"SET area_splitter.num_enumerators = "
-            f"{params.get('num_enumerators', 0)}"
+            f"{int(params.get('num_enumerators', 0))}"
         )
 
         # Close current cursor
@@ -1163,7 +1162,6 @@ be either the data extract used by the XLSForm, or a postgresql database.
             args.boundary,
             db=args.dburl,
             num_buildings=args.number,
-            num_enumerators=0,
             outfile=args.outfile,
             osm_extract=args.extract,
         )
@@ -1171,7 +1169,6 @@ be either the data extract used by the XLSForm, or a postgresql database.
         split_by_sql(
             args.boundary,
             db=args.dburl,
-            num_buildings=0,
             num_enumerators=args.tasks,
             outfile=args.outfile,
             osm_extract=args.extract,

--- a/src/backend/packages/area-splitter/area_splitter/splitter.py
+++ b/src/backend/packages/area-splitter/area_splitter/splitter.py
@@ -163,20 +163,32 @@ def _validate_algorithm_selection(algorithm: SplittingAlgorithm) -> None:
 def _resolve_algorithm_params(
     algorithm: SplittingAlgorithm,
     num_buildings: Optional[int],
+    num_enumerators: Optional[int],
     algorithm_params: Optional[dict],
 ) -> dict:
     """Normalize and validate algorithm parameters."""
     params = dict(algorithm_params or {})
     if not params:
-        if not num_buildings:
+        if num_buildings and num_enumerators:
             err = (
-                f"Algorithm {algorithm.value} requires the following parameters: "
-                f"{', '.join(algorithm.required_params)}. "
-                f"Either provide algorithm_params dict or num_buildings (deprecated)."
+                "Exactly one of num_buildings or num_enumerators may be provided "
+                "when algorithm_params is omitted."
             )
             log.error(err)
             raise ValueError(err)
-        params["num_buildings"] = num_buildings
+        if num_buildings:
+            params["num_buildings"] = num_buildings
+        elif num_enumerators:
+            params["num_enumerators"] = num_enumerators
+        else:
+            err = (
+                f"Algorithm {algorithm.value} requires the following parameters: "
+                f"{', '.join(algorithm.required_params)}. "
+                "Either provide algorithm_params dict or a compatible legacy "
+                "parameter."
+            )
+            log.error(err)
+            raise ValueError(err)
 
     missing_params = [
         param for param in algorithm.required_params if param not in params
@@ -715,7 +727,8 @@ class AreaSplitter:
                 database connections to be spawned.
             algorithm (SplittingAlgorithm): The algorithm to use.
             algorithm_params (dict): Dictionary of parameters for the algorithm.
-                For building-based algorithms, should include 'num_buildings'.
+                For building-based algorithms, should include 'num_buildings'
+                or 'num_enumerators', depending on the selected algorithm.
             osm_extract (dict, FeatureCollection): an OSM extract geojson,
                 containing building polygons, or linestrings.
 
@@ -751,6 +764,17 @@ class AreaSplitter:
             CROSS JOIN (SELECT geom FROM project_aoi LIMIT 1) p
             WHERE ST_Intersects(p.geom, w.geom)
         """)
+
+        # Make the input parameters accessible to other sql files.
+        cur.execute(
+            f"SET area_splitter.num_buildings = "
+            f"{params.get('num_buildings', 0)}"
+        )
+        cur.execute(
+            f"SET area_splitter.num_enumerators = "
+            f"{params.get('num_enumerators', 0)}"
+        )
+
         # Close current cursor
         cur.close()
 
@@ -908,6 +932,7 @@ def split_by_sql(
     aoi: Union[str, dict],
     db: Union[str, Connection],
     num_buildings: Optional[int] = None,
+    num_enumerators: Optional[int] = None,
     outfile: Optional[str] = None,
     osm_extract: Optional[Union[str, dict]] = None,
     algorithm: Optional[SplittingAlgorithm] = None,
@@ -918,9 +943,10 @@ def split_by_sql(
     The query will optimise on the following:
     - Attempt to divide the aoi into tasks that contain approximately the
         number of buildings from `num_buildings` (or algorithm_params).
+    - Or divide the AOI into a target number of tasks using
+        `num_enumerators`.
     - Split the task areas on major features such as roads an rivers, to
       avoid traversal of these features across task areas.
-
     Also has handling for multiple geometries within FeatureCollection object.
 
     Args:
@@ -935,6 +961,9 @@ def split_by_sql(
             splitting algorithm with (approx buildings per generated feature).
             Deprecated: Use algorithm_params instead. If algorithm_params is provided,
             this parameter is ignored.
+        num_enumerators(int, optional): The target number of task areas to
+            generate. Deprecated: Use algorithm_params instead. If
+            algorithm_params is provided, this parameter is ignored.
         outfile(str): Output to a GeoJSON file on disk.
         osm_extract (str, FeatureCollection): an OSM extract geojson,
             containing building polygons, or linestrings.
@@ -943,13 +972,13 @@ def split_by_sql(
             what you are doing.
         algorithm (SplittingAlgorithm, optional): The algorithm to use.
             Must be a building-based algorithm
-            (AVG_BUILDING_VORONOI or AVG_BUILDING_SKELETON).
+            (AVG_BUILDING_VORONOI, AVG_BUILDING_SKELETON, or TOTAL_TASKS).
             Defaults to AVG_BUILDING_SKELETON.
         algorithm_params (dict, optional): Dictionary of parameters for the algorithm.
             Should include all parameters required by the algorithm
             (see algorithm.required_params).
-            If not provided, will be constructed from num_buildings for backward
-            compatibility.
+            If not provided, it will be constructed from num_buildings or
+            num_enumerators for backward compatibility.
 
     Returns:
         features (FeatureCollection): A multipolygon of all the task boundaries.
@@ -959,6 +988,7 @@ def split_by_sql(
     algorithm_params = _resolve_algorithm_params(
         algorithm,
         num_buildings,
+        num_enumerators,
         algorithm_params,
     )
     aoi_featcol = _parse_aoi_feature_collection(aoi)
@@ -973,6 +1003,9 @@ def split_by_sql(
                 db,
                 num_buildings=algorithm_params.get("num_buildings")
                 if "num_buildings" in algorithm_params
+                else None,
+                num_enumerators=algorithm_params.get("num_enumerators")
+                if "num_enumerators" in algorithm_params
                 else None,
                 outfile=_outfile_variant(outfile, index),
                 osm_extract=osm_extract,
@@ -1081,6 +1114,7 @@ be either the data extract used by the XLSForm, or a postgresql database.
     parser.add_argument(
         "-number", "--number", nargs="?", const=5, help="Number of buildings in a task"
     )
+    parser.add_argument("-tasks", "--tasks", nargs="?", const=5, help="Number of tasks")
     parser.add_argument("-b", "--boundary", required=True, help="Polygon AOI")
     parser.add_argument("-s", "--source", help="Source data, Geojson or PG:[dbname]")
     parser.add_argument(
@@ -1129,6 +1163,16 @@ be either the data extract used by the XLSForm, or a postgresql database.
             args.boundary,
             db=args.dburl,
             num_buildings=args.number,
+            num_enumerators=0,
+            outfile=args.outfile,
+            osm_extract=args.extract,
+        )
+    elif args.tasks:
+        split_by_sql(
+            args.boundary,
+            db=args.dburl,
+            num_buildings=0,
+            num_enumerators=args.tasks,
             outfile=args.outfile,
             osm_extract=args.extract,
         )

--- a/src/backend/packages/area-splitter/tests/test_splitter.py
+++ b/src/backend/packages/area-splitter/tests/test_splitter.py
@@ -20,6 +20,7 @@ from time import sleep
 
 import pytest
 
+from area_splitter import SplittingAlgorithm
 from area_splitter.splitter import (
     AreaSplitter,
     _is_linear_split_feature,
@@ -198,6 +199,42 @@ def test_split_by_sql_ftm_with_extract(db, aoi_json, extract_json):
         feature.get("geometry", {}).get("type") in {"Polygon", "MultiPolygon"}
         for feature in feature_list
     )
+
+
+def test_split_by_sql_total_tasks_passes_num_enumerators(
+    monkeypatch, aoi_json, extract_json
+):
+    """Target-task splitting should pass num_enumerators to the SQL runner."""
+    captured = {}
+
+    def fake_split_by_sql(self, db, algorithm, algorithm_params, osm_extract):
+        captured["db"] = db
+        captured["algorithm"] = algorithm
+        captured["algorithm_params"] = algorithm_params
+        captured["osm_extract"] = osm_extract
+        return {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": aoi_json["features"][0]["geometry"],
+                }
+            ],
+        }
+
+    monkeypatch.setattr(AreaSplitter, "splitBySQL", fake_split_by_sql)
+
+    features = split_by_sql(
+        aoi_json,
+        "postgresql://unused",
+        num_enumerators=6,
+        osm_extract=extract_json,
+        algorithm=SplittingAlgorithm.TOTAL_TASKS,
+    )
+
+    assert captured["algorithm"] == SplittingAlgorithm.TOTAL_TASKS
+    assert captured["algorithm_params"]["num_enumerators"] == 6
+    assert isinstance(features, dict) and features.get("type") == "FeatureCollection"
 
 
 def test_split_by_sql_ftm_no_extract(aoi_json):

--- a/src/backend/tests/test_htmx_routes.py
+++ b/src/backend/tests/test_htmx_routes.py
@@ -11,11 +11,13 @@ from litestar import status_codes as status
 from app.config import AuthProvider, settings
 from app.db.enums import ProjectStatus
 from app.db.models import DbProject
+from app.htmx.map_helpers import render_leaflet_map
 from app.htmx.project_create_routes import _parse_outline_payload, new_project
 from app.htmx.project_list_routes import project_listing
 from app.htmx.setup_step_routes import (
     _build_finalize_error_html,
     _build_odk_finalize_success_html,
+    _task_boundaries_layer,
     accept_data_extract_htmx,
     accept_split_htmx,
 )
@@ -307,6 +309,64 @@ async def test_accept_split_htmx_decodes_html_escaped_geojson(monkeypatch):
     assert response.headers.get("HX-Refresh") == "true"
     assert saved["project_id"] == project.id
     assert saved["tasks_geojson"] == tasks_geojson
+
+
+def test_task_boundaries_layer_uses_translated_popup_labels():
+    """Task boundary popups should show translated labels without layer name."""
+    layer = _task_boundaries_layer(
+        {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": None,
+                    "properties": {"task_id": 3, "building_count": 14},
+                }
+            ],
+        }
+    )
+
+    assert layer["popup_options"]["showLayerName"] is False
+    assert layer["popup_options"]["propertyLabels"] == {
+        "task_id": "Task ID",
+        "building_count": "Building Count",
+    }
+    assert layer["popup_options"]["propertyOrder"] == ["task_id", "building_count"]
+
+
+def test_render_leaflet_map_serializes_popup_options():
+    """Leaflet helper should pass popup configuration through to the frontend."""
+    html = render_leaflet_map(
+        map_id="leaflet-map-test",
+        geojson_layers=[
+            {
+                "data": {
+                    "type": "FeatureCollection",
+                    "features": [
+                        {
+                            "type": "Feature",
+                            "geometry": None,
+                            "properties": {"task_id": 3, "building_count": 14},
+                        }
+                    ],
+                },
+                "name": "Task Boundaries (1 tasks)",
+                "popup_options": {
+                    "showLayerName": False,
+                    "propertyLabels": {
+                        "task_id": "Task ID",
+                        "building_count": "Building Count",
+                    },
+                    "propertyOrder": ["task_id", "building_count"],
+                },
+            }
+        ],
+    )
+
+    assert '"showLayerName": false' in html
+    assert '"task_id": "Task ID"' in html
+    assert '"building_count": "Building Count"' in html
+    assert '"propertyOrder": ["task_id", "building_count"]' in html
 
 
 async def test_project_details_shows_odk_media_upload_guidance(client, db, project):

--- a/src/backend/tests/test_projects_routes.py
+++ b/src/backend/tests/test_projects_routes.py
@@ -57,6 +57,7 @@ def test_create_project_request_split_defaults():
     )
 
     assert payload.no_of_buildings == 10
+    assert payload.no_of_tasks == 10
     assert payload.include_roads is True
     assert payload.include_rivers is True
     assert payload.include_railways is True
@@ -425,6 +426,92 @@ async def test_split_aoi_building_algorithms_run_sync_without_kwargs(
     assert callable(captured.get("func"))
     algorithm_params = captured["func"].keywords["algorithm_params"]
     assert algorithm_params["num_buildings"] == 50
+    assert algorithm_params["include_roads"] == "TRUE"
+    assert algorithm_params["include_rivers"] == "TRUE"
+    assert algorithm_params["include_railways"] == "TRUE"
+    assert algorithm_params["include_aeroways"] == "TRUE"
+    assert result["type"] == "FeatureCollection"
+    assert len(result["features"]) == 1
+
+
+async def test_split_aoi_total_tasks_passes_num_enumerators(monkeypatch):
+    """TOTAL_TASKS should pass num_enumerators into area-splitter."""
+    from app.projects import project_services
+
+    project = Mock(
+        outline={
+            "type": "Polygon",
+            "coordinates": [
+                [
+                    [85.30, 27.71],
+                    [85.30, 27.70],
+                    [85.31, 27.70],
+                    [85.31, 27.71],
+                    [85.30, 27.71],
+                ]
+            ],
+        },
+        data_extract_geojson={
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": {
+                        "type": "Polygon",
+                        "coordinates": [
+                            [
+                                [85.30, 27.71],
+                                [85.30, 27.70],
+                                [85.31, 27.70],
+                                [85.31, 27.71],
+                                [85.30, 27.71],
+                            ]
+                        ],
+                    },
+                    "properties": {"osm_id": 1},
+                }
+            ],
+        },
+    )
+
+    async def fake_project_one(_db, _project_id):
+        return project
+
+    captured: dict = {}
+
+    async def fake_run_sync(func, *args):
+        captured["func"] = func
+        captured["args"] = args
+        return {
+            "type": "FeatureCollection",
+            "features": [
+                {
+                    "type": "Feature",
+                    "geometry": project.outline,
+                    "properties": {"task_id": 1},
+                }
+            ],
+        }
+
+    async def fake_check_crs(_featcol):
+        return None
+
+    monkeypatch.setattr(project_services.DbProject, "one", fake_project_one)
+    monkeypatch.setattr(project_services.to_thread, "run_sync", fake_run_sync)
+    monkeypatch.setattr(project_services, "check_crs", fake_check_crs)
+
+    result = await project_services.split_aoi(
+        db=Mock(),
+        project_id=1,
+        options=project_services.SplitAoiOptions(
+            algorithm="TOTAL_TASKS",
+            no_of_tasks=6,
+        ),
+    )
+
+    assert callable(captured.get("func"))
+    algorithm_params = captured["func"].keywords["algorithm_params"]
+    assert algorithm_params["num_enumerators"] == 6
     assert algorithm_params["include_roads"] == "TRUE"
     assert algorithm_params["include_rivers"] == "TRUE"
     assert algorithm_params["include_railways"] == "TRUE"


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] 📝 Documentation
- [ ] 🧑‍💻 Refactor
- [ ] ✅ Test
- [ ] 🤖 Build or CI
- [ ] ❓ Other (please specify)

## Related Issue

Fixes https://github.com/hotosm/field-tm/issues/2992
Continues from https://github.com/amitdkhan-pg/field-tm/pull/1
Also fixes https://github.com/hotosm/field-tm/issues/3039

## Describe this PR

Copying content from linked PR for future ref:

```
This feature allows a command-line user of area-splitter to specify the number of enumerators rather than number of buildings, using option --tasks.

The end result is: exactly that many number of task polygons are generated.

The core part of the changes is in area_splitter/algorithms/common/3-cluster-buildings.sql
A table partition_tasks is created to store number of tasks in each partition (partitions here means the split-polygons generated by splitting the AOI using highways/railways):

postgres=# select * from partition_tasks ;
 polyid | numfeatures | tasks 
--------+-------------+-------
      7 |          66 |     3
      1 |          11 |     1
      5 |         136 |     7
      4 |           6 |     1
      2 |         118 |     6
      6 |          40 |     2
      3 |         226 |    11
(7 rows)

partition_tasks.numfeatures is the number of buildings in one partition.

The partition_tasks.tasks column has the desired number of tasks for that polyid. It is calculated by doing partition_tasks.numfeatures/buildings_per_cluster, where buildings_per_cluster is total features in the aoi divided by number of enumerators.

Now, the total of partition_tasks.tasks would not exactly match the user-supplied num_enumerators.

So, adjust the individual tasks based on the feature density (features per task).

So, if the actual tasks are more than the desired tasks, we decrement the number of mappers in the partition that has the least feature density. Similarly if the actual tasks are less, we increment the mappers in the most feature-dense partition because those would be the ones with maximum work load. We keep on doing this until total tasks matches the desired enumerators.

If the number of partitions are more than the user-specified num_enumerators, we don't do the above logic. Instead, we failback to the logic where in the end we merge the task polygons having least features into adjoining task polygons until the total task polygons match num_enumerators.

In the above table, the total tasks (sum(tasks)) is 31. Suppose, the user requests for 29 enumerators. So we have to decrement two of the tasks in the table. We order the table with ascending density:

postgres=# select numfeatures/tasks density, * from partition_tasks  order by 1;
 density | polyid | numfeatures | tasks 
---------+--------+-------------+-------
       6 |      4 |           6 |     1
      11 |      1 |          11 |     1
      19 |      5 |         136 |     7
      19 |      2 |         118 |     6
      20 |      6 |          40 |     2
      20 |      3 |         226 |    11
      22 |      7 |          66 |     3

We cannot decrement tasks from the first two rows; they already have only 1 task. So we decrement the task from polyid=5. and the re-order the table with the updated density, and then decrement again similarly.

Then, when we create the clusteredbuildings using ST_CLUSTERKMEANS(), we use the number of tasks in the above table as the second parameter to ST_CLUSTERKMEANS(). This way we can specify exactly the number of tasks.

Attaching the OSM data extract file used for basic testing. This extract is manually modified such that there are national highways that split the AOI into multiple polygons.
```

## AI Tool Usage

- [ ] No AI tools were used
- [x] AI tools were used (complete below)

**If AI-assisted:**

- Tool(s) used: Opus 4.6 for cleanup (majority work done by Amit).
- What was generated: Tests & merge cleanup.
- What you reviewed and changed: I reviewed everything manually and tested manually.

## Screenshots

<img width="1620" height="1218" alt="image" src="https://github.com/user-attachments/assets/280a42c5-e3d1-466d-b7ea-ec6bb5b52807" />

## Checklist

- [ ] I have read the [Contributing Guide](https://github.com/hotosm/field-tm/blob/main/CONTRIBUTING.md)
- [ ] I have read the [Code of Conduct](https://docs.hotosm.org/code-of-conduct)
- [ ] PR is focused and small
- [ ] Tests are included or updated
- [ ] I understand all code in this PR and can answer questions about it
- [ ] No secrets, credentials, or sensitive data are included
- [ ] Commit messages are descriptive
- [ ] Related docs and screenshots are updated

## [optional] What gif best describes this PR or how it makes you feel?
